### PR TITLE
AP-333 Vérifier que la langue des lettres parrains de l'app soit bien détéctée

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -270,8 +270,7 @@ class CrmClaim(models.Model):
         :param text: text to detect
         :return: res.lang compassion record if the language is found, or False
         """
-        detectlanguage.configuration.api_key = config.get(
-            'detect_language_api_key')
+        detectlanguage.configuration.api_key = config.get('detect_language_api_key')
         language_name = False
         langs = detectlanguage.languages()
         try:
@@ -286,7 +285,7 @@ class CrmClaim(models.Model):
         if not language_name:
             return False
 
-        return self.env['res.lang.compassion'].search(
+        return self.env['res.lang.compassion'].with_context({'lang': 'en_US'}).search(
             [('name', '=ilike', language_name)], limit=1)
 
     @api.multi

--- a/mobile_app_connector/models/compassion_correspondence.py
+++ b/mobile_app_connector/models/compassion_correspondence.py
@@ -164,6 +164,7 @@ class CompassionCorrespondence(models.Model):
             'selection_domain':
             "[('child_id.local_id', '=', '" + child_local_id + "')]",
             'body': escape(body),
+            'language_id':  int(self.env['crm.claim'].detect_lang(body)),
             's2b_template_id': int(template_id),
             'image_ids': datas,
             'source': 'app'

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -54,11 +54,7 @@ class CorrespondenceS2bGenerator(models.Model):
     sponsorship_ids = fields.Many2many(
         'recurring.contract', string='Sponsorships', required=True
     )
-    language_id = fields.Many2one(
-        'res.lang.compassion', 'Language',
-        default=lambda s: s.env.ref(
-            'child_compassion.lang_compassion_english')
-    )
+    language_id = fields.Many2one('res.lang.compassion', 'Language')
     body = fields.Text(
         required=True,
         help='You can use the following tags to replace with values :\n\n'


### PR DESCRIPTION
Il faut peut être ajouter `.with_context({'lang': 'en_US'}).` à l'autre fonction `detect_lang` dans /compassion-switzerland/partner_communication_switzerland. Sans ça, parfois les noms de langue en français de Odoo et ceux en anglais de `detectlanguage` et il n'y a donc pas de match. Ou merge les deux fonctions.