### PR TITLE
CO-1422 FIX Cancel sponsorship when hold is expired

### DIFF
--- a/sponsorship_tracking/wizards/sub_sponsorship_wizard.py
+++ b/sponsorship_tracking/wizards/sub_sponsorship_wizard.py
@@ -121,4 +121,8 @@ class SubSponsorshipWizard(models.TransientModel):
             'sds_state': 'no_sub',
             'color': 1
         })
+        contract.partner_id.message_post(
+            subject='{} - No SUB'.format(contract.child_code),
+            body="The sponsor doesn't want a new child."
+        )
         return True


### PR DESCRIPTION
- CRON does not expire holds, as we receive the expiration info from
  GMC.
- At hold expiration, if the child has not departed, still release the
  child, because it's no longer available to us