### PR TITLE
Review - Bound Case Studies and Child Pictures

### DIFF
--- a/child_compassion/__openerp__.py
+++ b/child_compassion/__openerp__.py
@@ -30,7 +30,7 @@
 
 {
     'name': 'Compassion Children',
-    'version': '1.4',
+    'version': '1.4.2',
     'category': 'Other',
     'description': """
 Setup child and projects for sponsorship management.

--- a/child_compassion/migrations/1.4.1/post-migration.py
+++ b/child_compassion/migrations/1.4.1/post-migration.py
@@ -8,9 +8,12 @@
 #    The licence is in the file __openerp__.py
 #
 ##############################################################################
+import sys
 
 
 def migrate(cr, version):
+    reload(sys)
+    sys.setdefaultencoding('UTF8')
 
     if not version:
         return

--- a/child_compassion/migrations/1.4.1/post-migration.py
+++ b/child_compassion/migrations/1.4.1/post-migration.py
@@ -53,7 +53,7 @@ def migrate(cr, version):
     for project in projects:
         cr.execute(
             "SELECT id FROM compassion_translated_value "
-            "WHERE value_en = '{}'".format(project[1]))
+            "WHERE value_en = '{}'".format(project[1].replace('\'', '\'\'')))
         translated_value_id = cr.fetchall()[0][0]
 
         cr.execute(

--- a/child_compassion/migrations/1.4.1/post-migration.py
+++ b/child_compassion/migrations/1.4.1/post-migration.py
@@ -1,0 +1,68 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Coninckx David <david@coninckx.com>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+
+def migrate(cr, version):
+
+    if not version:
+        return
+    # Add translated value for new property distance_from_closest_city
+    # based on old string distance_from_closest_city
+
+    cr.execute(
+        """
+        CREATE RULE "my_table_on_duplicate_ignore"
+        AS ON INSERT TO "compassion_translated_value"
+        WHERE EXISTS(SELECT 1 FROM compassion_translated_value
+                    WHERE value_en=NEW.value_en)
+        DO INSTEAD NOTHING;
+        INSERT INTO compassion_translated_value
+        (is_tag,value_en, property_name)
+        SELECT False, distance_from_closest_city, 'distance_from_closest_city'
+        FROM compassion_project
+        WHERE distance_from_closest_city IS NOT NULL;
+        DROP RULE "my_table_on_duplicate_ignore"
+        ON "compassion_translated_value";
+        """)
+
+    cr.execute(
+        'SELECT id, distance_from_closest_city '
+        'FROM compassion_project '
+        'WHERE distance_from_closest_city IS NOT NULL'
+    )
+    projects = cr.fetchall()
+
+    cr.execute(
+        '''
+        CREATE RULE "my_table_on_duplicate_ignore"
+        AS ON INSERT TO "project_property_to_value"
+        WHERE EXISTS(SELECT 1 FROM project_property_to_value
+                    WHERE value_id=NEW.value_id
+                    AND project_id = NEW.project_id)
+        DO INSTEAD NOTHING;
+        ''')
+
+    for project in projects:
+        cr.execute(
+            "SELECT id FROM compassion_translated_value "
+            "WHERE value_en = '{}'".format(project[1]))
+        translated_value_id = cr.fetchall()[0][0]
+
+        cr.execute(
+            "INSERT INTO project_property_to_value (project_id, value_id) "
+            "VALUES ({0},{1})".format(
+                project[0], translated_value_id))
+
+    cr.execute(
+        """
+        DROP RULE "my_table_on_duplicate_ignore"
+        ON "project_property_to_value";
+        """)

--- a/child_compassion/migrations/1.4.2/post-migration.py
+++ b/child_compassion/migrations/1.4.2/post-migration.py
@@ -1,0 +1,41 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Attach last pictures to last case study of children
+    cr.execute(
+        """
+        SELECT cs.id as cs_id, p.id as p_id
+        FROM compassion_child_property cs JOIN compassion_child_pictures p
+        ON cs.child_id = p.child_id
+        WHERE cs.id IN (
+            SELECT max(id)
+            FROM compassion_child_property
+            GROUP BY child_id)
+        AND p.id IN (
+            SELECT max(id)
+            FROM compassion_child_pictures
+            GROUP BY child_id)
+        ORDER BY cs.child_id
+        """)
+    to_link = cr.fetchall()
+    for data in to_link:
+        cr.execute(
+            'UPDATE compassion_child_property '
+            'SET pictures_id = {0} '
+            'WHERE id = {1}; '
+            'UPDATE compassion_child_pictures '
+            'SET case_study_id = {1} '
+            'WHERE id = {0}'.format(data[1], data[0]))

--- a/child_compassion/model/child_compassion.py
+++ b/child_compassion/model/child_compassion.py
@@ -287,7 +287,9 @@ class compassion_child(orm.Model):
                     'name': child.code[:5],
                 })
                 proj_obj.update_informations(cr, uid, proj_id)
-            res = res and self._get_last_pictures(cr, uid, child.id, context)
+            # Temporarily deactivate update of picture so that it doesn't
+            # attach to an old case study. (To fix when we have picture date)
+            # res = res and self._get_last_pictures(cr, uid, child.id, context)
         return res
 
     def generate_descriptions(self, cr, uid, child_id, context=None):
@@ -314,7 +316,8 @@ class compassion_child(orm.Model):
         }
 
     def _get_last_pictures(self, cr, uid, child_id, context=None):
-        pic_id = self.pool.get('compassion.child.pictures').create(
+        pictures_obj = self.pool.get('compassion.child.pictures')
+        pic_id = pictures_obj.create(
             cr, uid, {'child_id': child_id}, context)
         if pic_id:
             # Add a note in child
@@ -322,6 +325,7 @@ class compassion_child(orm.Model):
                 cr, uid, child_id, "The picture has been updated.",
                 "Picture update", 'comment',
                 context={'thread_model': self._name})
+
         return pic_id
 
     ##################################################

--- a/child_compassion/model/child_compassion.py
+++ b/child_compassion/model/child_compassion.py
@@ -462,6 +462,12 @@ class compassion_child(orm.Model):
             child_prop_obj.write(cr, uid, study_ids, vals, context)
         else:
             child_prop_obj.create(cr, uid, vals, context)
+            # Remove old descriptions
+            child.write({
+                'desc_fr': False,
+                'desc_de': False,
+                'desc_it': False,
+                'desc_en': False})
 
         # Add a note in child
         self.pool.get('mail.thread').message_post(

--- a/child_compassion/model/child_pictures.py
+++ b/child_compassion/model/child_pictures.py
@@ -67,6 +67,7 @@ class child_pictures(orm.Model):
         and attach the pictures to the last case study.
         """
         res_id = super(child_pictures, self).create(cr, uid, vals, context)
+
         child = self.pool.get('compassion.child').browse(
             cr, uid, vals['child_id'], context)
         # Retrieve Fullshot
@@ -96,7 +97,7 @@ class child_pictures(orm.Model):
             self.unlink(cr, uid, res_id, context)
             self.write(
                 cr, uid, same_picture_ids,
-                {'date': date.today()}, context)
+                {'date': context['image_date']}, context)
             self.pool.get('mail.thread').message_post(
                 cr, uid, child.id,
                 _('The picture was the same'), 'Picture update',
@@ -137,11 +138,13 @@ class child_pictures(orm.Model):
                      type='Headshot', dpi=72, width=400, height=400,
                      format='jpeg', context=None):
         ''' Gets a picture from Compassion webservice '''
