### PR TITLE
CO-2384 : Do not update lang using the env value when matching partner.

### DIFF
--- a/cms_form_compassion/forms/match_partner_form.py
+++ b/cms_form_compassion/forms/match_partner_form.py
@@ -169,8 +169,6 @@ if not testing:
             }
             # Make active any partner that is matched
             vals['active'] = True
-            if 'lang' not in vals:
-                vals['lang'] = self.env.lang
             return vals
 
         def _get_partner_keys(self):


### PR DESCRIPTION
The lang is still set if the partner is created.