### PR TITLE
CO-1539 Le widget tree_image ne fonctionne plus en prod

### DIFF
--- a/sbc_compassion/views/import_letters_history_view.xml
+++ b/sbc_compassion/views/import_letters_history_view.xml
@@ -43,7 +43,9 @@
                                 <field name="mandatory_review"/>
                                 <field name="physical_attachments"/>
                                 <field name="attachments_description"/>
-                                <field name="letter_image_preview" widget='image_preview' display="icon" string="Letter image preview" readonly="1"/>
+                                <field name="letter_image_preview"
+                                       widget='image' height="400"
+                                       string="Letter image preview" readonly="1"/>
                             </tree>
                         </field>
                         <field name="letters_ids" states="done"/>


### PR DESCRIPTION
Removing attributes that were available in odoo 8.0 but not anymore in odoo 10.0. We replace it with an attribute that make the preview image a bit bigger. We however lose the thumbnail feature that could be clicked on. This could be implemented by diffing the web_tree_image module code betwenn branch 8.0 and 10.0.