### PR TITLE
AP-155 Wordpress posts encoding bug

### DIFF
--- a/mobile_app_connector/__manifest__.py
+++ b/mobile_app_connector/__manifest__.py
@@ -43,7 +43,7 @@
         'sms_sponsorship',
     ],
     'external_dependencies': {
-        'python': ['simplejson', 'bs4', 'requests', 'HTMLParser'],
+        'python': ['simplejson', 'bs4', 'requests'],
     },
     'data': [
         'security/ir.model.access.csv',

--- a/mobile_app_connector/__manifest__.py
+++ b/mobile_app_connector/__manifest__.py
@@ -43,7 +43,7 @@
         'sms_sponsorship',
     ],
     'external_dependencies': {
-        'python': ['simplejson', 'bs4', 'requests'],
+        'python': ['simplejson', 'bs4', 'requests', 'HTMLParser'],
     },
     'data': [
         'security/ir.model.access.csv',

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -8,15 +8,18 @@
 #
 ##############################################################################
 import logging
-from HTMLParser import HTMLParser
 from ..tools import wp_requests
-
 
 from odoo import api, models, fields, _
 from odoo.exceptions import UserError
 from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
+
+try:
+    from HTMLParser import HTMLParser
+except ImportError:
+    _logger.warning("Please install HTMLParser")
 
 
 class WordpressPost(models.Model):

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -8,6 +8,7 @@
 #
 ##############################################################################
 import logging
+from HTMLParser import HTMLParser
 from ..tools import wp_requests
 
 
@@ -92,10 +93,15 @@ class WordpressPost(models.Model):
         category_obj = self.env['wp.post.category']
         found_ids = []
         try:
+            h = HTMLParser()
             with wp_requests.Session() as requests:
                 for lang in self._supported_langs():
                     params['lang'] = lang.code[:2]
                     wp_posts = requests.get(wp_api_url, params=params).json()
+                    for post in wp_posts:
+                        post['excerpt']['rendered'] = h.unescape(post['excerpt']['rendered'])
+                        post['title']['rendered'] = h.unescape(post['title']['rendered'])
+
                     _logger.info('Processing posts in %s', lang.name)
                     for i, post_data in enumerate(wp_posts):
                         _logger.info("...processing post %s/%s",

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -8,18 +8,15 @@
 #
 ##############################################################################
 import logging
+from HTMLParser import HTMLParser
 from ..tools import wp_requests
+
 
 from odoo import api, models, fields, _
 from odoo.exceptions import UserError
 from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
-
-try:
-    from HTMLParser import HTMLParser
-except ImportError:
-    _logger.warning("Please install HTMLParser")
 
 
 class WordpressPost(models.Model):

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -99,8 +99,10 @@ class WordpressPost(models.Model):
                     params['lang'] = lang.code[:2]
                     wp_posts = requests.get(wp_api_url, params=params).json()
                     for post in wp_posts:
-                        post['excerpt']['rendered'] = h.unescape(post['excerpt']['rendered'])
-                        post['title']['rendered'] = h.unescape(post['title']['rendered'])
+                        post['excerpt']['rendered'] =\
+                            h.unescape(post['excerpt']['rendered'])
+                        post['title']['rendered'] =\
+                            h.unescape(post['title']['rendered'])
 
                     _logger.info('Processing posts in %s', lang.name)
                     for i, post_data in enumerate(wp_posts):

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -98,11 +98,6 @@ class WordpressPost(models.Model):
                 for lang in self._supported_langs():
                     params['lang'] = lang.code[:2]
                     wp_posts = requests.get(wp_api_url, params=params).json()
-                    for post in wp_posts:
-                        post['excerpt']['rendered'] =\
-                            h.unescape(post['excerpt']['rendered'])
-                        post['title']['rendered'] =\
-                            h.unescape(post['title']['rendered'])
 
                     _logger.info('Processing posts in %s', lang.name)
                     for i, post_data in enumerate(wp_posts):
@@ -159,7 +154,7 @@ class WordpressPost(models.Model):
                             category = category_obj
                         # Cache new post in database
                         self.create({
-                            'name': post_data['title']['rendered'],
+                            'name': h.unescape(post_data['title']['rendered']),
                             'date': post_data['date'],
                             'wp_id': post_id,
                             'url': post_data['link'],


### PR DESCRIPTION
The posts fetched from Wordpress used to have an encoding issue when they were entered on the DB. Indeed, they were HTML entities with decimal encoding of some characters. The incriminated strings are now unescaped to prevent this unwanted behaviour.
No script for migration has been written but the posts will be updated in the database at the next Cron. It can even be triggered manually to update the data. 