### PR TITLE
CO-3378 FIX Support replies aren't set to resolved when replied to

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -248,9 +248,6 @@ class CrmClaim(models.Model):
         - Push partner to associated mail messages
         """
 
-        if values.get("user_id"):
-            values["stage_id"] = self.env.ref("crm_request.stage_wait_support").id
-
         if not values.get("user_id") and values.get("stage_id") in (
                 self.env.ref("crm_request.stage_wait_support").id,
                 self.env.ref("crm_claim.stage_claim2").id):

--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -243,10 +243,13 @@ class CrmClaim(models.Model):
     @api.multi
     def write(self, values):
         """
+        - If a user is assigned and the request is 'New', set to 'Waiting on support'
         - If move request in stage 'Waiting on support' assign the request to
         the current user.
         - Push partner to associated mail messages
         """
+        if values.get("user_id") and self.stage_id == self.env.ref("crm_claim.stage_claim1"):
+            values["stage_id"] = self.env.ref("crm_request.stage_wait_support").id
 
         if not values.get("user_id") and values.get("stage_id") in (
                 self.env.ref("crm_request.stage_wait_support").id,


### PR DESCRIPTION
Was introduced by CO-3240. Each time the write method of crm.claim was called with an user_id set, the state was set back to "waiting for support".

I deleted this code which solves the bug, but I'm not sure why it was here so it might introduce another bug. Would be good if Joel could review this.