### PR TITLE
CO-3339 Sponsorship type is available again

### DIFF
--- a/crm_compassion/models/contract.py
+++ b/crm_compassion/models/contract.py
@@ -56,7 +56,8 @@ class Contracts(models.Model):
 
     def get_inv_lines_data(self):
         res = super().get_inv_lines_data()
-        for i, c_line in enumerate(self.mapped("contract_line_ids")):
-            if c_line.contract_id.user_id:
-                res[i]["user_id"] = c_line.contract_id.user_id.id
+        if res:
+            for i, c_line in enumerate(self.mapped("contract_line_ids")):
+                if c_line.contract_id.user_id:
+                    res[i]["user_id"] = c_line.contract_id.user_id.id
         return res


### PR DESCRIPTION
After migration to _Odoo 12_, changing the type of a sponsorship from _Sponsorships_ to _Correspondence_ used to trigger an error. This issue is addressed by this PR, in addition to the one on [compassion-modules](https://github.com/CompassionCH/compassion-accounting)  (https://github.com/CompassionCH/compassion-accounting/pull/119).