-        url = self.pool.get('compassion.child').get_url(child_code, 'image')
+        url = self.pool.get('compassion.child').get_url(
+            child_code, 'image/2015/03')
         url += '&Height=%s&Width=%s&DPI=%s&ImageFormat=%s&ImageType=%s' \
             % (height, width, dpi, format, type)
         r = requests.get(url)
         json_data = r.json()
+
         if not r.status_code/100 == 2:
             self.pool.get('mail.thread').message_post(
                 cr, uid, child_id,
@@ -154,7 +157,7 @@ class child_pictures(orm.Model):
         if not context:
             context = dict()
         context['store_fname'] = type + '.' + format
-
+        context['image_date'] = json_data['imageDate'] or date.today()
         return attachment_obj.create(cr, uid, {
             'datas_fname': type + '.' + format,
             'res_model': self._name,

--- a/child_compassion/model/child_properties.py
+++ b/child_compassion/model/child_properties.py
@@ -128,4 +128,15 @@ class child_property(orm.Model):
         'desc_fr': fields.text(_('French description'), readonly=True),
         'desc_de': fields.text(_('German description'), readonly=True),
         'desc_it': fields.text(_('Italian description'), readonly=True),
+        'pictures_id': fields.many2one(
+            'compassion.child.pictures', _('Child images'), readonly=True),
     }
+
+    def attach_pictures(self, cr, uid, ids, pictures_id, context=None):
+        if len(ids) != 1:
+            raise orm.except_orm(
+                _('Picture error'),
+                _('You cannot attach a picture to more than one '
+                  'case study.'))
+        self.write(cr, uid, ids, {'pictures_id': pictures_id}, context)
+        return True

--- a/child_compassion/model/project_compassion.py
+++ b/child_compassion/model/project_compassion.py
@@ -210,6 +210,11 @@ class compassion_project(orm.Model):
             'project_id', 'value_id', _('Terrain description'),
             domain=[('property_name', '=', 'terrain_description')],
             track_visibility='onchange'),
+        'distance_from_closest_city_ids': fields.many2many(
+            'compassion.translated.value', 'project_property_to_value',
+            'project_id', 'value_id', _('Distance from closest city'),
+            domain=[('property_name', '=', 'distance_from_closest_city')],
+            track_visibility='onchange'),
         # b. Static Values
         'gps_latitude': fields.float(_('GPS latitude')),
         'gps_longitude': fields.float(_('GPS longitude')),
@@ -225,8 +230,7 @@ class compassion_project(orm.Model):
         'education_needs': fields.text(_('Education needs')),
         'social_needs': fields.text(_('Social needs')),
         'spiritual_needs': fields.text(_('Spiritual needs')),
-        'distance_from_closest_city': fields.text(_('Distance from closest '
-                                                    'city')),
+
         # d. Age groups section
         'age_group_ids': fields.one2many(
             'compassion.project.age.group', 'project_id',
@@ -376,8 +380,6 @@ class compassion_project(orm.Model):
             'social_needs': json_values['socialNeeds'],
             'spiritual_needs': json_values['spiritualNeeds'],
             'closest_city': json_values['closestCityName'],
-            'distance_from_closest_city': json_values['distanceFrom'
-                                                      'ClosestCity'],
         }
 
         # Automatic translated fields retrieval
@@ -392,6 +394,7 @@ class compassion_project(orm.Model):
             'primaryDiet': ('primary_diet', ','),
             'commonHealthProblems': ('health_problems', ', '),
             'primaryOccupationTitle': ('primary_occupation', '/'),
+            'distanceFromClosestCity': ('distance_from_closest_city', '?'),
         }
 
         # Get the property values ids

