### PR TITLE
Remove drag and drop on kanban and replace it by button for group actions

### DIFF
--- a/sponsorship_compassion/view/contract_view.xml
+++ b/sponsorship_compassion/view/contract_view.xml
@@ -77,7 +77,7 @@
                         </group>
                         <group>
                             <field name="child_id" domain="[('state', 'in', ('N', 'D', 'I', 'R', 'Z')), ('project_id.suspension', 'not in', ('suspended','fund-suspended'))]"
-                                   options="{'create': false, 'm2o_dialog': false, 'create_edit': false, 'search_more':True, 'field_color':'state', 'colors':{'R':'red', 'F':'gray', 'X':'gray', 'N':'blue'} }"/>
+                                   options="{'create': false, 'm2o_dialog': false, 'create_edit': false, 'search_more':True, 'field_color':'state', 'colors':{'R':'red', 'N':'blue'} }"/>
                             <field name="end_reason" states="terminated,cancelled"/>
                             <field name="num_pol_ga" invisible="1"/>
                         </group>

--- a/sponsorship_compassion/view/contract_view.xml
+++ b/sponsorship_compassion/view/contract_view.xml
@@ -62,7 +62,7 @@
                             <field name="group_id" domain="[('partner_id', '=', partner_id)]"
                                    context="{'default_partner_id': partner_id}"
                                    on_change="on_change_group_id(group_id)"/>
-                            <field name="parent_id" domain="[('partner_id', '=', partner_id), ('child_id', '!=', child_id)]"/>
+                            <field name="parent_id" domain="[('partner_id', '=', partner_id), ('child_id', '!=', child_id)]" options="{'create': false, 'm2o_dialog': false, 'field_color':'state', 'search_more':True, 'colors':{'cancelled':'gray','terminated':'gray','mandate':'red','draft':'blue','waiting':'green'}}"/>
                         </group>
                         <group>
                             <field name="start_date" string="Creation date"/>
@@ -77,7 +77,7 @@
                         </group>
                         <group>
                             <field name="child_id" domain="[('state', 'in', ('N', 'D', 'I', 'R', 'Z')), ('project_id.suspension', 'not in', ('suspended','fund-suspended'))]"
-                                   options="{'create': false, 'm2o_dialog': false, 'create_edit': false}"/>
+                                   options="{'create': false, 'm2o_dialog': false, 'create_edit': false, 'search_more':True, 'field_color':'state', 'colors':{'R':'red', 'F':'gray', 'X':'gray', 'N':'blue'} }"/>
                             <field name="end_reason" states="terminated,cancelled"/>
                             <field name="num_pol_ga" invisible="1"/>
                         </group>

