### PR TITLE
CO-3371 Language identification for German on Samsung browser

### DIFF
--- a/mobile_app_connector/controllers/mobile_app_controller.py
+++ b/mobile_app_connector/controllers/mobile_app_controller.py
@@ -204,7 +204,7 @@ class RestController(http.Controller):
         :return: Redirect to sms_sponsorship form
         """
         values = {
-            "lang_code": "de_DE",  # german by default, temporary solution
+            "lang_code": _get_lang(request, parameters),
             "source": parameters.get("source"),
             "partner_id": parameters.get("partner_id"),
         }

--- a/sms_sponsorship/webapp/src/App.js
+++ b/sms_sponsorship/webapp/src/App.js
@@ -86,8 +86,6 @@ class Main extends React.Component {
                 child: child,
                 partner: partner,
             });
-            // Set the language as the request
-            i18n.changeLanguage(child.lang);
         });
     };
 


### PR DESCRIPTION
After a looooong search to understand how the react code worked, this is the best solution I came up with. The basic issue is that German (`de_DE` or `de_CH`) is not recognized by _Samsung web browser_ and so the language of the corresponding request is `en_US` (even though it works fine for `fr_FR`, `it_CH` or `it_IT`, for instance). Because of that, the `sms_sponsorship_request` is created with English for its language when the browser is in German. I cannot come up with a solution to prevent this (I looked every variable contained in the `request`), so the solution is to bypass the usage of this value, since everything still works just fine.
From my tests, everything works fine and the bug is fixed (I tried with my phone in all 4 languages, trying to change the language and to refresh multiple times).