### PR TITLE
CO-2911 fix thankyou letters - partner without email address

### DIFF
--- a/thankyou_letters/__manifest__.py
+++ b/thankyou_letters/__manifest__.py
@@ -9,7 +9,7 @@
 #                        /_/
 #                            in Jesus' name
 #
-#    Copyright (C) 2016-2017 Compassion CH (http://www.compassion.ch)
+#    Copyright (C) 2016-2020 Compassion CH (http://www.compassion.ch)
 #    @author: Emanuel Cino <ecino@compassion.ch>
 #
 #    This program is free software: you can redistribute it and/or modify
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     'name': 'Thank You Letters',
-    'version': '10.0.2.1.0',
+    'version': '10.0.2.1.1',
     'category': 'Other',
     'author': 'Compassion CH',
     'license': 'AGPL-3',

--- a/thankyou_letters/models/account_invoice_line.py
+++ b/thankyou_letters/models/account_invoice_line.py
@@ -69,7 +69,9 @@ class AccountInvoiceLine(models.Model):
 
         thankyou_config = self.env['thankyou.config'].search(
             []).for_donation(invoice_lines)
-        send_mode, auto_mode = thankyou_config.build_inform_mode(partner)
+        send_mode, auto_mode = thankyou_config.build_inform_mode(
+            partner, communication_config.print_if_not_email)
+
         comm_vals = {
             'partner_id': partner.id,
             'config_id': communication_config.id,

--- a/thankyou_letters/models/thankyou_config.py
+++ b/thankyou_letters/models/thankyou_config.py
@@ -50,7 +50,7 @@ class ThankYouConfig(models.Model):
     def get_need_call(self):
         return self.env['partner.communication.config'].get_need_call()
 
-    def build_inform_mode(self, partner):
+    def build_inform_mode(self, partner, print_if_not_email=False):
         """ Returns how the partner should be informed for the given
         thank you letter (digital, physical or False).
         It makes the product of the thank you preference and the partner
@@ -58,5 +58,5 @@ class ThankYouConfig(models.Model):
         """
         return self.env['partner.communication.config'] \
             .build_inform_mode(partner, self.send_mode,
-                               print_if_not_email=False,
-                               send_mode_pref_field='none')
+                               print_if_not_email=print_if_not_email,
+                               send_mode_pref_field=None)

--- a/thankyou_letters/views/thankyou_config_view.xml
+++ b/thankyou_letters/views/thankyou_config_view.xml
@@ -21,7 +21,7 @@
         <field name="context">{}</field>
     </record>
 
-    <!-- Add an entry in Sponsorship \ Configuration \ Correspondence -->
+    <!-- Add an entry in Sales \ Communications \ Settings -->
     <menuitem name="Settings" id="thank_you_config_item" parent="menu_donation_sales"
               action="action_thank_you_config" sequence="10"/>
 </odoo>


### PR DESCRIPTION
Set the send_mode to physical when the partner has no email address.

Note that when the partner has neither a physical address nor an email address, the send_mode stay blank