--- a/child_compassion/model/project_compassion.py
+++ b/child_compassion/model/project_compassion.py
@@ -69,7 +69,6 @@ class compassion_project(orm.Model):
         return True
 
     def _has_desc(self, cr, uid, ids, field_names, args, context=None):
-
         res = dict()
         field_res = dict()
         for child in self.browse(cr, uid, ids, context):

--- a/child_compassion/model/translated_value.py
+++ b/child_compassion/model/translated_value.py
@@ -41,11 +41,11 @@ class translated_value(orm.Model):
 
     def get_translated_value(self, cr, uid, id, lang, context):
         value = self.browse(cr, uid, id, context)[0]
-        id = value.value_en
+        html_id = value.value_en
         translated_value = getattr(value, "value_"+lang) or value.value_en
         color = 'red' if not getattr(value, "value_"+lang) else 'blue'
-        return u'<span id="{}" style="color:{}">{}</span>'.format(
-            id, color, translated_value)
+        return u'<span id="{0}" style="color:{1}">{2}</span>'.format(
+            html_id, color, translated_value)
 
     def get_value_ids(self, cr, uid, eng_values, property_name, context):
         """ Utility method that finds already existing translated values

--- a/child_compassion/view/project_compassion_view.xml
+++ b/child_compassion/view/project_compassion_view.xml
@@ -75,6 +75,7 @@
                                     <group> 
                                         <field name="primary_diet_ids" widget="many2many_tags" />
                                         <field name="closest_city" />
+                                        <field name="distance_from_closest_city_ids" widget="many2many_tags"/>
                                         <field name="terrain_description_ids" widget="many2many_tags" />
                                         <field name="community_population" />
                                         <field name="floor_material_ids" widget="many2many_tags" />

--- a/child_compassion/wizard/child_description_de.py
+++ b/child_compassion/wizard/child_description_de.py
@@ -300,9 +300,9 @@ class Child_description_de:
 
         be = [u'ist', u'ist', u'sind']
         dead = [u'ist gestorben', u'ist gestorben', u'sind gestorben']
-        support = [u'unterstüzt die Familie finanziell',
-                   u'unterstüzt die Familie finanziell',
-                   u'unterstüzt die Familie finanziell']
+        support = [u'unterstützt die Familie finanziell',
+                   u'unterstützt die Familie finanziell',
+                   u'unterstützt die Familie finanziell']
 
         status_tags = {
             u'inprison': [u'im Gefängnis', u'im Gefängnis', u'im Gefängnis'],

--- a/message_center_compassion/__openerp__.py
+++ b/message_center_compassion/__openerp__.py
@@ -50,6 +50,7 @@
         'security/ir.model.access.csv',
         'view/gmc_message_view.xml',
         'view/contracts_view.xml',
+        'view/child_compassion_view.xml',
         'data/gmc_action.xml',
         'data/gmc_message_cron.xml',
         'workflow/contract_workflow.xml',

--- a/message_center_compassion/__openerp__.py
+++ b/message_center_compassion/__openerp__.py
@@ -30,7 +30,7 @@
 
 {
     'name': 'Compassion CH Message Center',
-    'version': '1.4',
+    'version': '1.4.1',
     'category': 'Other',
     'description': """
         Message Center that offers a queue of messages that have to be sent

