### PR TITLE
CO-3347 Fix check in/ check out and add dynamic update of working hours

### DIFF
--- a/hr_attendance_management/models/hr_employee.py
+++ b/hr_attendance_management/models/hr_employee.py
@@ -305,7 +305,7 @@ class HrEmployee(models.Model):
             self, start_date=None, end_date=None, existing_balance=0
     ):
         """
-        Compute the balance of extra and lost horus at end_date.
+        Compute the balance of extra and lost hours at end_date.
         :param start_date: Start date of the computation
         :param end_date: Date of desired data
         :param existing_balance: Existing extra hours balance at start_date
@@ -379,7 +379,7 @@ class HrEmployee(models.Model):
         for employee in self:
             if employee.balance < 0:
                 employee.time_warning_balance = "red"
-            elif max_extra_hours and employee.balance >= max_extra_hours * 2 // 3:
+            elif max_extra_hours and employee.balance >= max_extra_hours * 2 / 3:
                 employee.time_warning_balance = "orange"
             else:
                 employee.time_warning_balance = "green"
@@ -434,7 +434,7 @@ class HrEmployee(models.Model):
                 worked_hours += attendance.worked_hours
             else:
                 delta = datetime.datetime.now() - attendance.check_in
-                worked_hours += delta.total_seconds() // 3600.0
+                worked_hours += delta.total_seconds() / 3600.0
         return worked_hours
 
     def open_balance_graph(self):

--- a/hr_attendance_management/static/src/js/attendance.js
+++ b/hr_attendance_management/static/src/js/attendance.js
@@ -6,7 +6,6 @@ odoo.define('hr_attendance_management.attendance', function (require) {
     var hr_attendance = require('hr_attendance.my_attendances');
     var greeting_message = require('hr_attendance.greeting_message');
     var session = require('web.session');
-    window.asdf = session
     var rpc = require('web.rpc');
 
     var QWeb = core.qweb;

--- a/hr_attendance_management/static/src/js/attendance.js
+++ b/hr_attendance_management/static/src/js/attendance.js
@@ -12,6 +12,28 @@ odoo.define('hr_attendance_management.attendance', function (require) {
     var QWeb = core.qweb;
     var _t = core._t;
 
+    window.localStorage.setItem('trigger_source', 'other');
+    // We look for URL changes, corresponding we leave the actual page
+    window.addEventListener('popstate', function (event) {
+        var interval_id = window.localStorage.getItem('interval_id');
+        var trigger_source = window.localStorage.getItem('trigger_source');
+
+        // We don't clear the interval after the greeting message (the
+        // start() function won't be called afterward in that case)
+        if (interval_id && trigger_source !== 'back_from_update') {
+            clearInterval(interval_id);
+            window.localStorage.removeItem('interval_id');
+        }
+
+        // Check if we go to or leave greeting page
+        if (trigger_source === 'from_update_attendance') {
+            window.localStorage.setItem('trigger_source', 'back_from_update');
+        } else if (trigger_source === 'back_from_update') {
+            window.localStorage.setItem('trigger_source', 'other');
+        }
+    });
+
+
     hr_attendance.include({
         start: function () {
             var self = this;
@@ -49,55 +71,63 @@ odoo.define('hr_attendance_management.attendance', function (require) {
                 });
             })
 
-        // Counter
-        var now = new Date();
-        $('#moment_pl').html(now);
-        if ($('#moment_pl').length) {
-            var moment_start =
-                moment(new Date($('#moment_pl').text()));
-            var diff_minutes =
-                moment().diff(moment_start, 'minutes');
+            // Update worked hours dynamically
+            var interval_id = setInterval(
+                function() {
+                    if ($('#state').text() === 'checked in') {
+                        var start_time = window.localStorage.getItem('start_time')
 
-            ['worked_today', 'balance_today'].forEach(
-                function (el) {
-                    var matches =
-                    $('#' + el + '_pl')
-                        .text().match(/^-?(\d{2}):(\d{2})$/);
+                        ['worked_today', 'balance_today'].forEach(
+                            function (el) {
+                                var diff_minutes =
+                                    moment().diff(moment(start_time), 'minutes');
+                                var matches = $('#' + el)
+                                    .text().match(/^-?(\d{2}):(\d{2})$/);
 
-                    if (matches !== null &&
-                        $('#state').text() === 'checked in') {
-                        var hours = parseInt(matches[1]);
-                        var minutes = parseInt(matches[2]);
+                                if (matches !== null && diff_minutes >= 1) {
+                                    var hours = parseInt(matches[1]);
+                                    var minutes = parseInt(matches[2]);
 
-                        var total_minutes = (minutes +
-                            (hours * 60)) *
-                            (matches[0].substring(0, 1) ===
-                             '-' ? -1 : 1);
-                        var negative = total_minutes +
-                            diff_minutes < 0;
+                                    var total_minutes = (minutes +
+                                        (hours * 60)) *
+                                        (matches[0].substring(0, 1) ===
+                                         '-' ? -1 : 1);
+                                    var negative = total_minutes +
+                                        diff_minutes < 0;
 
-                        var new_total = Math.abs(total_minutes +
-                            diff_minutes);
-                        var new_hours =
-                            ('0' + Math.trunc(new_total / 60))
-                                .slice(-2);
-                        var new_minutes =
-                            ('0' + (new_total % 60)).slice(-2);
+                                    var new_total = Math.abs(total_minutes +
+                                        diff_minutes);
+                                    var new_hours =
+                                        ('0' + Math.trunc(new_total / 60))
+                                            .slice(-2);
+                                    var new_minutes =
+                                        ('0' + (new_total % 60)).slice(-2);
 
-                        $('#' + el).text((negative ? '-' : '') +
-                            new_hours + ':' + new_minutes);
+                                    $('#' + el).text((negative ? '-' : '') +
+                                        new_hours + ':' + new_minutes);
 
-                        if (el !== 'worked_today') {
-                            $('#' + el).parent()
-                                .get(0).style.color =
-                            negative ? 'red' : 'green';
-                        }
+                                    if (el !== 'worked_today') {
+                                        $('#' + el).parent()
+                                            .get(0).style.color =
+                                        negative ? 'red' : 'green';
+                                    }
+                                    // We update the time for the next time difference
+                                    window.localStorage.setItem('start_time', new Date())
+                                }
+                            }
+                        );
                     }
-                });
-            }
+                }, 5000
+            )
+            window.localStorage.setItem('interval_id', interval_id);
+            // We save the time at which the widget was created
+            window.localStorage.setItem('start_time', new Date());
+
             return result;
         },
         update_attendance: function () {
+            // We don't want to clear interval because we stay on the same page
+            window.localStorage.setItem('trigger_source', 'from_update_attendance');
             var loc_id = parseInt($('#location').val(), 10);
             session.user_context['default_location_id'] = loc_id;
             this._super();


### PR DESCRIPTION
The check in / check out functionality have been broken since migration to _Odoo 12_. The number of working hours would only update on refresh every hour. Before that, the number of working minutes was displayed on every refresh. This error happened because of an integer division that would make a computation worth 0 unless 1 hour had passed. The same error was found in another function and fixed as well.
The great improvement of this PR is to propose a dynamic update of the working hours. This new functionality basically works by calling an update function repetitively. Because there is no guarantee that the function will be executed at the end of the timeout, it has to be called pretty often to make sure to have a precise update of the working hours. In the code, a refresh is done at most every  seconds, but one call usually lands more between 15 and 25 seconds. The function is only called when the user is on the _check in / check out_ menu and the state is `checked_in` (the user is actually doing some working hours). In all other cases, no call to update the interface is done, so having a small refresh timeout is not an issue at all.
One corner case that is handled in the code is the case where the user actually press the button to check in or check out. In that case, the URL is modified but we don't want to clear the interval in all cases. This is correctly handled in the _Javascript_ file that has been modified. 