--- a/sponsorship_tracking/__openerp__.py
+++ b/sponsorship_tracking/__openerp__.py
@@ -45,7 +45,7 @@ It adds a new tree and form view to track sponsorships.
     'data': [
         'view/contract_view.xml',
         'view/project_view.xml',
-        'workflow/contract_workflow.xml',
+        'workflow/sds_workflow.xml',
         'workflow/project_workflow.xml',
         'data/contract_cron.xml',
         'data/install.xml',

--- a/sponsorship_tracking/model/contracts.py
+++ b/sponsorship_tracking/model/contracts.py
@@ -26,15 +26,15 @@ class recurring_contract(orm.Model):
     def button_mail_sent(self, cr, uid, value, context=None):
         contract_ids = self.search(
             cr, uid, [('sds_state', '=', value)], context)
-        for contract in self.browse(cr, uid, contract_ids, context):
-            self.mail_sent(cr, uid, contract.id, context)
+        for contract in contract_ids:
+            self.mail_sent(cr, uid, contract, context)
         return True
 
     def button_project_mail_sent(self, cr, uid, value, context=None):
         contract_ids = self.search(
             cr, uid, [('project_state', '=', value)], context)
-        for contract in self.browse(cr, uid, contract_ids, context):
-            self.project_mail_sent(cr, uid, contract.id, context)
+        for contract in contract_ids:
+            self.project_mail_sent(cr, uid, contract, context)
         return True
 
     _columns = {

--- a/sponsorship_tracking/model/contracts.py
+++ b/sponsorship_tracking/model/contracts.py
@@ -16,29 +16,26 @@ from openerp.tools.translate import _
 from datetime import datetime, date, timedelta
 import logging
 
+
 logger = logging.getLogger(__name__)
 
 
 class recurring_contract(orm.Model):
     _inherit = "recurring.contract"
 
-    def state_transition_from_kanban(
-            self, cr, uid, old_state, new_state, id, context=None):
-        start, end, signal = 'start', 'end', 'signal'
+    def button_mail_sent(self, cr, uid, value, context=None):
+        contract_ids = self.search(
+            cr, uid, [('sds_state', '=', value)], context)
+        for contract in self.browse(cr, uid, contract_ids, context):
+            self.mail_sent(cr, uid, contract.id, context)
+        return True
 
-        state_transitions = [
-            {start: 'start', end: 'active', signal: 'mail_sent'},
-            {start: 'waiting_welcome', end: 'active', signal: 'welcome_sent'},
-            {start: 'sub_waiting', end: 'no_sub', signal: 'no_sub'},
-        ]
-
-        for state_transition in state_transitions:
-            if (state_transition[start] == old_state and
-                    state_transition[end] == new_state):
-                trans_method = getattr(self, state_transition[signal])
-                return trans_method(cr, uid, id, context)
-        else:
-            return False
+    def button_project_mail_sent(self, cr, uid, value, context=None):
+        contract_ids = self.search(
+            cr, uid, [('project_state', '=', value)], context)
+        for contract in self.browse(cr, uid, contract_ids, context):
+            self.project_mail_sent(cr, uid, contract.id, context)
+        return True
 
     _columns = {
         'sds_state': fields.selection([
@@ -47,13 +44,13 @@ class recurring_contract(orm.Model):
             ('waiting_welcome', _('Waiting welcome')),
             ('active', _('Active')),
             ('field_memo', _('Field memo')),
-            ('cancelled', _('Cancelled')),
             ('sub_waiting', _('Sub waiting')),
-            ('no_sub', _('No sub')),
             ('sub', _('Sub')),
             ('sub_accept', _('Sub Accept')),
-            ('sub_reject', _('Sub Reject'))], _('SDS Status'), select=True,
-            readonly=True, track_visibility='onchange',
+            ('sub_reject', _('Sub Reject')),
+            ('no_sub', _('No sub')),
+            ('cancelled', _('Cancelled'))], _('SDS Status'),
+            readonly=True, track_visibility='onchange', select=True,
             help=_('')),
         'last_sds_state_change_date': fields.date(
             _('Last SDS state change date'),
@@ -110,6 +107,12 @@ class recurring_contract(orm.Model):
         logger.info("Contract " + str(contract_id) + " mail sent.")
         wf_service.trg_validate(uid, 'recurring.contract', contract_id,
                                 'mail_sent', cr)
+
+    def project_mail_sent(self, cr, uid, contract_id, context=None):
+        wf_service = netsvc.LocalService('workflow')
+        logger.info("Contract " + str(contract_id) + " project mail sent.")
+        wf_service.trg_validate(uid, 'recurring.contract', contract_id,
+                                'project_mail_sent', cr)
 
     def reactivate_project(self, cr, uid, contract_id, context=None):
         wf_service = netsvc.LocalService('workflow')

--- a/sponsorship_tracking/view/contract_view.xml
+++ b/sponsorship_tracking/view/contract_view.xml
@@ -14,7 +14,7 @@
                 <kanban default_group_by="sds_state" create='false' edit='false'>
                     <field name="name"/>
                     <field name="color"/>
-                    <field name="sds_state" options="{'test':'test'}"/>
+                    <field name="sds_state"/>
                     <field name="state" />
                     <templates>
                         <field name="child_id"/>
@@ -48,7 +48,7 @@
         </record>
 
         <record id="view_tracking_contract_form" model="ir.ui.view">
-			<field name="name">recurring.contract.compassion.form</field>
+			<field name="name">tracking.contract.compassion.form</field>
 			<field name="model">recurring.contract</field>
             <field name="inherit_id" ref="recurring_contract.view_recurring_contract_form"/>
 			<field name="arch" type="xml">

--- a/sponsorship_tracking/view/contract_view.xml
+++ b/sponsorship_tracking/view/contract_view.xml
@@ -9,17 +9,19 @@
         <record id="view_follow_contract_kanban_compassion" model="ir.ui.view">
 			<field name="name">follow.contract.compassion.kanban</field>
 			<field name="model">recurring.contract</field>
+            <field name="options">{'test':'test'}</field>
 			<field name="arch" type="xml">
-                <kanban default_group_by="sds_state" create='false' edit='true'>
+                <kanban default_group_by="sds_state" create='false' edit='false'>
                     <field name="name"/>
                     <field name="color"/>
-                    <field name="sds_state"/>
+                    <field name="sds_state" options="{'test':'test'}"/>
                     <field name="state" />
                     <templates>
                         <field name="child_id"/>
                         <t t-name="kanban-box">
                             <div t-attf-class="oe_kanban_color_#{kanban_getcolor(record.color.raw_value)} oe_kanban_card oe_kanban_global_click">
                                 <div class="oe_dropdown_toggle oe_dropdown_kanban">
+                                    <span class="oe_e">í</span>
                                     <ul class="oe_dropdown_menu">
                                         <li><ul class="oe_kanban_colorpicker" data-field="color"/></li>
                                     </ul>
@@ -46,7 +48,7 @@
         </record>
 
         <record id="view_tracking_contract_form" model="ir.ui.view">
-			<field name="name">follow.contract.compassion.form</field>
+			<field name="name">recurring.contract.compassion.form</field>
 			<field name="model">recurring.contract</field>
             <field name="inherit_id" ref="recurring_contract.view_recurring_contract_form"/>
 			<field name="arch" type="xml">
@@ -63,14 +65,14 @@
         <record id="view_follow_contract_form_compassion" model="ir.ui.view">
 			<field name="name">follow.contract.compassion.form</field>
 			<field name="model">recurring.contract</field>
+            <field eval="18" name="priority"/>
 			<field name="arch" type="xml">
                 <form string="Follow contract" version="7.0" create="false" edit="false">
                     <header>
                         <field name="sds_state" widget="statusbar" statusbar_visible="draft,start,waiting_welcome,active,sub,sub_accept"/>
                         <button name="contract_validated" class="oe_highlight" attrs="{'invisible':[('sds_state','!=','draft')]}" string="Validate"/>
                         
-                        <button name="mail_sent" class="oe_highlight" string="Mail sent" attrs="{'invisible':[('sds_state','!=','start')]}"/>
-                        <button name="welcome_sent" class="oe_highlight" string="Welcome sent" attrs="{'invisible':[('sds_state','!=','waiting_welcome')]}"/>
+                        <button name="mail_sent" class="oe_highlight" string="Mail sent" attrs="{'invisible':[('sds_state','not in',['start', 'waiting_welcome'])]}"/>
                         <button name="no_sub" class="oe_highlight" string="No sub" attrs="{'invisible':[('sds_state','!=','sub_waiting')]}"/>
                         <button 
                             name="project_mail_sent" 

--- a/sponsorship_tracking/workflow/sds_workflow.xml
+++ b/sponsorship_tracking/workflow/sds_workflow.xml
@@ -63,6 +63,7 @@
             <field name="name">no_sub</field>
             <field name="kind">function</field>
             <field name="action">write({'sds_state': 'no_sub'})</field>
+            <field name="flow_stop" eval='True' />
         </record>
         
         <record model="workflow.activity" id="act_sub">
@@ -77,6 +78,7 @@
             <field name="name">sub_accept</field>
             <field name="kind">function</field>
             <field name="action">write({'sds_state': 'sub_accept'})</field>
+            <field name="flow_stop" eval='True' />
         </record>
         
         <record model="workflow.activity" id="act_sub_reject">
@@ -84,6 +86,7 @@
             <field name="name">sub_reject</field>
             <field name="kind">function</field>
             <field name="action">write({'sds_state': 'sub_reject'})</field>
+            <field name="flow_stop" eval='True' />
         </record>
 
         <!-- Transitions -->
@@ -109,7 +112,7 @@
         <record model="workflow.transition" id="t2">
             <field name="act_from" ref="act_waiting_welcome" />
             <field name="act_to" ref="act_active" />
-            <field name="signal">welcome_sent</field>
+            <field name="signal">mail_sent</field>
         </record>
         
         <record model="workflow.transition" id="t5a">


### PR DESCRIPTION
- Fix wrong view on create contracts

- Add colors to m2one fields parrent_id and child_id

- Fix order groups for sds state