### PR TITLE
CO-2624: Base default language is added to spoken_languages in all cases

### DIFF
--- a/child_compassion/models/field_office.py
+++ b/child_compassion/models/field_office.py
@@ -75,6 +75,7 @@ class FieldOffice(models.Model):
     ##########################################################################
     #                             VIEW CALLBACKS                             #
     ##########################################################################
+
     @api.multi
     def update_informations(self):
         """ Get the most recent informations for selected field offices and

--- a/sbc_compassion/migrations/10.0.1.4.0/post-migration.py
+++ b/sbc_compassion/migrations/10.0.1.4.0/post-migration.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Create a tuple (partner_id, lang_id) for all the res_partners.
+    # Adds each row in the relational table
+    cr.execute("""
+INSERT INTO res_lang_compassion_res_partner_rel
+(res_partner_id, res_lang_compassion_id)
+(SELECT res_partner.id AS partner_id, res_lang.id AS lang_id FROM res_partner
+INNER JOIN res_lang ON res_lang.code = res_partner.lang)
+ON CONFLICT
+DO NOTHING
+    """)

--- a/sbc_compassion/models/partner_compassion.py
+++ b/sbc_compassion/models/partner_compassion.py
@@ -53,11 +53,19 @@ class ResPartner(models.Model):
 
     @api.model
     def create(self, vals):
+        lang_id = self.env['res.lang.compassion'].search([
+            ('lang_id.code', '=', vals.get('lang', self.env.lang))
+        ]).ids
         if 'spoken_lang_ids' not in vals:
-            lang_ids = self.env['res.lang.compassion'].search([
-                ('lang_id.code', '=', vals.get('lang', self.env.lang))
-            ]).ids
-            vals['spoken_lang_ids'] = [(6, 0, lang_ids)]
+            vals['spoken_lang_ids'] = [(6, 0, lang_id)]
+        else:
+            base_language = (4, lang_id[0])
+            spoken_languages = vals['spoken_lang_ids']
+            # If the base language is not in the list of the spoken languages,
+            # we have to add it
+            if base_language not in spoken_languages:
+                spoken_languages.append(base_language)
+                vals['spoken_lang_ids'] = spoken_languages
         return super(ResPartner, self).create(vals)
 
     @api.multi

--- a/sbc_compassion/models/partner_compassion.py
+++ b/sbc_compassion/models/partner_compassion.py
@@ -13,8 +13,7 @@ from odoo import fields, models, api
 
 
 class ResPartner(models.Model):
-    """ Add correspondence preferences to Partners
-    """
+    """ Add correspondence preferences to Partners """
     _inherit = 'res.partner'
 
     ##########################################################################


### PR DESCRIPTION
Previously, when a user selected a list of spoken languages which did not propose its base language, a profile was created without the base language to be added to the spoken languages in that case.
This pull request also provide a post-migration.py file, which contains a request to update the spoken language field of all users to also contain the base language. This request does not modify users for which the field was already correct. 