### PR TITLE
CO-2984 - option to see all sponsorships in the apps

### DIFF
--- a/mobile_app_connector/__manifest__.py
+++ b/mobile_app_connector/__manifest__.py
@@ -71,6 +71,7 @@
         'views/firebase_notification.xml',
         'views/communication_job.xml',
         'views/communication_config.xml',
+        'views/res_partner.xml'
     ],
     'demo': [
     ],

--- a/mobile_app_connector/data/tile_type_data.xml
+++ b/mobile_app_connector/data/tile_type_data.xml
@@ -218,7 +218,7 @@ Make a donation]]></field>
         <field name="code">LE1</field>
         <field name="view_order">1</field>
         <field name="default_model_id" ref="model_recurring_contract"/>
-        <field name="default_records_filter">lambda c: c.correspondent_id == c.env.user.partner_id</field>
+        <field name="default_records_filter"></field>
         <field name="default_title">${ctx['objects'].sudo().child_id.preferred_name}</field>
         <field name="default_body"><![CDATA[% set sponsorship = ctx['objects'].sudo()
 % set letters = sponsorship.sponsor_letter_ids

--- a/mobile_app_connector/models/app_hub.py
+++ b/mobile_app_connector/models/app_hub.py
@@ -48,11 +48,17 @@ class AppHub(models.AbstractModel):
             return self._public_hub(**pagination)
 
         partner = self.env['res.partner'].browse(partner_id)
-        # TODO For now we only display the contracts for which the sponsor
-        #  is correspondent (to avoid viewing letters when he doesn't write)
-        sponsorships = (partner.contracts_correspondant +
-                        partner.contracts_fully_managed).filtered('is_active')
-        unpaid = partner.contracts_fully_managed.filtered(
+
+        if partner.app_displayed_sponsorships == "all":
+            sponsorships = partner.sponsorship_ids
+            unpaid = partner.contracts_fully_managed + partner.contracts_paid
+        else:
+            sponsorships = partner.contracts_correspondant + \
+                           partner.contracts_fully_managed
+            unpaid = partner.contracts_fully_managed
+
+        sponsorships = sponsorships.filtered('is_active')
+        unpaid = unpaid.filtered(
             lambda c: not c.is_active and not c.parent_id and
             (c.state in ['waiting', 'draft']))
         children = sponsorships.mapped('child_id')

--- a/mobile_app_connector/models/app_hub.py
+++ b/mobile_app_connector/models/app_hub.py
@@ -54,7 +54,7 @@ class AppHub(models.AbstractModel):
             unpaid = partner.contracts_fully_managed + partner.contracts_paid
         else:
             sponsorships = partner.contracts_correspondant + \
-                           partner.contracts_fully_managed
+                partner.contracts_fully_managed
             unpaid = partner.contracts_fully_managed
 
         sponsorships = sponsorships.filtered('is_active')

--- a/mobile_app_connector/models/res_partner.py
+++ b/mobile_app_connector/models/res_partner.py
@@ -9,11 +9,16 @@
 #
 ##############################################################################
 
-from odoo import api, models
+from odoo import api, models, fields, _
 
 
 class GetPartnerMessage(models.Model):
     _inherit = "res.partner"
+
+    app_displayed_sponsorships = fields.Selection([
+        ("all", _("All (partner is the correspondent and/or the payer)")),
+        ("correspondent", _("Correspondent (Children the partner correspond with)")),
+    ], "Sponsorships displayed in the app", default="correspondent", required=True)
 
     ##########################################################################
     #                             PUBLIC METHODS                             #

--- a/mobile_app_connector/views/res_partner.xml
+++ b/mobile_app_connector/views/res_partner.xml
@@ -1,0 +1,14 @@
+<odoo>
+    <record model="ir.ui.view" id="view_partner_form_mobile">
+        <field name="name">res.partner.form.mobile</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="sponsorship_compassion.view_res_partner_invoice_line_button_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//page[1]//button[@name='create_contract']" position="after">
+                <group>
+                    <field name="app_displayed_sponsorships" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The option is added in the res.partner form view under the "Sponsorships" tab
The letters sent to paids-only sponsorships are correctly sent as the official correspondent

@ecino FYI the records for the tiles (in tile_type_data.xml) do not have the noupdate attribute, it might be a mistake