### PR TITLE
Fixing call button raising an error and failing request to an icon

### DIFF
--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -13,14 +13,13 @@ import logging
 from HTMLParser import HTMLParser
 
 from odoo.addons.base_phone import fields as phone_fields
-from odoo.addons.base_phone.controllers.main import BasePhoneController
 
 from pyPdf import PdfFileReader, PdfFileWriter
 from reportlab.lib.units import mm
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.lib.colors import white
 
-from odoo import api, models, fields, _, http
+from odoo import api, models, fields, _
 from odoo.exceptions import UserError
 
 logger = logging.getLogger(__name__)
@@ -410,12 +409,9 @@ class CommunicationJob(models.Model):
     def call(self):
         """ Call partner from tree view button. """
         self.ensure_one()
-        phone_controller = BasePhoneController()
-        phone_controller.click2dial(
-            self.partner_phone or self.partner_mobile,
-            self._name,
-            self.id
-        )
+        self.env['phone.common'].with_context(
+            click2dial_model=self._name, click2dial_id=self.id)\
+            .click2dial(self.partner_phone or self.partner_mobile)
         return self.log_call()
 
     @api.multi

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -411,9 +411,7 @@ class CommunicationJob(models.Model):
         """ Call partner from tree view button. """
         self.ensure_one()
         phone_controller = BasePhoneController()
-        request = http.request
         phone_controller.click2dial(
-            request,
             self.partner_phone or self.partner_mobile,
             self._name,
             self.id

--- a/partner_communication/static/src/js/phone_button_widget.js
+++ b/partner_communication/static/src/js/phone_button_widget.js
@@ -14,7 +14,6 @@ odoo.define('partner_communication.phone_widget', function (require) {
                 var self = this;
                 var phone_num = this.get('value');
                 if(phone_num) {
-                    // pylint: disable=W7903
                     phone_num = phone_num.replace(/\s/g, '').replace(/-/g, '');
                 }
                 var click2dial_text = '';

--- a/partner_communication/views/call_wizard_view.xml
+++ b/partner_communication/views/call_wizard_view.xml
@@ -8,7 +8,7 @@
                     <field name="comments"/>
                 </group>
                 <footer>
-                    <button name="call_success" string="Log the call" type="object" class="oe_highlight" icon="terp-camera_test"/>
+                    <button name="call_success" string="Log the call" type="object" class="oe_highlight" icon="fa-save"/>
                     <button name="log_fail" string="Still pending" type="object" icon="fa-ban"/>
                 </footer>
             </form>


### PR DESCRIPTION
Icon is not present in odoo any more.
The click2dial function take 4 instead of 5 arguments. 
(self, phone_number, click2dial_model, click2dial_id)