### PR TITLE
Minor fix: adapt email subject to the number it refers to (is/are)

### DIFF
--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -362,7 +362,7 @@ class SmsChildRequest(models.Model):
                 body=_("{} partner(s) have ongoing SMS Sponsorship").format(
                     nb_sms_requests),
                 subject=_("{} SMS Sponsorship {} ongoing").format(
-                    nb_sms_requests, 'is' if nb_sms_requests <= 1 else 'are'),
+                    nb_sms_requests, _('is') if nb_sms_requests <= 1 else _('are')),
                 partner_ids=notify_ids,
                 type='comment',
                 subtype='mail.mt_comment',

--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -361,8 +361,8 @@ class SmsChildRequest(models.Model):
             self.message_post(
                 body=_("{} partner(s) have ongoing SMS Sponsorship").format(
                     nb_sms_requests),
-                subject=_("{} SMS Sponsorship are ongoing").format(
-                    nb_sms_requests),
+                subject=_("{} SMS Sponsorship {} ongoing").format(
+                    nb_sms_requests, 'is' if nb_sms_requests <= 1 else 'are'),
                 partner_ids=notify_ids,
                 type='comment',
                 subtype='mail.mt_comment',

--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -364,7 +364,8 @@ class SmsChildRequest(models.Model):
                 body=_("{} partner(s) have ongoing SMS Sponsorship").format(
                     nb_sms_requests),
                 subject=_("{} SMS Sponsorship {} ongoing").format(
-                    nb_sms_requests, _('is') if nb_sms_requests <= 1 else _('are')),
+                    nb_sms_requests,
+                    _('is') if nb_sms_requests <= 1 else _('are')),
                 partner_ids=notify_ids,
                 type='comment',
                 subtype='mail.mt_comment',


### PR DESCRIPTION
I received a mail this morning displaying "1 SMS sponsorship are ongoing". This PR simply change this to write "1 SMS sponsorship is ongoing" in that case.