### PR TITLE
CO 3345 12.0 fix mapping for interventions

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -13,7 +13,6 @@ from datetime import datetime, date
 
 from dateutil.relativedelta import relativedelta
 
-from odoo.addons.message_center_compassion.models.field_to_json import RelationNotFound
 from odoo.addons.message_center_compassion.tools.onramp_connector import OnrampConnector
 from odoo.addons.queue_job.job import job, related_action
 

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -557,15 +557,7 @@ class CompassionProject(models.Model):
 
     @api.multi
     def json_to_data(self, json, mapping_name=None):
-        while True:  # catch more than one relation not found
-            try:
-                odoo_data = super().json_to_data(json, mapping_name)
-                break
-            except RelationNotFound as e:
-                self.fetch_missing_relational_records(
-                    e.field_relation, e.field_name, e.value, e.json_name
-                )
-
+        odoo_data = super().json_to_data(json, mapping_name)
         status = odoo_data.get("status")
         if status:
             status_mapping = {
@@ -600,58 +592,6 @@ class CompassionProject(models.Model):
                 # Weird value received, we prefer to ignore it.
                 del odoo_data["monthly_income"]
         return odoo_data
-
-    def fetch_missing_relational_records(self, field_relation,
-                                         field_name, values, json_name):
-        onramp = OnrampConnector()
-        endpoint = "churchpartners/{0}/kits/icpkit?FinalLanguage={1}"
-        languages_map = {
-            "English": "en_US",
-            "French": "fr_CH",
-            "German": "de_DE",
-            "Italian": "it_IT",
-        }
-        # transform values to list first
-        if not isinstance(values, list):
-            values = [values]
-        # go over all missing values, keep count of index to know which translation
-        # to take from onramp result
-        for i, value in enumerate(values):
-            # check if hobby/household duty, etc... exists in our database
-            search_vals = [(field_name, "=", value)]
-            relation_obj = self.env[field_relation].sudo()
-            if hasattr(relation_obj, "value"):
-                # Useful for connect.multipicklist objects
-                search_vals.insert(0, "|")
-                search_vals.append(("value", "=", value))
-            search_count = relation_obj.search_count(search_vals)
-            # if not exist, then create it
-            if not search_count:
-                value_record = (
-                    relation_obj.create({field_name: value, "value": value})
-                )
-                if not hasattr(relation_obj, "value"):
-                    return
-                # fetch translations for connect.multipicklist values
-                must_manually_translate = False
-                for lang_literal, lang_context in languages_map.items():
-                    result = onramp.send_message(
-                        endpoint.format(self[0].fcp_id, lang_literal), "GET"
-                    )
-                    if "ICPResponseList" in result.get("content", {}):
-                        content = result["content"]["ICPResponseList"][0]
-                        if json_name in content:
-                            content_values = content[json_name]
-                            if not isinstance(content_values, list):
-                                content_values = [content_values]
-                            translation = content_values[i]
-                            if translation == value_record.value:
-                                must_manually_translate = True
-                            value_record.with_context(
-                                lang=lang_context
-                            ).value = translation
-                if must_manually_translate:
-                    value_record.assign_translation()
 
     ##########################################################################
     #                             VIEW CALLBACKS                             #

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -13,7 +13,6 @@ import re
 from datetime import datetime, timedelta
 
 import requests
-from odoo.addons.message_center_compassion.models.field_to_json import RelationNotFound
 from odoo.addons.message_center_compassion.tools.onramp_connector import OnrampConnector
 
 from odoo import models, fields, api, tools, _

--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -27,6 +27,7 @@ class CompassionIntervention(models.Model):
         "compassion.generic.intervention",
         "mail.thread",
         "compassion.mapped.model",
+        "mail.activity.mixin"
     ]
     _name = "compassion.intervention"
     _description = "Intervention"
@@ -429,6 +430,20 @@ class CompassionIntervention(models.Model):
             # By default we want to opt-in for next years
             vals["next_year_opt_in"] = True
             intervention = self.create(vals)
+
+            # Once the intervention is created, send task for the primary owner
+            if intervention:
+                for user in intervention.user_id:
+                    intervention.activity_schedule(
+                        "mail.mail_activity_data_todo",
+                        summary=_("Set an expiration date and service level"),
+                        note=_("You have been assigned to the Intervention {}. "
+                               "Please update the intervention by setting an "
+                               "expiration date and service level.".
+                               format(intervention.intervention_id)
+                               ),
+                        user_id=user.id
+                    )
 
         return intervention.ids
 

