### PR TITLE
CO-3346 Can't create events from calendar view

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -210,7 +210,7 @@ class EventCompassion(models.Model):
                 )
 
     def compute_hold_start_date(self, start=None):
-        delta = self.env["res.config.settings"].get_param("days_allocate_before_event")
+        delta = self.env["res.config.settings"].sudo().get_param("days_allocate_before_event")
         return (start if start else self.start_date.date()) - timedelta(days=delta)
 
     @api.multi

--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -114,7 +114,7 @@ class EventCompassion(models.Model):
         default=0,
     )
     planned_sponsorships = fields.Integer(
-        "Expected sponsorships", track_visibility="onchange", required=True
+        "Expected sponsorships", track_visibility="onchange", required=True, default=0
     )
     lead_id = fields.Many2one(
         "crm.lead", "Opportunity", track_visibility="onchange", readonly=False
@@ -209,6 +209,10 @@ class EventCompassion(models.Model):
                     _("The hold start date must " "be before the event starting date !")
                 )
 
+    def compute_hold_start_date(self, start=None):
+        delta = self.env["res.config.settings"].get_param("days_allocate_before_event")
+        return (start if start else self.start_date.date()) - timedelta(days=delta)
+
     @api.multi
     @api.depends("staff_ids")
     def _compute_users(self):
@@ -237,6 +241,11 @@ class EventCompassion(models.Model):
         elif event_name[-2:] == event_year[-2:]:
             vals["name"] = event_name[:-2]
 
+        # Compute hold_start_date from vals if it hasn't been set
+        if not vals.get("hold_start_date"):
+            hold_start_date = self.compute_hold_start_date(start=vals["start_date"])
+            vals["hold_start_date"] = hold_start_date
+
         event = super().create(vals)
 
         # Analytic account and Origin linked to this event
@@ -252,8 +261,13 @@ class EventCompassion(models.Model):
             {"origin_id": origin_id, "analytic_id": analytic_id, }
         )
 
+        # Workaround, default_start_date must be removed from context, details in commit
+        context = dict(self._context)
+        context.pop("default_start_date", None)
+        calendar_obj = self.env["calendar.event"].with_context({}, context)
+
         # Add calendar event
-        calendar_event = self.env["calendar.event"].create(event._get_calendar_vals())
+        calendar_event = calendar_obj.create(event._get_calendar_vals())
         event.with_context(no_calendar=True).calendar_event_id = calendar_event
 
         return event
@@ -396,14 +410,9 @@ class EventCompassion(models.Model):
     @api.onchange("start_date")
     @api.multi
     def onchange_start_date(self):
-        """ Update end_date and hold_start_date as soon as start_date is
-        changed """
-        days_allocate_before_event = self.env["res.config.settings"].get_param(
-            "days_allocate_before_event"
-        )
-        dt = timedelta(days=days_allocate_before_event)
+        """ Update end_date and hold_start_date as soon as start_date is changed """
         for event in self.filtered("start_date"):
-            event.hold_start_date = (event.start_date - dt).date()
+            event.hold_start_date = event.compute_hold_start_date()
             if not event.end_date or event.end_date < event.start_date:
                 event.end_date = event.start_date
 


### PR DESCRIPTION
I found the origin of the bug but I'm not sure on how to proceed, as the fix would require heavy refactoring.

Here is the problem:
- The Event Calendar View (id `view_events_calendar`) declares what field are used as start and stop of the event model for display in the calendar, currently `start_date` and `end_date`
- The calendar_view.js of the core web module maps the fields declared above, and calendar_controller.js uses the names of the mapping to set in the context "default_[name of the mapped field]" to the value selected when creating the event from the calendar view.
- The `calendar.event` has a computed `start_date` field. When creating an instance of a model, Odoo checks in the context for a "default_[name of the field]" (odoo/models.py l. 1153), finds the value set previously by the JS for `default_start_date`, and uses it for this field.
- As it is a computed field, the inverse method is called to set the `start` and `stop` fields, but it returns Null as this is not the expected behavior, resulting in the error that originated this task.

In short, the name used to store the start and stop datetimes (`start_date` and `end_date`) of  `crm.event.compassion` conflicts with the one used in `calendar.event` through the context set in JS. Renaming `start_date` and `end_date` to `start` and `stop` (or any other name without conflict) solves the bug. The problem is that those fields are used heavily throughout the codebase, and as the name isn't unique refactoring to a new name everywhere will be error prone. 

Therefore I would like to make sure this is the fix I should use before continuing. I do not see another obvious one as it would require the modification of base odoo modules.
