### PR TITLE
CO-3382 send gift to any shelter

### DIFF
--- a/gift_compassion/views/gift_view.xml
+++ b/gift_compassion/views/gift_view.xml
@@ -80,9 +80,11 @@
                     <group>
                         <group>
                             <field name="sponsorship_id"
-                                   options="{'colors':{'draft':'blue', 'waiting':'green', 'cancelled':'grey', 'terminated':'grey', 'mandate':'red'}, 'field_color':'state'}"/>
-                            <field name="partner_id"/>
+                                   options="{'colors':{'draft':'blue', 'waiting':'green', 'cancelled':'grey', 'terminated':'grey', 'mandate':'red'}, 'field_color':'state'}"
+                                   attrs="{'required': [('gift_type', '!=', 'Project Gift')]}"/>
+                            <field name="partner_id" domain="[('global_id', '!=', False)]"/>
                             <field name="child_id"/>
+                            <field name="project_id"/>
                         </group>
                         <group>
                             <field name="gift_type"/>


### PR DESCRIPTION
- [x] permettre de choisir n'importe quel partenaire (avec un global id) 
- [x] permettre de choisir un FCP (pas un enfant)

lorsqu'on choisit un autre champ que sponsorship id, les champs en dessous ne sont pas automatique mis à jour. Mais comme ces autres champs sont "related" avec sponsorship_id, est-ce que lui mettre un compute peut poser problème ou non ?

- [ ] limiter les options attribution /repartition (subtype ) aux options valide (cf.png) (pas possible selon Ema)