### PR TITLE
AP-227 and AP-228 Prayer tile and wordpress category

### DIFF
--- a/mobile_app_connector/__manifest__.py
+++ b/mobile_app_connector/__manifest__.py
@@ -50,6 +50,7 @@
         'security/access_rules.xml',
         'data/tile_type_data.xml',
         'data/default_hub.xml',
+        'data/prayer_tile.xml',
         'data/ir_cron.xml',
         'data/request_sequence.xml',
         'data/crm_claim_category_data.xml',

--- a/mobile_app_connector/data/prayer_tile.xml
+++ b/mobile_app_connector/data/prayer_tile.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data>
+        <record id="tile_pr1_1" model="mobile.app.tile">
+            <field name="name">Prayer now</field>
+            <field name="subtype_id" ref="tile_subtype_pr1"/>
+            <field name="mode">many</field>
+            <field name="visibility">private</field>
+            <field name="prayer_title">Pray for ${ctx['objects'].preferred_name} to make strong friendships</field>
+            <field name="prayer_body" type="html">
+                <p>
+                    Who is your closest friend? Take a moment to thank God for them today. Praise God that He is the one who created relationship.
+                </p><p>
+                    Pray for ${ctx['objects'].preferred_name} to have good friends who will encourage and support ${ctx['objects'].get('him')}. Ask that ${ctx['objects'].get('he')} develops really strong friendships at ${ctx['objects'].get('his')} Compassion project.<br />
+                </p><p>
+                    Pray also that ${ctx['objects'].preferred_name} will know the friendship and love of ${ctx['objects'].get('his')} Heavenly Father.
+                </p>
+            </field>
+            <field name="action_text">Pray now</field>
+            <!-- the correct action_destination will be set when the init method will be called -->
+            <field name="action_destination">Compass</field>
+        </record>
+
+        <function model="mobile.app.tile" name="init_tiles"/>
+    </data>
+</odoo>

--- a/mobile_app_connector/data/tile_type_data.xml
+++ b/mobile_app_connector/data/tile_type_data.xml
@@ -159,8 +159,11 @@ Make a donation]]></field>
         <field name="name">Prayer now</field>
         <field name="code">PR1</field>
         <field name="view_order">10</field>
+        <field name="default_model_id" ref="model_compassion_child"/>
         <field name="default_action_text">Pray now</field>
         <field name="default_action_destination">Read overlay</field>
+        <field name="default_title">${ctx['objects'].preferred_name}</field>
+        <field name="default_body">Pray for my child</field>
         <field name="tile_preview" type="base64" file="mobile_app_connector/static/img/PR1.png"/>
     </record>
     <record id="tile_subtype_pr2" model="mobile.app.tile.subtype">

--- a/mobile_app_connector/mappings/wp_post_mapping.py
+++ b/mobile_app_connector/mappings/wp_post_mapping.py
@@ -29,6 +29,8 @@ class WPPostMapping(OnrampMapping):
         'SortOrder': 'view_order',
         'IsAutomaticOrdering': 'is_automatic_ordering',
         'OrderDate': 'date',