--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -828,7 +828,7 @@ class CompassionIntervention(models.Model):
 
         return intervention_local_ids
 
-    @api.model
+    @api.multi
     def json_to_data(self, json, mapping_name=None):
         if "ICP" in json:
             json["ICP"] = json["ICP"].split("; ")

--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -404,15 +404,15 @@ class CompassionIntervention(models.Model):
         )
         intervention = self
         if intervention_details_request:
-            vals = self.json_to_data(commkit_data)
+            vals = self.json_to_data(intervention_details_request)
 
             vals["total_cost"] = vals["hold_amount"] = float(
                 vals["hold_amount"].replace("'", "").replace(",", "")
             )
-            if not vals["secondary_owner"]:
+            if "secondary_owner" in vals and not vals["secondary_owner"]:
                 del vals["secondary_owner"]
 
-            if "service_level" not in vals:
+            if "service_level" not in vals or not vals.get("service_level"):
                 vals["service_level"] = "Level 1"
 
             intervention_name = vals["name"]

--- a/intervention_compassion/views/compassion_intervention_view.xml
+++ b/intervention_compassion/views/compassion_intervention_view.xml
@@ -173,6 +173,7 @@
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers"/>
+                    <field name="activity_ids" widget="mail_activity"/>
                     <field name="message_ids" widget="mail_thread"/>
                 </div>
             </form>

--- a/message_center_compassion/models/compassion_mapped_model.py
+++ b/message_center_compassion/models/compassion_mapped_model.py
@@ -107,7 +107,7 @@ class CompassionMappedModel(models.AbstractModel):
         for single_json in json:
             data = {}
             for json_spec in all_fields:
-                for _ in range(10):  # try x attempts, avoid while loop
+                for attempt in range(10):  # try x attempts, avoid while loop
                     try:
                         json_value = single_json.get(json_spec.json_name)
                         if json_spec.sub_mapping_id and json_value:

--- a/message_center_compassion/models/connect_multipicklist.py
+++ b/message_center_compassion/models/connect_multipicklist.py
@@ -64,15 +64,16 @@ class ConnectMultipicklist(models.AbstractModel):
         )
         # Remove previous todos
         self.activity_unlink("mail.mail_activity_data_todo")
-        for user_id in notify_ids[0][2]:
-            act_vals = {
-                "user_id": user_id
-            }
-            self.activity_schedule(
-                "mail.mail_activity_data_todo",
-                summary=_("A new value needs translation"),
-                note=_(
-                    "This is a new value that needs translation "
-                    "for printing the child dossier."),
-                **act_vals
-            )
+        if notify_ids: #  check if not False
+            for user_id in notify_ids[0][2]:
+                act_vals = {
+                    "user_id": user_id
+                }
+                self.activity_schedule(
+                    "mail.mail_activity_data_todo",
+                    summary=_("A new value needs translation"),
+                    note=_(
+                        "This is a new value that needs translation "
+                        "for printing the child dossier."),
+                    **act_vals
+                )

--- a/message_center_compassion/models/connect_multipicklist.py
+++ b/message_center_compassion/models/connect_multipicklist.py
@@ -64,7 +64,7 @@ class ConnectMultipicklist(models.AbstractModel):
         )
         # Remove previous todos
         self.activity_unlink("mail.mail_activity_data_todo")
-        if notify_ids: #  check if not False
+        if notify_ids:  # check if not False
             for user_id in notify_ids[0][2]:
                 act_vals = {
                     "user_id": user_id

--- a/message_center_compassion/models/field_to_json.py
+++ b/message_center_compassion/models/field_to_json.py
@@ -183,7 +183,8 @@ class FieldToJson(models.Model):
             values = value if isinstance(value, list) else [value]
             for val in values:
                 relational_record = relational_model.search([
-                    (self.field_name, "=ilike", val)])
+                    "|", (self.field_name, "=ilike", val), (self.field_name, "=", val)
+                ])
                 if not relational_record and not self.allow_relational_creation:
                     # Break to raise error in case we don't find the relation
                     records = relational_model


### PR DESCRIPTION
- Update intervention hold now possible
- Missing FCP values and their translations created when getting info of interventions
- Refactored fetching of missing relational records in common parent class
- Removed fetching of missing relational records in compassion child and project models
- Users now receive a To Do activity notification when a new intervention is assigned to him/her
- Correctly create new interventions from incoming messages from GMC connect