### PR TITLE
CO-2397 : Use match partner for sms sponsorship

### DIFF
--- a/cms_form_compassion/models/match_partner.py
+++ b/cms_form_compassion/models/match_partner.py
@@ -42,7 +42,11 @@ class MatchPartner(models.AbstractModel):
         for rule in self._match_get_rules_order():
             if not partner or len(partner) > 1:
                 method = getattr(self, '_match_rule_' + rule)
-                partner = method(partner_obj, infos)
+                try:
+                    partner = method(partner_obj, infos)
+                except KeyError:
+                    # Not enough info for the matching rule
+                    partner = False
             else:
                 break
 

--- a/cms_form_compassion/models/match_partner.py
+++ b/cms_form_compassion/models/match_partner.py
@@ -8,8 +8,10 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+from datetime import datetime, timedelta
 
 from odoo import api, models
+from odoo.addons.queue_job.job import job
 
 
 class MatchPartner(models.AbstractModel):
@@ -63,7 +65,8 @@ class MatchPartner(models.AbstractModel):
     def match_after_match(self, partner, new_partner, infos):
         """Once a match is found or created, this method allows to change it"""
         if not new_partner:
-            self.match_update(partner, infos)
+            delay = datetime.now() + timedelta(minutes=1)
+            self.with_delay(eta=delay).match_update(partner, infos)
         return partner
 
     @api.model
@@ -88,6 +91,7 @@ class MatchPartner(models.AbstractModel):
         return create_infos
 
     @api.model
+    @job
     def match_update(self, partner, infos):
         """Update the matched partner with a selection of the given infos."""
         update_infos = self.match_process_update_infos(infos)

--- a/cms_form_compassion/models/match_partner.py
+++ b/cms_form_compassion/models/match_partner.py
@@ -138,12 +138,13 @@ class MatchPartner(models.AbstractModel):
     @api.model
     def _match_get_valid_create_fields(self):
         """Return the fields which can be used at creation."""
-        return ['firstname', 'lastname', 'email', 'phone', 'street', 'city',
-                'zip', 'country_id', 'state_id', 'title', 'lang', 'birthdate',
-                'church_unlinked', 'function', 'spoken_lang_ids']
+        return ['firstname', 'lastname', 'email', 'phone', 'mobile', 'street',
+                'city', 'zip', 'country_id', 'state_id', 'title', 'lang',
+                'birthdate', 'church_unlinked', 'function', 'spoken_lang_ids']
 
     @api.model
     def _match_get_valid_update_fields(self):
         """Return the fields which can be used at update."""
-        return ['email', 'phone', 'street', 'city', 'zip', 'country_id',
-                'state_id', 'church_unlinked', 'function', 'spoken_lang_ids']
+        return ['email', 'phone', 'mobile', 'street', 'city', 'zip',
+                'country_id', 'state_id', 'church_unlinked', 'function',
+                'spoken_lang_ids']

--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -74,9 +74,6 @@ class SmsChildRequest(models.Model):
     field_office_id = fields.Many2one(
         'compassion.field.office', 'Field Office')
 
-    new_partner = fields.Boolean('New partner ?',
-                                 help="is true if partner was created when "
-                                      "sending sms", default=False)
     is_trying_to_fetch_child = fields.Boolean(
         help="This is set to true when a child is currently being fetched. "
              "It prevents to fetch multiple children.")

--- a/sms_sponsorship/static/react
+++ b/sms_sponsorship/static/react
@@ -1,1 +1,1 @@
-/home/ecino/addons/compassion-modules/sms_sponsorship/webapp/build/
+../webapp/build

--- a/sms_sponsorship/tests/test_sms_compassion.py
+++ b/sms_sponsorship/tests/test_sms_compassion.py
@@ -50,7 +50,6 @@ class TestSmsCompassion(BaseSponsorshipTest):
             ('email', '=', 'test@email.com')
         ])
         self.assertTrue(new_partner)
-        self.assertTrue(self.child_request.new_partner)
         self.assertEqual(new_partner.lang, 'en_US')
         new_sponsorship = self.env['recurring.contract'].search([
             ('partner_id', '=', new_partner.id),

--- a/sms_sponsorship/views/sms_child_request_view.xml
+++ b/sms_sponsorship/views/sms_child_request_view.xml
@@ -37,7 +37,6 @@
                         <group>
                             <field name="event_id"/>
                             <field name="step1_url"/>
-                            <field name="new_partner"/>
                             <field name="sms_reminder_sent"/>
                             <field name="sponsorship_confirmed"/>
                             <field name="step2_url"/>


### PR DESCRIPTION
As the field new_partner was removed from sms.child.request, all new sms sponsorship must now be manually confirmed.