+        'Type': 'tile_type',
+        'SubType': 'tile_subtype'
     }
 
     FIELDS_TO_SUBMIT = {
@@ -49,8 +51,5 @@ class WPPostMapping(OnrampMapping):
 
     CONSTANTS = {
         'ActionDestination': 'Stories and prayer with relevant blog at '
-                             'the top',
-        'Type': 'Story',
-        # TODO See if we must change subtype depending on post
-        'SubType': 'ST_T1'
+                             'the top'
     }

--- a/mobile_app_connector/models/app_hub.py
+++ b/mobile_app_connector/models/app_hub.py
@@ -148,7 +148,8 @@ class AppHub(models.AbstractModel):
         """
         available_posts = self.env['wp.post'].search([
             ('lang', '=', self.env.lang),
-            ('display_on_hub', '=', True)
+            ('display_on_hub', '=', True),
+            ('category_ids.name', '=', 'Afficher dans le hub')
         ])
         messages = []
         if available_posts:

--- a/mobile_app_connector/models/app_tile.py
+++ b/mobile_app_connector/models/app_tile.py
@@ -73,6 +73,16 @@ class AppTile(models.Model):
     action_destination = fields.Selection(
         lambda s: s.env['mobile.app.tile.subtype'].select_action_destination(),
         required=True)
+    prayer_title = fields.Text(
+        translate=True,
+        help="Mako template enabled."
+             "Use ctx['objects'] to get associated records."
+    )
+    prayer_body = fields.Html(
+        translate=True,
+        help="Mako template enabled."
+             "Use ctx['objects'] to get associated records."
+    )
 
     @api.depends('subtype_id', 'subtype_id.code', 'name')
     def _compute_display_name(self):
@@ -189,6 +199,14 @@ class AppTile(models.Model):
                 'SortOrder': self.view_order,
                 'IsAutomaticOrdering': self.is_automatic_ordering,
             }
+
+            if self.prayer_title and self.prayer_body:
+                res['PrayerPoint'] = {
+                    'Body': template_obj.render_template(
+                        self.prayer_body, self._name, self.id),
+                    'Title': template_obj.render_template(
+                        self.prayer_title, self._name, self.id),
+                }
 
             if hasattr(records, 'get_app_json'):
                 res.update(records.get_app_json(multi=len(records) > 1))

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -46,12 +46,12 @@ class WordpressPost(models.Model):
         default=True, help='Deactivate in order to hide tiles in App.')
     view_order = fields.Integer('View order', required=True, default=6000)
     is_automatic_ordering = fields.Boolean("Automatic ordering", default=True)
-    tile_type = fields.Char(compute='_compute_tile_type',
+    tile_type = fields.Char(compute='_compute_tile_type', default='Story',
                             string='Type of tile', store=True,
                             required=True)
     tile_subtype = fields.Char(compute='_compute_tile_subtype',
-                               string='Subtype of tile', store=True,
-                               required=True)
+                               default='ST_T1', string='Subtype of tile',
+                               store=True, required=True)
 
     _sql_constraints = [
         ('wp_unique', 'unique(wp_id)', 'This post already exists')
@@ -82,14 +82,14 @@ class WordpressPost(models.Model):
 
     @api.depends('category_ids')
     def _compute_tile_type(self):
-        if 'Prières' in self.category_ids.mapped('name'):
+        if 'Prieres' in self.category_ids.mapped('name'):
             self.tile_type = 'Prayer'
         else:
             self.tile_type = 'Story'
 
     @api.depends('category_ids')
     def _compute_tile_subtype(self):
-        if 'Prières' in self.category_ids.mapped('name'):
+        if 'Prieres' in self.category_ids.mapped('name'):
             self.tile_subtype = 'PR2'
         else:
             self.tile_subtype = 'ST_T1'
@@ -165,12 +165,12 @@ class WordpressPost(models.Model):
 
                             categories_request = requests.get(
                                 category_json_url).json()
-                            for c_name in categories_request.mapped('name'):
+                            for c in categories_request:
                                 category = category_obj.search([
-                                    ('name', '=', c_name)])
+                                    ('name', '=', c['name'])])
                                 if not category:
                                     category = category_obj.create({
-                                        'name': c_name
+                                        'name': c['name']
                                     })
                                 categories_id.append(category.id)
 

--- a/mobile_app_connector/models/wordpress_post_category.py
+++ b/mobile_app_connector/models/wordpress_post_category.py
@@ -28,8 +28,6 @@ class WordpressPostCategory(models.Model):
         default=1000,
         help='Decrease order weight to display tiles above others'
     )
-    display_on_hub = fields.Boolean(
-        default=True, help='Deactivate in order to hide tiles in App.')
 
     _sql_constraints = [
         ('name_unique', 'unique(name)', 'This category already exists')

--- a/mobile_app_connector/views/wp_post_view.xml
+++ b/mobile_app_connector/views/wp_post_view.xml
@@ -16,7 +16,7 @@
                         <group>
                             <field name="name"/>
                             <field name="post_type"/>
-                            <field name="category_id"/>
+                            <field name="category_ids"/>
                             <field name="lang"/>
                             <field name="date"/>
                         </group>
@@ -42,7 +42,7 @@
                 <field name="name"/>
                 <field name="date"/>
                 <field name="post_type"/>
-                <field name="category_id"/>
+                <field name="category_ids"/>
                 <field name="lang"/>
                 <field name="display_on_hub" invisible="1"/>
             </tree>
@@ -57,7 +57,7 @@
                 <field name="name"/>
                 <field name="lang"/>
                 <field name="post_type"/>
-                <field name="category_id"/>
+                <field name="category_ids"/>
                 <separator/>
                 <filter name="active" string="Active" domain="[('display_on_hub', '=', True)]"/>
                 <group expand="0" string="Group By">


### PR DESCRIPTION
Added support for PR1 and PR2

Added support for multiple category for WordPress posts, the following category are used but not created in WordPress (can be changed in the code for other name if needed):
- 'Afficher dans le hub' to show/hide post in app from WordPress
- 'Prieres' to select the PR2 (prayer type) tile from WordPress instead of ST_T1 (story type)

Post can still be hidden from Odoo using the Display on hub selection

To show a post that was hidden on the app, select manually the category 'Afficher dans le hub' from Odoo