### PR TITLE
CO-3255 Translated text is added to english translation if empty

### DIFF
--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -908,6 +908,11 @@ class Correspondence(models.Model):
         if "GlobalPartner" in json_data:
             json_data["GlobalPartner"] = {"Id": json_data["GlobalPartner"]}
 
+        english_text = json_data["Pages"]["EnglishTranslatedText"]
+        translated_text = json_data["Pages"]["TranslatedText"]
+        if "".join(english_text) == "" and "".join(translated_text) != "":
+            json_data["Pages"]["EnglishTranslatedText"] = translated_text
+
         return json_data
 
     @api.model


### PR DESCRIPTION
The field EnglishTranslationText used to be empty when one of the language of the child was known prior to sending to Compassion US. For that reason, these letters would be sent back to Compassion CH. This field is now always set: either with the English translation, or a copy of the translated text.