### PR TITLE
CO-3106 colors of manually logged emails and phone calls 

### DIFF
--- a/crm_compassion/__manifest__.py
+++ b/crm_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion CH - Events",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "CRM",
     "sequence": 150,
     "author": "Compassion CH",

--- a/crm_compassion/migrations/12.0.1.0.1/pre-migration.py
+++ b/crm_compassion/migrations/12.0.1.0.1/pre-migration.py
@@ -1,0 +1,13 @@
+def migrate(cr, version):
+    if not version:
+        return
+
+    cr.execute("""
+        ALTER TABLE mail_mail
+        ADD COLUMN IF NOT EXISTS is_from_employee boolean;
+    """)
+
+    cr.execute("""
+        ALTER TABLE crm_phonecall
+        ADD COLUMN IF NOT EXISTS is_from_employee boolean;
+    """)

--- a/crm_compassion/models/__init__.py
+++ b/crm_compassion/models/__init__.py
@@ -21,3 +21,5 @@ from . import weekly_demand
 from . import weekly_revision
 from . import compassion_hold
 from . import interaction_resume
+from . import mail_mail
+from . import phone_call

--- a/crm_compassion/models/interaction_resume.py
+++ b/crm_compassion/models/interaction_resume.py
@@ -36,6 +36,7 @@ class InteractionResume(models.TransientModel):
     email_id = fields.Many2one("mail.mail", "Email", readonly=False)
     color = fields.Char(compute="_compute_color")
     message_id = fields.Many2one("mail.message", "Email", readonly=False)
+    is_from_employee = fields.Boolean(default=False)
     tracking_status = fields.Selection(
         [
             ("error", "Error"),
@@ -80,6 +81,7 @@ class InteractionResume(models.TransientModel):
                         0 as phone_id,
                         0 as email_id,
                         0 as message_id,
+                        false as is_from_employee,
                         pcj.id as paper_id,
                         NULL as tracking_status
                         FROM "partner_communication_job" as pcj
@@ -108,6 +110,7 @@ class InteractionResume(models.TransientModel):
                         crmpc.id as phone_id,
                         0 as email_id,
                         0 as message_id,
+                        crmpc.is_from_employee as is_from_employee,
                         0 as paper_id,
                         NULL as tracking_status
                         FROM "crm_phonecall" as crmpc
@@ -127,6 +130,7 @@ class InteractionResume(models.TransientModel):
                         0 as phone_id,
                         mail.id as email_id,
                         0 as message_id,
+                        mail.is_from_employee as is_from_employee,
                         job.id as paper_id,
                         COALESCE(mt.state, 'error') as tracking_status
                         FROM "mail_mail" as mail
@@ -158,6 +162,7 @@ class InteractionResume(models.TransientModel):
                         0 as phone_id,
                         0 as email_id,
                         m.id as message_id,
+                        false as is_from_employee,
                         0 as paper_id,
                         NULL as tracking_status
                         FROM "mail_message" as m

--- a/crm_compassion/models/mail_mail.py
+++ b/crm_compassion/models/mail_mail.py
@@ -1,0 +1,17 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Quentin Gigon <gigon.quentin@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import api, models, fields, _
+
+
+class Partner(models.Model):
+    _inherit = "mail.mail"
+
+    is_from_employee = fields.Boolean(default=False)

--- a/crm_compassion/models/mail_mail.py
+++ b/crm_compassion/models/mail_mail.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 
-from odoo import api, models, fields, _
+from odoo import models, fields
 
 
 class Partner(models.Model):

--- a/crm_compassion/models/phone_call.py
+++ b/crm_compassion/models/phone_call.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 
-from odoo import api, models, fields, _
+from odoo import api, models, fields
 
 
 class Partner(models.Model):

--- a/crm_compassion/models/phone_call.py
+++ b/crm_compassion/models/phone_call.py
@@ -1,0 +1,25 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Quentin Gigon <gigon.quentin@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import api, models, fields, _
+
+
+class Partner(models.Model):
+    _inherit = "crm.phonecall"
+
+    is_from_employee = fields.Boolean(default=False)
+
+    @api.model
+    def create(self, vals):
+        res = super().create(vals)
+        if "origin" in self._context and \
+                self._context.get('origin') == 'employee':
+            res.is_from_employee = True
+        return res

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -116,6 +116,7 @@ class Partner(models.Model):
                 "default_partner_id": self.id,
                 "default_partner_mobile": self.mobile,
                 "default_partner_phone": self.phone,
+                "origin": "employee"
             }
         )
         domain = [("partner_id", "=", self.id)]

--- a/crm_compassion/views/interaction_resume_view.xml
+++ b/crm_compassion/views/interaction_resume_view.xml
@@ -4,13 +4,18 @@
         <field name="name">interaction_resume_tree_view</field>
         <field name="model">interaction.resume</field>
         <field name="arch" type="xml">
-            <tree decoration-danger="state == 'failed'" decoration-success="state == 'reached'" decoration-muted="state == 'canceled'" edit="0" create="0" delete="0">
+            <tree decoration-danger="tracking_status == 'error'"
+                  decoration-success="tracking_status == 'opened'" decoration-muted="tracking_status == 'canceled'"
+                  decoration-primary="tracking_status == False and is_from_employee == True"
+                  decoration-info="tracking_status == True and is_from_employee == True"
+                  edit="0" create="0" delete="0">
                 <button name="out" icon="fa-arrow-up" states="out" attrs="{'readonly': True}" />
                 <button name="in" icon="fa-arrow-down" states="in" attrs="{'readonly': True}" />
                 <field name="communication_date"/>
                 <field name="communication_type"/>
                 <field name="state" invisible="1"/>
                 <field name="color" invisible="1"/>
+                <field name="is_from_employee" invisible="1"/>
                 <field name="email"/>
                 <field name="tracking_status"/>
                 <field name="subject"/>

--- a/crm_compassion/wizards/partner_log_interaction_wizard.py
+++ b/crm_compassion/wizards/partner_log_interaction_wizard.py
@@ -31,7 +31,7 @@ class LogInteractionWizard(models.TransientModel):
         in order for it to appear in the interaction.resume view
         :return: True
         """
-        return self.env["mail.mail"].create(
+        mail = self.env["mail.mail"].create(
             {
                 "state": "sent",
                 "recipient_ids": [(4, self.partner_id.id)],
@@ -53,3 +53,14 @@ class LogInteractionWizard(models.TransientModel):
                 .id,
             }
         )
+        # Create the mail.tracking.email object in the case of a manually logged email
+        email = mail._send_prepare_values(partner=self.partner_id)
+        vals = mail._tracking_email_prepare(self.partner_id, email)
+        vals.update({
+            "state": "sent"
+        })
+        mail_tracking_obj = self.env['mail.tracking.email']
+        mail_tracking_obj.search([
+            ('mail_id', '=', mail.id)
+        ]).unlink()
+        mail_tracking_obj.sudo().create(vals)

--- a/crm_compassion/wizards/partner_log_interaction_wizard.py
+++ b/crm_compassion/wizards/partner_log_interaction_wizard.py
@@ -38,6 +38,7 @@ class LogInteractionWizard(models.TransientModel):
                 "subject": self.subject,
                 "body_html": self.body,
                 "author_id": self.env.user.partner_id.id,
+                "is_from_employee": True,
                 "mail_message_id": self.env["mail.message"]
                 .create(
                     {


### PR DESCRIPTION
The colors are the following:
- **purple** for logged phone calls
- **blue** for logged emails
- **green** for opened emails
- **red** for errors

There is still a bug with the tracking status of manually logged email -> it always is "error". After that, the task should be done