### PR TITLE
AP-329 Fix app crashes when user has no sponsorship

### DIFF
--- a/mobile_app_connector/controllers/json_request.py
+++ b/mobile_app_connector/controllers/json_request.py
@@ -88,4 +88,5 @@ class MobileAppJsonRequest(JsonRequest):
                 'http_status': code,
                 'message': str(exception)
             })
-        raise exception
+        # RE-Raise last error, without compromising the StackTrace
+        raise

--- a/mobile_app_connector/models/app_tile.py
+++ b/mobile_app_connector/models/app_tile.py
@@ -165,8 +165,7 @@ class AppTile(models.Model):
                     self.env.ref(module % 'tile_type_child') +\
                     self.env.ref(module % 'tile_type_community')
                 if tile.subtype_id.type_id not in no_render and \
-                        tile.subtype_id != self.env.ref(
-                            module % 'tile_subtype_pr1'):
+                        tile.subtype_id != self.env.ref(module % 'tile_subtype_pr1'):
                     res.append(tile_json)
         return res
 

--- a/mobile_app_connector/models/compassion_child.py
+++ b/mobile_app_connector/models/compassion_child.py
@@ -48,11 +48,12 @@ class CompassionChild(models.Model):
         children_pictures = self.sudo().mapped('pictures_ids')
         project = self.sudo().mapped('project_id')
 
-        if not self:
-            return {}
-        mapping = MobileChildMapping(self.env)
         if not wrapper:
             wrapper = 'Children' if multi else 'Child'
+        if not self:
+            return {wrapper: []}
+
+        mapping = MobileChildMapping(self.env)
         if len(self) == 1 and not multi:
             data = mapping.get_connect_data(self)
         else:

--- a/mobile_app_connector/models/wordpress_post.py
+++ b/mobile_app_connector/models/wordpress_post.py
@@ -136,13 +136,13 @@ class WordpressPost(models.Model):
                             # Skip post already fetched
                             continue
 
-                        content_empty = False
+                        content_empty = True
                         self_url = post_data['_links']['self'][0]['href']
-                        content = requests.get(self_url).json()
-                        if not content['content']['rendered']:
-                            # We won't display the post in hub when content
-                            # is empty
-                            content_empty = True
+                        http_response = requests.get(self_url)
+                        if http_response.ok:
+                            content = http_response.json()
+                            if content['content']['rendered']:
+                                content_empty = False
                         try:
                             # Fetch image for thumbnail
                             image_json_url = post_data['_links'][


### PR DESCRIPTION
Apps expected an empty list of children in that case
+ Fix stack trace in console when the mobile_app endpoint raises an exception
+ Fix Wordpress cron occasional failures