### PR TITLE
WP-29 : Tool to authenticate REST requests to Wordpress.

### DIFF
--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -8,7 +8,8 @@
 #
 ##############################################################################
 import logging
-import requests
+from ..tools import wp_requests
+
 
 from odoo import api, models, fields, _
 from odoo.exceptions import UserError
@@ -67,51 +68,54 @@ class WordpressPost(models.Model):
         category_obj = self.env['wp.post.category']
         found_ids = []
         try:
-            for lang in self._supported_langs():
-                params['lang'] = lang.code[:2]
-                wp_posts = requests.get(wp_api_url, params=params).json()
-                _logger.info('Processing posts in %s', lang.name)
-                for i, post_data in enumerate(wp_posts):
-                    _logger.info("...processing post %s/%s",
-                                 str(i+1), str(len(wp_posts)))
-                    post_id = post_data['id']
-                    found_ids.append(post_id)
-                    try:
-                        # Fetch image for thumbnail
-                        image_json_url = post_data['_links'][
-                            'wp:featuredmedia'][0]['href']
-                        image_json = requests.get(image_json_url).json()
-                        image_url = image_json['media_details']['sizes'][
-                            'medium']['source_url']
-                    except KeyError:
-                        # Some post images may not be accessible
-                        image_url = False
-                        _logger.warning('WP Post ID %s has no image',
-                                        str(post_id))
-                    # Fetch post category
-                    category_data = [
-                        d for d in post_data['_links']['wp:term']
-                        if d['taxonomy'] == 'category'
-                    ][0]
-                    category_json_url = category_data['href']
-                    category_name = requests.get(
-                        category_json_url).json()[0]['name']
-                    category = category_obj.search([
-                        ('name', '=', category_name)])
-                    if not category:
-                        category = category_obj.create({'name': category_name})
-                    if not self.search([('wp_id', '=', post_id)]):
-                        # Cache new post in database
-                        self.create({
-                            'name': post_data['title']['rendered'],
-                            'date': post_data['date'],
-                            'wp_id': post_id,
-                            'url': post_data['link'],
-                            'image_url': image_url,
-                            'post_type': post_data['type'],
-                            'category_id': category.id,
-                            'lang': lang.code
-                        })
+            with wp_requests.Session() as requests:
+                for lang in self._supported_langs():
+                    params['lang'] = lang.code[:2]
+                    wp_posts = requests.get(wp_api_url, params=params).json()
+                    _logger.info('Processing posts in %s', lang.name)
+                    for i, post_data in enumerate(wp_posts):
+                        _logger.info("...processing post %s/%s",
+                                     str(i+1), str(len(wp_posts)))
+                        post_id = post_data['id']
+                        found_ids.append(post_id)
+                        try:
+                            # Fetch image for thumbnail
+                            image_json_url = post_data['_links'][
+                                'wp:featuredmedia'][0]['href']
+                            image_json = requests.get(image_json_url).json()
+                            image_url = image_json['media_details']['sizes'][
+                                'medium']['source_url']
+                        except KeyError:
+                            # Some post images may not be accessible
+                            image_url = False
+                            _logger.warning('WP Post ID %s has no image',
+                                            str(post_id))
+                        # Fetch post category
+                        category_data = [
+                            d for d in post_data['_links']['wp:term']
+                            if d['taxonomy'] == 'category'
+                        ][0]
+                        category_json_url = category_data['href']
+                        category_name = requests.get(
+                            category_json_url).json()[0]['name']
+                        category = category_obj.search([
+                            ('name', '=', category_name)])
+                        if not category:
+                            category = category_obj.create({
+                                'name': category_name
+                            })
+                        if not self.search([('wp_id', '=', post_id)]):
+                            # Cache new post in database
+                            self.create({
+                                'name': post_data['title']['rendered'],
+                                'date': post_data['date'],
+                                'wp_id': post_id,
+                                'url': post_data['link'],
+                                'image_url': image_url,
+                                'post_type': post_data['type'],
+                                'category_id': category.id,
+                                'lang': lang.code
+                            })
             # Delete unpublished posts
             self.search([('wp_id', 'not in', found_ids)]).unlink()
             _logger.info("Fetch Wordpress Posts finished!")

--- a/mobile_app_connector/readme/CONFIGURE.rst
+++ b/mobile_app_connector/readme/CONFIGURE.rst
@@ -1,3 +1,9 @@
 Make sure the following variables are defined in your odoo.conf file:
 
 - `wordpress_host`: host URL for the Wordpress website where the blog posts will be fetched.
+- `wordpress_user`: user login for the Wordpress website where the blog posts will be fetched.
+- `wordpress_pwd`: user password for the Wordpress website where the blog posts will be fetched.
+
+The login info allows the fetching of attached media which main post isn't published.
+The plugin `wp-api-jwt-auth` must be installed on Wordpress so that
+the requests can be authenticated.

--- a/mobile_app_connector/tools/__init__.py
+++ b/mobile_app_connector/tools/__init__.py
@@ -3,13 +3,10 @@
 #
 #    Copyright (C) 2018 Compassion CH (http://www.compassion.ch)
 #    Releasing children from poverty in Jesus' name
-#    @author: Emanuel Cino <ecino@compassion.ch>
+#    @author: Christopher Meier <dev@c-meier.ch>
 #
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
 
-from . import models
-from . import mappings
-from . import tools
-from . import controllers
+from . import wp_requests

--- a/mobile_app_connector/tools/wp_requests.py
+++ b/mobile_app_connector/tools/wp_requests.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Christopher Meier <dev@c-meier.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+import requests
+
+from odoo import exceptions
+from odoo.tools import config
+
+
+class Session(requests.Session):
+    def __enter__(self):
+        """Authenticate and set the JSON Web Token for the session"""
+        wp_host = config.get('wordpress_host')
+        wp_user = config.get('wordpress_user')
+        wp_pwd = config.get('wordpress_pwd')
+
+        wp_api_url = 'https://' + wp_host + '/wp-json/jwt-auth/v1/token'
+
+        auth = self.post(wp_api_url, json={
+            'username': wp_user,
+            'password': wp_pwd,
+        }).json()
+
+        if 'token' not in auth:
+            raise exceptions.AccessError('Wordpress authentication failed !')
+
+        self.headers.update({'Authorization': 'Bearer %s' % auth['token']})
+
+        return super(Session, self).__enter__()


### PR DESCRIPTION
For Wordpress:

- The plugin [wp-api-jwt-auth](https://wordpress.org/plugins/jwt-authentication-for-wp-rest-api/) must be installed
- The following config options must be set in `wp-config.php` (before the DEBUG define) :
```
define('JWT_AUTH_SECRET_KEY', 'your-top-secret-key-that-must-be-changed');
define('JWT_AUTH_CORS_ENABLE', true);
```
- The following instruction must be set in `.htaccess` :
```
SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
```