### PR TITLE
Fixes for hr_attendance_management

### DIFF
--- a/hr_attendance_management/models/hr_employee.py
+++ b/hr_attendance_management/models/hr_employee.py
@@ -126,9 +126,9 @@ class HrEmployee(models.Model):
             final_balance = None
 
             with cond:
-                _logger.info("waiting predicate")
+                # _logger.info("waiting predicate")
                 cond.wait_for(employee.condition())
-                _logger.info("Condition passed")
+                # _logger.info("Condition passed")
 
                 if employee.period_ids:
                     employee_history_sorted = \
@@ -193,10 +193,10 @@ class HrEmployee(models.Model):
         def predicate():
             return self.periods_computed
         if not predicate():
-            _logger.info("Computing periods")
+            # _logger.info("Computing periods")
             self._compute_periods()
         self.periods_computed = True
-        _logger.info("Condition notified")
+        # _logger.info("Condition notified")
         cond.notify(1)
         return predicate
 

--- a/hr_attendance_management/models/hr_employee.py
+++ b/hr_attendance_management/models/hr_employee.py
@@ -153,7 +153,7 @@ class HrEmployee(models.Model):
             # it means there is a period with end_date == today
             # so we just assign the value. The cap is taken in consideration
             # here.
-            elif final_balance != None:
+            elif final_balance is not None:
                 max_extra_hours = self.env['res.config.settings'].create({}) \
                     .get_max_extra_hours()
                 bal = min(max_extra_hours, final_balance)

--- a/hr_attendance_management/models/hr_employee.py
+++ b/hr_attendance_management/models/hr_employee.py
@@ -4,11 +4,9 @@
 import datetime
 import logging
 import threading
-from dateutil.relativedelta import relativedelta
 
 from odoo import models, fields, api, _
 from odoo.exceptions import ValidationError
-from odoo.addons.queue_job.job import job
 
 _logger = logging.getLogger(__name__)
 
@@ -95,7 +93,6 @@ class HrEmployee(models.Model):
 
     @api.multi
     @api.depends('initial_balance', 'attendance_days_ids.paid_hours')
-    @job
     def _compute_periods(self):
         for employee in self:
             employee.period_ids = self.env['hr.employee.period'].search([

--- a/hr_attendance_management/models/hr_employee_period.py
+++ b/hr_attendance_management/models/hr_employee_period.py
@@ -32,7 +32,7 @@ def get_previous_overlapping_period(employee_periods, res):
 def get_next_overlapping_period(employee_periods, res):
     return employee_periods.filtered(
         lambda r: res.end_date > r.start_date > res.start_date
-        and r.end_date >= res.end_date)
+        and r.end_date > res.end_date)
 
 
 def get_surrounding_period(employee_periods, res):


### PR DESCRIPTION
This is a fix proposition for 2 problems that can occur when using hr_attendance_management. 
It locks a field behind a Condition/Mutex because this field is accessed around the same time by the methods that depends on the same parameter -> _employee.period_ids_.
It should help with the KeyError problem and with the creation of attendances by the CRON