### PR TITLE
AP-235 Add support for the What I'm learning view of the app

### DIFF
--- a/child_compassion/security/ir.model.access.csv
+++ b/child_compassion/security/ir.model.access.csv
@@ -92,5 +92,7 @@ access_demand_weekly_demand,Full access on demand_weekly_demand,model_demand_wee
 read_access_demand_weekly_demand,Read only access on demand_weekly_demand,model_demand_weekly_demand,group_sponsorship,1,0,0,0
 access_user_field_office,access_user_field_office,model_compassion_field_office,base.group_user,1,0,0,0
 access_field_office,access_field_office,model_compassion_field_office,base.group_portal,1,0,0,0
+access_admin_field_office,access_admin_field_office,model_compassion_field_office,base.group_system,1,1,1,1
 access_user_learning_info,access_user_learning_info,model_learning_info,base.group_user,1,0,0,0
 access_learning_info,access_learning_info,model_learning_info,base.group_portal,1,0,0,0
+access_admin_learning_info,access_admin_learning_info,model_learning_info,base.group_system,1,1,1,1

--- a/child_compassion/security/ir.model.access.csv
+++ b/child_compassion/security/ir.model.access.csv
@@ -90,3 +90,7 @@ access_demand_planning,Full access on demand_planning,model_demand_planning,sale
 read_access_demand_planning,Read only access on demand_planning,model_demand_planning,group_sponsorship,1,0,0,0
 access_demand_weekly_demand,Full access on demand_weekly_demand,model_demand_weekly_demand,sales_team.group_sale_manager,1,1,1,1
 read_access_demand_weekly_demand,Read only access on demand_weekly_demand,model_demand_weekly_demand,group_sponsorship,1,0,0,0
+access_user_field_office,access_user_field_office,model_compassion_field_office,base.group_user,1,0,0,0
+access_field_office,access_field_office,model_compassion_field_office,base.group_portal,1,0,0,0
+access_user_learning_info,access_user_learning_info,model_learning_info,base.group_user,1,0,0,0
+access_learning_info,access_learning_info,model_learning_info,base.group_portal,1,0,0,0

--- a/mobile_app_connector/controllers/mobile_app_controller.py
+++ b/mobile_app_connector/controllers/mobile_app_controller.py
@@ -195,24 +195,3 @@ class RestController(http.Controller):
                 response['message'] = _("Mail delivery error")
 
         return response
-
-    @http.route('/mobile-app-api/faq',
-                type='json', auth='public', methods=['GET'])
-    def mobile_app_faq(self, **parameters):
-        """
-        Called whenever the user want to access the FAQ. The question are
-        retrieved from the website and returned as a JSON message to the user.
-        """
-        return request.env['frequently.asked.questions']\
-            .mobile_get_faq_json(_get_lang(request, parameters))
-
-    @http.route('/mobile-app-api/privacy_notice',
-                type='json', auth='public', methods=['GET'])
-    def mobile_privacy_notice(self, **parameters):
-        """
-        Called whenever the user want to access the Privacy notice agreement.
-        The question are retrieved from the website and returned as a JSON
-        message to the user.
-        """
-        return request.env['privacy.statement.agreement']\
-            .mobile_get_privacy_notice(_get_lang(request, parameters))

--- a/mobile_app_connector/models/frequently_asked_questions.py
+++ b/mobile_app_connector/models/frequently_asked_questions.py
@@ -28,7 +28,7 @@ class FAQ(models.AbstractModel):
     _name = 'frequently.asked.questions'
     _description = 'Mobile App FAQ'
 
-    def mobile_get_faq_json(self, language, **params):
+    def mobile_get_faq(self, language, **params):
         """
         Method that takes care of retrieving the FAQ from the website and
         returns it in a JSON format. The method should be called directly
@@ -40,9 +40,9 @@ class FAQ(models.AbstractModel):
         :return: a JSON formatted dictionary containing all the questions and
         answers of the FAQ.
         """
-        if language == 'fr_CH':
+        if language == 'fr':
             faq_link = 'https://compassion.ch/questions-frequentes/'
-        elif language == 'it_IT':
+        elif language == 'it':
             faq_link = 'https://compassion.ch/it/domande-frequenti/'
         else:
             faq_link = 'https://compassion.ch/de/haeufig-gestellte-fragen/'


### PR DESCRIPTION
the points that are added in this PR are the following:
- Useless routes for the **FAQ** and the **Privacy notice** have been deleted.
- A new model **learning_info** has been created and contains information about schedule of different activites done at the project.
- The model **compassion_field_office** has been slightly modified to contain a few additional fields.
- A method to return a json description of the _learning_info_list_ has been added.
- the security rules have been modified to to provide proper access.
Most of the task was done here, since the application were already expecting some information that never arrived, to fill the views. The information is now returned properly.