### PR TITLE
AP-94 Provide links for old children's images

### DIFF
--- a/child_compassion/__manifest__.py
+++ b/child_compassion/__manifest__.py
@@ -50,6 +50,7 @@
     },
     'data': [
         'security/sponsorship_groups.xml',
+        'security/child_pictures_security.xml',
         'security/ir.model.access.csv',
         'views/child_compassion_view.xml',
         'views/field_office_view.xml',

--- a/child_compassion/migrations/10.0.1.3.0/post-migration.py
+++ b/child_compassion/migrations/10.0.1.3.0/post-migration.py
@@ -18,9 +18,7 @@ def migrate(cr, version):
         UPDATE compassion_child_pictures AS pics
         SET image_url = CONCAT(
             'https://erp.compassion.ch/web/image/compassion.child.pictures/',
-            id,
-            '/fullshot/child.jpg'
+            id, '/fullshot/', pics.date, '_', pics.child_id, '.jpg'
         )
         WHERE (pics.image_url <> '') IS NOT TRUE
     """)
-

--- a/child_compassion/migrations/10.0.1.3.0/post-migration.py
+++ b/child_compassion/migrations/10.0.1.3.0/post-migration.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2018 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    # Update pictures older pictures that don't have a link
+    cr.execute("""
+        UPDATE compassion_child_pictures AS pics
+        SET image_url = CONCAT(
+            'https://erp.compassion.ch/web/image/compassion.child.pictures/',
+            id,
+            '/fullshot/child.jpg'
+        )
+        WHERE (pics.image_url <> '') IS NOT TRUE
+    """)
+

--- a/child_compassion/security/child_pictures_security.xml
+++ b/child_compassion/security/child_pictures_security.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="child_model_access" model="ir.model.access">
+        <field name="name">Child model access</field>
+        <field name="model_id" ref="model_compassion_child"/>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="domain_force">[('sponsor_id', '=', user.partner_id.id)]</field>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+        <field name="perm_create" eval="0"/>
+    </record>
+    <record id="child_pictures_model_access" model="ir.model.access">
+        <field name="name">Child pictures model access</field>
+        <field name="model_id" ref="model_compassion_child_pictures"/>
+        <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        <field name="domain_force">[('child_id.sponsor_id', '=', user.partner_id.id)]</field>
+        <field name="perm_read" eval="1"/>
+        <field name="perm_write" eval="0"/>
+        <field name="perm_unlink" eval="0"/>
+        <field name="perm_create" eval="0"/>
+    </record>
+</odoo>
+

--- a/child_compassion/security/child_pictures_security.xml
+++ b/child_compassion/security/child_pictures_security.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record id="child_model_access" model="ir.model.access">
-        <field name="name">Child model access</field>
+        <field name="name">Child access to portal users</field>
         <field name="model_id" ref="model_compassion_child"/>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="domain_force">[('sponsor_id', '=', user.partner_id.id)]</field>

--- a/child_compassion/security/child_pictures_security.xml
+++ b/child_compassion/security/child_pictures_security.xml
@@ -11,7 +11,7 @@
         <field name="perm_create" eval="0"/>
     </record>
     <record id="child_pictures_model_access" model="ir.model.access">
-        <field name="name">Child pictures model access</field>
+        <field name="name">Child pictures access to portal users</field>
         <field name="model_id" ref="model_compassion_child_pictures"/>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="domain_force">[('child_id.sponsor_id', '=', user.partner_id.id)]</field>

--- a/child_compassion/security/ir.model.access.csv
+++ b/child_compassion/security/ir.model.access.csv
@@ -2,6 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_compassion_project,Full access on compassion_project,model_compassion_project,group_sponsorship,1,1,1,1
 access_compassion_child,Full access on compassion_child,model_compassion_child,group_sponsorship,1,1,1,1
 access_compassion_child_pictures,Full access on compassion_child_pictures,model_compassion_child_pictures,group_sponsorship,1,1,1,1
+access_public_compassion_child_pictures,Read access on compassion_child_pictures,model_compassion_child_pictures,base.group_portal,1,0,0,0
 access_res_lang_compassion,Read only access on res_lang_compassion,model_res_lang_compassion,group_sponsorship,1,0,0,0
 access_admin_res_lang_compassion,Full access on res_lang_compassion,model_res_lang_compassion,base.group_system,1,1,1,1
 access_child_assessement,Read access on child_assessement,model_compassion_child_cdpr,group_sponsorship,1,0,1,0


### PR DESCRIPTION
Older pictures from children can now have their own link, to be added in some application's tiles. All that is required is a migration of the module with a provided migration file. Links do not have a random part, but access control has been set up, in order to prevent anybody to browse through the entire list of children's images.