### PR TITLE
add zxing and OpenCV dependencies on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,19 @@ python:
     - '2.7'
 
 env:
-    - VERSION="8.0" ODOO_REPO="odoo/odoo" EXCLUDE="sbc_compassion,onramp_compassion"
+    global:
+        - VERSION="8.0"
+        - ODOO_REPO="odoo/odoo"
+        - EXCLUDE="sbc_compassion,onramp_compassion"
+        - OPENCV_ROOT=${HOME}/opencv
 
 virtualenv:
   system_site_packages: true
 
 install:
+    - travis/install_opencv.sh
+    - export PYTHONPATH=${PYTHONPATH}:${OPENCV_ROOT}/install/lib/python2.7/site-packages
+    - python -c 'import cv2; print("OpenCV version is {}".format(cv2.__version__))'
     - pip install flake8
     - pip install pysftp
     - pip install MySQL-python
@@ -48,4 +55,3 @@ script:
 
 after_success:
     - coveralls
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ install:
     - pip install urllib3
     - pip install certifi
     - pip install coveralls
+    - pip install python-magic
+    - pip install wand
     - git clone https://github.com/CompassionCH/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools -b r2
     - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
     - git clone https://github.com/OCA/l10n-switzerland.git ${HOME}/build/CompassionCH/l10n-switzerland -b 8.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,13 @@ env:
         - ODOO_REPO="odoo/odoo"
         - EXCLUDE="sbc_compassion,onramp_compassion"
         - OPENCV_ROOT=${HOME}/opencv
+        - ZXING_ROOT=${HOME}/.libZxing
 
 virtualenv:
   system_site_packages: true
 
 install:
+    - travis/install_zxing.sh
     - travis/install_opencv.sh
     - export PYTHONPATH=${PYTHONPATH}:${OPENCV_ROOT}/install/lib/python2.7/site-packages
     - python -c 'import cv2; print("OpenCV version is {}".format(cv2.__version__))'

--- a/travis/install_opencv.sh
+++ b/travis/install_opencv.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 # Downloads, builds, and installs OpenCV 3.0.0 to $OPENCV_ROOT/install.
-# Note that OPENCV_ROOT has to be set before calling this script.
+# Note that OPENCV_ROOT has to be set to some writable absolute path
+# before calling this script.
 # You will have to add $OPENCV_ROOT/install/lib/python2.7/site-packages
 # to your PYTHONPATH in order to use OpenCV from python.
 

--- a/travis/install_opencv.sh
+++ b/travis/install_opencv.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+# Downloads, builds, and installs OpenCV 3.0.0 to $OPENCV_ROOT/install.
+# Note that OPENCV_ROOT has to be set before calling this script.
+# You will have to add $OPENCV_ROOT/install/lib/python2.7/site-packages
+# to your PYTHONPATH in order to use OpenCV from python.
+
+set -ex
+
+: "${OPENCV_ROOT?You have to set OPENCV_ROOT before running this script!}"
+
+OPENCV_BUILD_DIR=${OPENCV_ROOT}/build
+OPENCV_INSTALL_DIR=${OPENCV_ROOT}/install
+OPENCV_CONTRIB_DIR=${OPENCV_ROOT}/contrib
+
+git clone https://github.com/Itseez/opencv.git -b 3.0.0 ${OPENCV_ROOT}
+git clone https://github.com/Itseez/opencv_contrib -b 3.0.0 ${OPENCV_CONTRIB_DIR}
+
+mkdir -p ${OPENCV_BUILD_DIR}
+mkdir -p ${OPENCV_INSTALL_DIR}
+
+cd ${OPENCV_BUILD_DIR}
+
+cmake \
+-DCMAKE_INSTALL_PREFIX=${OPENCV_INSTALL_DIR} \
+-DOPENCV_EXTRA_MODULES_PATH=${OPENCV_CONTRIB_DIR}/modules \
+-DBUILD_PERF_TESTS=OFF \
+-DBUILD_TESTS=OFF \
+-DBUILD_opencv_java=OFF \
+${OPENCV_ROOT}
+
+make -j4
+make -j4 install

--- a/travis/install_zxing.sh
+++ b/travis/install_zxing.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Downloads and builds zxing and python-zxing in $ZXING_ROOT.
+# Note that ZXING_ROOT has to be set to some writable absolute path
+# before calling this script.
+
+# Adapted from install instructions in
+# https://github.com/oostendo/python-zxing/blob/master/README.md
+
+set -ex
+
+: "${ZXING_ROOT?You have to set ZXING_ROOT before running this script!}"
+
+ZXING_PYTHON_DIR=${ZXING_ROOT}/python
+
+git clone https://github.com/zxing/zxing.git ${ZXING_ROOT}
+cd ${ZXING_ROOT}
+# We need a commit that was added after release 3.2.1
+# Should be replaced by cloning 3.2.2 as soon as it's available.
+git checkout 9910fcfaa9be4e3c81efe7febdb121d59baa07e9
+
+git clone git://github.com/oostendo/python-zxing.git ${ZXING_PYTHON_DIR}
+cd ${ZXING_PYTHON_DIR}
+# python-zxing does not have a stable release yet, so we just use the latest
+# version that we have successfully tested before
+git checkout 827db9794fef4d5589a75c89ebd6345338f092ad
+
+cd ${ZXING_ROOT}
+# Disable rat plugin to avoid incorrect license header errors; save time by
+# not building and running tests.
+mvn install -Drat.skip=true -Dmaven.test.skip=true
+
+cd ${ZXING_ROOT}/core
+wget http://central.maven.org/maven2/com/google/zxing/core/2.2/core-2.2.jar
+mv core-2.2.jar core.jar
+mvn install -Drat.skip=true -Dmaven.test.skip=true
+
+cd ${ZXING_ROOT}/javase
+wget http://central.maven.org/maven2/com/google/zxing/javase/2.2/javase-2.2.jar
+mv javase-2.2.jar javase.jar
+mvn install -Drat.skip=true -Dmaven.test.skip=true
+
+cd ${ZXING_PYTHON_DIR}
+# Check if bar code reader is working properly:
+# - read sample.png that is part of the python-zxing distribution
+# - return error code from python -> result can be interpreted in shell script
+python -c "from zxing import tests; import sys; tests.testimage='${ZXING_PYTHON_DIR}/zxing/sample.png'; sys.exit(not tests.test_codereader())"


### PR DESCRIPTION
This fixes several errors on travis (`import cv2` etc) and build is now passing again.
Some more tweaking may be required when we actually have tests that use zxing/OpenCV.