### PR TITLE
AP-122 Add support for ''Not sponsor' tiles

### DIFF
--- a/mobile_app_connector/i18n/de.po
+++ b/mobile_app_connector/i18n/de.po
@@ -202,6 +202,11 @@ msgid "Both"
 msgstr "Both"
 
 #. module: mobile_app_connector
+#: selection:mobile.app.tile,visibility:0
+msgid "Not sponsor"
+msgstr "Not sponsor"
+
+#. module: mobile_app_connector
 #: model:ir.model.fields,field_description:mobile_app_connector.field_mobile_app_banner_button_text
 msgid "Button text"
 msgstr "Button text"

--- a/mobile_app_connector/i18n/fr_CH.po
+++ b/mobile_app_connector/i18n/fr_CH.po
@@ -213,6 +213,11 @@ msgid "Both"
 msgstr "Both"
 
 #. module: mobile_app_connector
+#: selection:mobile.app.tile,visibility:0
+msgid "Not sponsor"
+msgstr "Not sponsor"
+
+#. module: mobile_app_connector
 #: model:ir.model.fields,field_description:mobile_app_connector.field_mobile_app_banner_button_text
 msgid "Button text"
 msgstr "Button text"

--- a/mobile_app_connector/models/app_tile.py
+++ b/mobile_app_connector/models/app_tile.py
@@ -37,7 +37,8 @@ class AppTile(models.Model):
     end_date = fields.Datetime()
     is_active = fields.Boolean('Active', default=True)
     visibility = fields.Selection(
-        [('public', 'Public'), ('private', 'Private'), ('both', 'Both')],
+        [('public', 'Public'), ('private', 'Private'),
+         ('both', 'Both'), ('not_sponsor', 'Not Sponsor')],
         required=True,
         help='Choose private if the sponsor must be logged in to see the tile'
     )


### PR DESCRIPTION
Users that are connected but do not yet sponsor a child can use this new type of tile: _Not Sponsor_. It is more restrictive than _Public_ because users need to be logged into the app, and less than _Private_ because it allows users that are not the sponsor of a child yet to see these tiles.