### PR TITLE
Co 2667 Migrate Advanced translation 

### DIFF
--- a/advanced_translation/__manifest__.py
+++ b/advanced_translation/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     'name': 'Advanced Translation',
-    'version': '10.0.1.0.0',
+    'version': '11.0.1.0.0',
     'category': 'Other',
     'sequence': 150,
     'author': 'Compassion CH',

--- a/advanced_translation/models/ir_advanced_translation.py
+++ b/advanced_translation/models/ir_advanced_translation.py
@@ -11,7 +11,6 @@
 
 import logging
 import re
-import sys
 import threading
 import locale
 from collections import OrderedDict
@@ -145,7 +144,7 @@ class AdvancedTranslatable(models.AbstractModel):
         return res or ''
 
     @api.multi
-    def get_list(self, field, limit=sys.maxint, substitution=None,
+    def get_list(self, field, limit=float("inf"), substitution=None,
                  translate=True):
         """
         Get a list of values, separated with commas. (last separator 'and')


### PR DESCRIPTION
The only change we had to do is to change a max int to a float("inf") because int has no max in python 3.