### PR TITLE
Right number of labels is now printed on multiple pages

### DIFF
--- a/label/models/report_dynamic_label.py
+++ b/label/models/report_dynamic_label.py
@@ -19,14 +19,14 @@ class ReportDynamicLabel(models.TransientModel):
     _name = "report.label.report_label"
     _description = "Construct report from page"
 
-    def get_data(self, row, columns, records, nber_labels):
+    def get_data(self, rows, columns, records, nber_labels):
         """
         Function called in the xml in order to get the datas for one page
         (in dynamic_label.xml).
         If multiple ids are given, the labels will be grouped by ids (therefore
         N Bob, then N Will, ...).
 
-        :param int row: Number of row for one page of labels
+        :param int rows: Number of rows for one page of labels
         :param int columns: Number of columns of labels
         :param records: recordset used for the labels
         :param int nber_labels: Number of labels of each ids
@@ -38,14 +38,14 @@ class ReportDynamicLabel(models.TransientModel):
         label_print_data = label_print_obj.browse(self.env.context.get("label_print"))
 
         tot = nber_labels * len(records)
-        tot_page = int(ceil(float(ceil(tot) // (columns * row))))
+        tot_page = int(ceil(tot / (columns * rows)))
         # return value
         result = []
         for i in range(tot_page):
             result.append(
                 [
                     [[{"type": "", "style": "", "value": ""}] for i in range(columns)]
-                    for j in range(row)
+                    for j in range(rows)
                 ]
             )
         # current indices
@@ -96,7 +96,7 @@ class ReportDynamicLabel(models.TransientModel):
                 if cur_col >= columns:
                     cur_col = 0
                     cur_row += 1
-                if cur_row >= row:
+                if cur_row >= rows:
                     cur_page += 1
                     cur_row = 0
         return result

--- a/label/reports/dynamic_label.xml
+++ b/label/reports/dynamic_label.xml
@@ -3,9 +3,9 @@
         <link rel="stylesheet" href="/label/static/src/css/label.css"/>
         <t t-call="web.basic_layout">
             <t t-foreach="docs" t-as="o">
-                <div class="page">
-                    <t t-foreach="label_data" t-as="data_page">
-                        <div t-attf-style="position: absolute; left: {{ o.config_id.left_margin}}mm; top: {{(o.config_id.top_margin)}}mm; height: {{(297 - o.config_id.top_margin - o.config_id.bottom_margin)}}mm; width: {{(210 - o.config_id.left_margin - o.config_id.right_margin)}}mm;">
+                <t t-foreach="label_data" t-as="data_page">
+                    <div class="page">
+                        <div t-attf-style="position: absolute; left: {{ o.config_id.left_margin}}mm; top: {{(o.config_id.top_margin + data_page_index * 297)}}mm; height: {{(297 - o.config_id.top_margin - o.config_id.bottom_margin)}}mm; width: {{(210 - o.config_id.left_margin - o.config_id.right_margin)}}mm;">
                             <!-- Start page -->
                             <table class="o_label_page_table" t-attf-style="border-space: {{o.config_id.cell_spacing}}mm;">
                                 <t t-foreach="data_page" t-as="row">
@@ -20,8 +20,9 @@
                                 </t>
                             </table>
                         </div>
-                    </t>
-                </div>
+                        <p style="page-break-after:always;"/>
+                    </div>
+                </t>
             </t>
         </t>
     </template>

--- a/label/reports/one_label.xml
+++ b/label/reports/one_label.xml
@@ -15,7 +15,6 @@
 
                     <td style="vertical-align: middle; height: 100%;">
                         <div class="o_label_div_cell">
-
                             <table class="o_label_text_table">
                                 <t t-foreach="col" t-as="val">
                                     <t t-if="(val['type'] != 'barcode')">
@@ -29,9 +28,7 @@
                                     </t>
                                 </t>
                             </table>
-
                         </div>
-
                     </td>
                 </tr>
             </table>


### PR DESCRIPTION
Previously, 33 labels could be printed (3 columns  of 11 rows on one page). Less would make the script fail and more would not show up. This PR solves how the number of pages is computed and allow for generation of PDF with more than 33 labels on more than one page.