### PR TITLE
AP-348 fix for banners deactivation

### DIFF
--- a/mobile_app_connector/models/mobile_banner.py
+++ b/mobile_app_connector/models/mobile_banner.py
@@ -86,7 +86,7 @@ class AppBanner(models.Model):
             [("date_start", "<=", today), ("date_stop", ">=", today), ]
         )
         without_dates_banners = self.search(
-            [("date_start", "=", None), ("date_stop", "=", None), ]
+            ["|", ("date_start", "=", None), ("date_stop", "=", None), ]
         )
         # Deactivate old stories
         (active_banners - current_banners - without_dates_banners).write(


### PR DESCRIPTION
The function seems fine and should always keep banners without a date active. My guess is that some banners had only the `date_start` or the `date_stop` set at False and so were considered as standard active banners