### PR TITLE
CI-750 fix reseservation failing

### DIFF
--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -180,7 +180,10 @@ class CompassionHold(models.Model):
     primary_owner = fields.Many2one(track_visibility="onchange", readonly=False)
     type = fields.Selection(track_visibility="onchange")
     channel = fields.Selection(track_visibility="onchange")
-    expiration_date = fields.Datetime(track_visibility="onchange")
+    expiration_date = fields.Datetime(track_visibility="onchange",
+                                      required=False,
+                                      default=datetime.now() + timedelta(days=60)
+                                      )
 
     _sql_constraints = [
         ("hold_id", "unique(hold_id)", "The hold already exists in database."),


### PR DESCRIPTION
Made the field expiration_date of holds not required and implemented default value of 60 days from now