--- a/message_center_compassion/migrations/1.4.1/post-migration.py
+++ b/message_center_compassion/migrations/1.4.1/post-migration.py
@@ -1,7 +1,7 @@
 # -*- encoding: utf-8 -*-
 ##############################################################################
 #
-#    Copyright (C) 2014 Compassion CH (http://www.compassion.ch)
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
 #    Releasing children from poverty in Jesus' name
 #    @author: Emanuel Cino <ecino@compassion.ch>
 #
@@ -9,10 +9,15 @@
 #
 ##############################################################################
 
-from . import gmc_message
-from . import child_compassion
-from . import child_properties
-from . import project_compassion
-from . import contracts
-from . import res_partner
-from . import invoice_line
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Change 'casestudy' states to 'biennial'
+    cr.execute(
+        """
+        UPDATE recurring_contract
+        SET gmc_state = 'biennial'
+        WHERE gmc_state = 'casestudy'
+        """)

--- a/message_center_compassion/model/child_compassion.py
+++ b/message_center_compassion/model/child_compassion.py
@@ -138,9 +138,7 @@ class compassion_child(orm.Model):
         if event in ('Allocate', 'Transfer'):
             res = self.get_infos(cr, uid, args.get('object_id'), context)
         elif event == 'CaseStudy':
-            # As we send an update to sponsors, we also get the last picture
             res = self._get_case_study(cr, uid, child, context)
-            self._get_last_pictures(cr, uid, child.id, context)
         elif event == 'NewImage':
             res = self._get_last_pictures(cr, uid, child.id, context)
 

--- a/message_center_compassion/model/child_compassion.py
+++ b/message_center_compassion/model/child_compassion.py
@@ -184,3 +184,12 @@ class compassion_child(orm.Model):
                 'object_id': child_id,
                 'child_id': child_id}, context)
         return child_id
+
+    def view_error_messages(self, cr, uid, ids, context=None):
+        return {
+            'type': 'ir.actions.act_window',
+            'id': 'action_gmc_message_incoming_form',
+            'view_mode': 'tree,form',
+            'res_model': 'gmc.message.pool',
+            'domain': [('child_id', 'in', ids), ('state', '=', 'failure')]
+        }

--- a/message_center_compassion/model/child_properties.py
+++ b/message_center_compassion/model/child_properties.py
@@ -1,0 +1,28 @@
+# -*- encoding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2015 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Emanuel Cino <ecino@compassion.ch>
+#
+#    The licence is in the file __openerp__.py
+#
+##############################################################################
+from openerp.osv import orm
+
+
+class child_properties(orm.Model):
+    """ Write contracts in Biennial State when a picture is attached to a
+        Case Study. """
+    _inherit = 'compassion.child.property'
+
+    def attach_pictures(self, cr, uid, ids, pictures_id, context=None):
+        res = super(child_properties, self).attach_pictures(
+            cr, uid, ids, pictures_id, context)
+        if not isinstance(ids, list):
+            ids = [ids]
+        property = self.browse(cr, uid, ids, context)[0]
+        for contract in property.child_id.contract_ids:
+            if contract.state in ('waiting', 'active', 'mandate'):
+                contract.write({'gmc_state': 'biennial'})
+        return res

