### PR TITLE
AP-223 Method send/deleteDeviceId used to throw an exception, now fixed

### DIFF
--- a/mobile_app_connector/models/firebase_registration.py
+++ b/mobile_app_connector/models/firebase_registration.py
@@ -104,4 +104,4 @@ class GetPartnerMessage(models.Model):
             raise NotImplemented('Operation %s is not supported by Odoo' %
                                  operation)
 
-        return {"Registration": reg_id}
+        return reg_id


### PR DESCRIPTION
We obtained the following error:
`java.lang.IllegalStateException: Expected a string but was BEGIN_OBJECT at line 1 column 2 path`