### PR TITLE
v11 fixes

### DIFF
--- a/advanced_translation/models/ir_advanced_translation.py
+++ b/advanced_translation/models/ir_advanced_translation.py
@@ -39,9 +39,10 @@ class IrAdvancedTranslation(models.Model):
     @api.model
     def get(self, src, female=False, plural=False):
         """ Returns the translation term. """
+        lang = self.env.context.get('lang') or self.env.lang or 'en_US'
         term = self.search([
             ('src', '=', src),
-            ('lang', '=', self.env.lang or 'en_US')])
+            ('lang', '=', lang)])
         if not term:
             return _(src)
         if female and plural:

--- a/advanced_translation/models/translatable_model.py
+++ b/advanced_translation/models/translatable_model.py
@@ -1,6 +1,5 @@
 import re
 import logging
-from collections import OrderedDict
 from babel.dates import format_datetime
 
 
@@ -120,22 +119,16 @@ class AdvancedTranslatable(models.AbstractModel):
         :param date_type: a valid src of a ir.advanced.translation date format
         :return: the formatted dates
         """
+        _lang = self.env.context.get('lang') or self.env.lang or 'en_US'
         _format = self.env['ir.advanced.translation'].get(date_type)
-        dates = map(fields.Datetime.from_string,
-                    self.filtered(field).sorted(
-                        key=lambda r: getattr(r, field)).mapped(field))
-        ordered_dates = OrderedDict.fromkeys(dates)
-        for d in dates:
-            ordered_dates[d] = format_datetime(
-                d, _format, tzinfo=self.env.tz, locale=self.env.lang)
-        # Filter unique dates
-        unique = set()
-        unique_add = unique.add
-        dates_string = [d for d in ordered_dates.values() if not (
-            d in unique or unique_add(d))]
-        if len(dates_string) > 1:
-            res_string = ', '.join(dates_string[:-1])
-            res_string += ' ' + _('and') + ' ' + dates_string[-1]
+        dates = sorted(set(map(fields.Datetime.from_string,
+                               self.filtered(field).mapped(field))))
+
+        dates = [format_datetime(d, _format, locale=_lang) for d in dates]
+
+        if len(dates) > 1:
+            res_string = ', '.join(dates[:-1])
+            res_string += ' ' + _('and') + ' ' + dates[-1]
         else:
-            res_string = dates_string and dates_string[0] or ''
+            res_string = dates and dates[0] or ''
         return res_string

--- a/advanced_translation/tests/test_advanced_translation.py
+++ b/advanced_translation/tests/test_advanced_translation.py
@@ -7,14 +7,15 @@ class AdvancedTranslationTest(SingleTransactionCase):
     def setUpClass(cls):
         """ Create test data."""
         super().setUpClass()
+
         cls.test_partner_obj = cls.env['res.partner']
         tang = cls.browse_ref(cls, 'base.res_partner_address_1')
         joseph = cls.browse_ref(cls, 'base.res_partner_address_2')
-        cls.males = tang + joseph
+        cls.males = (tang + joseph).with_context(lang='en_US')
         julia = cls.browse_ref(cls, 'base.res_partner_address_26')
         jessica = cls.browse_ref(cls, 'base.res_partner_address_14')
         (julia + jessica).write({'gender': 'F'})
-        cls.females = julia + jessica
+        cls.females = (julia + jessica).with_context(lang='en_US')
 
     def test_keyword_gender(self):
         """Testing that the correct term is returned given the recordset.

--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -303,8 +303,8 @@ class CompassionChild(models.Model):
     @api.depends('birthdate')
     def _compute_birthday_month(self):
         for child in self.filtered('birthdate'):
-            child.birthday_month = child.get_date('birthdate', '%B')
-            child.birthday_dm = child.get_date('birthdate', '%m-%d')
+            child.birthday_month = child.get_date('birthdate', 'MMMM')
+            child.birthday_dm = child.get_date('birthdate', 'MM-dd')
 
     @api.constrains('state', 'hold_type')
     def check_state(self):

--- a/cms_form_compassion/models/cms_form.py
+++ b/cms_form_compassion/models/cms_form.py
@@ -43,7 +43,7 @@ class CMSForm(models.AbstractModel):
 
     def _handle_exception(self, err, **kw):
         def truncate_strings(params, length=50):
-            for k, v in params.iteritems():
+            for k, v in params.items():
                 if isinstance(v, dict):
                     truncate_strings(v)
                 elif isinstance(v, str):
@@ -54,7 +54,7 @@ class CMSForm(models.AbstractModel):
                      "entry in database.")
 
         err_class = err.__class__.__name__
-        err_name = f"'{err_class}' in '{self.__name__}'"
+        err_name = f"'{err_class}' in '{self._name}'"
 
         # We are handling an exception, rollback previous DB transactions
         self.env.cr.rollback()

--- a/cms_form_compassion/models/widgets.py
+++ b/cms_form_compassion/models/widgets.py
@@ -58,6 +58,14 @@ class Document(models.AbstractModel):
     _inherit = 'cms.form.widget.binary.mixin'
     _w_template = 'cms_form_compassion.field_widget_document'
 
+    def w_extract(self, **req_values):
+        req_values.setdefault(self.w_fname + '_keepcheck', 'no')
+        value = req_values.get(self.w_fname)
+        if hasattr(value, 'seek'):
+            value.seek(0)
+
+        return self.form_to_binary(value, **req_values)
+
 
 class ReadonlyWidget(models.AbstractModel):
     _name = 'cms_form_compassion.form.widget.readonly'

--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -502,7 +502,7 @@ class EventCompassion(models.Model):
                         f"SET user_id = {user.id} WHERE id = {event.id}"
                     )
                     values = {'user_ids': user.id}
-                    super(event).message_auto_subscribe(
+                    super(EventCompassion, event).message_auto_subscribe(
                         updated_fields, values
                     )
                 # Restore ambassador

--- a/sms_sponsorship/views/notification_settings_view.xml
+++ b/sms_sponsorship/views/notification_settings_view.xml
@@ -11,7 +11,7 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="child_compassion.compassion_settings"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='notification_configuration']//div[@class='o_setting_right_pane']" position='inside'>
+            <xpath expr="//div[@name='notification_configuration']//div[hasclass('o_setting_right_pane')]" position='inside'>
                 <div name="sms_new_partner">
                     <label for="sms_new_partner_notify_ids" string="New partner via SMS sponsorship" class="o_light_label"/>
                     <field name="sms_new_partner_notify_ids" widget="many2many_tags"/>


### PR DESCRIPTION
- Fix logging feature port to v11 in cms_form
- file upload in cms_form
- super() in python 3
- Fix warning: use hasclass() instead of @class in xml xpath
- Fix advanced_translation migration:
  - Refactor buggy and complex get_date and added some tests
  - Fixed translations in child_switzerland, babel does not use the same patterns as strftime