--- a/message_center_compassion/model/contracts.py
+++ b/message_center_compassion/model/contracts.py
@@ -27,6 +27,7 @@ class recurring_contract(orm.Model):
         'gmc_state': fields.selection([
             ('picture', _('New Picture')),
             ('casestudy', _('New Case Study')),
+            ('biennial', _('Biennial')),
             ('depart', _('Child Departed')),
             ('transfer', _('Child Transfer')),
             ('suspension', _('Project Fund-Suspended')),

--- a/message_center_compassion/model/gmc_message.py
+++ b/message_center_compassion/model/gmc_message.py
@@ -151,8 +151,7 @@ class gmc_message_pool(orm.Model):
     def process_update_messages(self, cr, uid, context=None):
         gmc_action_ids = self.pool.get('gmc.action').search(
             cr, uid,
-            [('type', '=', 'update'), ('direction', '=', 'in'),
-             ('event', '!=', 'NewImage')],
+            [('type', '=', 'update'), ('direction', '=', 'in')],
             context=context)
         gmc_update_messages_ids = self.search(
             cr, uid, [('action_id', 'in', gmc_action_ids)], context=context)
@@ -222,6 +221,11 @@ class gmc_message_pool(orm.Model):
                     'money_sent_date': today,
                     'state': 'success'
                 })
+
+            elif message.state == 'failure':
+                # Set back to new
+                message.reset_message()
+
         return True
 
     def reset_message(self, cr, uid, ids, context=None):

--- a/message_center_compassion/model/gmc_message.py
+++ b/message_center_compassion/model/gmc_message.py
@@ -151,7 +151,8 @@ class gmc_message_pool(orm.Model):
     def process_update_messages(self, cr, uid, context=None):
         gmc_action_ids = self.pool.get('gmc.action').search(
             cr, uid,
-            [('type', '=', 'update'), ('direction', '=', 'in')],
+            [('type', '=', 'update'), ('direction', '=', 'in'),
+             ('event', '!=', 'NewImage')],
             context=context)
         gmc_update_messages_ids = self.search(
             cr, uid, [('action_id', 'in', gmc_action_ids)], context=context)

--- a/message_center_compassion/view/child_compassion_view.xml
+++ b/message_center_compassion/view/child_compassion_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (C) 2015 Compassion (http://www.compassion.ch)
+    @author David Copninckx <david@coninckx.com>
+    The licence is in the file __openerp__.py
+-->
+<openerp>
+    <data>
+        <record id="view_gmc_child_compassion" model="ir.ui.view">
+            <field name="name">gmc.child.compassion.view</field>
+            <field name="model">compassion.child</field>
+            <field name="inherit_id" ref="child_compassion.view_compassion_child_form" />
+            <field name="arch" type="xml">
+                 <div name="buttons" position='inside'>
+                    <button string="Error message" name="view_error_messages" type="object" attrs="{'invisible': [('state', '!=', 'E')]}" />
+                 </div>
+            </field>
+        </record>
+    </data>
+</openerp>

--- a/message_center_compassion/view/contracts_view.xml
+++ b/message_center_compassion/view/contracts_view.xml
@@ -15,7 +15,7 @@
                 <data>
                     <filter name="cancelled" position="after">
                         <separator/>
-                        <filter name="biennial" string="Biennial" domain="[('gmc_state', 'in', ('picture', 'casestudy'))]" context="{'group_by': 'gmc_state'}"/>
+                        <filter name="biennial" string="Biennial" domain="[('gmc_state', '=', 'biennial')]"/>
                         <filter name="depart" string="Departure" domain="[('gmc_state', '=', 'depart')]"/>
                         <filter name="transfer" string="Child Transfer" domain="[('gmc_state', '=', 'transfer')]"/>
                         <filter name="suspension" string="Suspension" domain="[('gmc_state', 'in', ('suspension', 'suspension-extension', 'reactivation'))]" context="{'group_by': 'gmc_state'}"/>


### PR DESCRIPTION
This contains the latest changes on 1.4 branch (this branch has still some corrections pending !).

We bounded case studies with child pictures, because on GP, we send updates to sponsors only when we have both a new case study and a new image. We had a problem  : when updating info of child, we sometimes put new pictures to old case studies in GP. With these changes, we assure we don't mess with GP until we have complete information to be useful.

The update contains migration scripts (v1.4.2) to bound last case study to last image.
Migration script 1.4.1 is because we changed a field from char text to translated value.

All these changes are also in other review pull request but can be reviewed here for more clarity.

Thanks.