### PR TITLE
Improvements of dynamic hours and simplification of the code

### DIFF
--- a/hr_attendance_management/static/src/js/attendance.js
+++ b/hr_attendance_management/static/src/js/attendance.js
@@ -13,11 +13,15 @@ odoo.define('hr_attendance_management.attendance', function (require) {
         var compute_diff_minutes = function() {
             var init_hours = window.localStorage.getItem('initial_hours');
             var init_minutes = window.localStorage.getItem('initial_minutes');
+            var init_seconds = window.localStorage.getItem('initial_seconds');
             var now = new Date();
             var now_hours = now.getHours();
             var now_minutes = now.getMinutes();
+            var now_seconds = now.getSeconds();
 
-            return now_minutes - init_minutes + (now_hours - init_hours) * 60;
+            return Math.trunc(((now_seconds - init_seconds) +
+                (now_minutes - init_minutes) * 60 +
+                (now_hours - init_hours) * 3600) / 60);
         }
 
         var displayed_time = window.localStorage.getItem(item_name);
@@ -63,7 +67,7 @@ odoo.define('hr_attendance_management.attendance', function (require) {
                     compute_hours('worked_today');
                     compute_hours('balance_today');
                 }
-            }, 5000
+            }, 1000
         );
         window.localStorage.setItem('interval_id', interval_id);
     }
@@ -141,6 +145,7 @@ odoo.define('hr_attendance_management.attendance', function (require) {
                 var now = new Date();
                 window.localStorage.setItem('initial_hours', now.getHours());
                 window.localStorage.setItem('initial_minutes', now.getMinutes());
+                window.localStorage.setItem('initial_seconds', now.getSeconds());
             }
             var loc_id = parseInt($('#location').val(), 10);
             this.getSession().user_context.default_location_id = loc_id;

--- a/hr_attendance_management/static/src/js/attendance.js
+++ b/hr_attendance_management/static/src/js/attendance.js
@@ -9,81 +9,78 @@ odoo.define('hr_attendance_management.attendance', function (require) {
     var QWeb = core.qweb;
     var _t = core._t;
 
+    var compute_hours = function(item_name) {
+        var compute_diff_minutes = function() {
+            var init_hours = window.localStorage.getItem('initial_hours');
+            var init_minutes = window.localStorage.getItem('initial_minutes');
+            var now = new Date();
+            var now_hours = now.getHours();
+            var now_minutes = now.getMinutes();
+
+            return now_minutes - init_minutes + (now_hours - init_hours) * 60;
+        }
+
+        var displayed_time = window.localStorage.getItem(item_name);
+        var matches = displayed_time.match(/^-?(\d{2}):(\d{2})$/);
+
+        if (matches !== null) {
+            var hours = parseInt(matches[1]);
+            var minutes = parseInt(matches[2]);
+            var total_minutes = (minutes + (hours * 60)) *
+                (matches[0].substring(0, 1) === '-' ? -1 : 1);
+
+            var new_minutes = compute_diff_minutes();
+            if (new_minutes < 0) {
+                return; // We don't want to decrease working time
+            }
+            var negative = total_minutes + new_minutes < 0;
+            var new_total = Math.abs(total_minutes + new_minutes);
+
+            var new_hours = ('0' + Math.trunc(new_total / 60)).slice(-2);
+            var new_minutes = ('0' + (new_total % 60)).slice(-2);
+
+            $('#' + item_name).text((negative ? '-' : '') +
+                new_hours + ':' + new_minutes);
+            if (item_name !== 'worked_today') {
+                $('#' + item_name).parent().get(0).style.color = negative ?
+                    'red' : 'green';
+            }
+        }
+    }
+
     var start_dynamic_hours = function() {
         var interval_id = setInterval(
             function() {
                 if ($('#state').text() === 'checked in') {
-                    var start_time = window.localStorage.getItem('start_time');
+                    if (window.localStorage.getItem('check_in') === 'true') {
+                        // Store balance when we check in
+                        window.localStorage.setItem('worked_today', $('#worked_today').text());
+                        window.localStorage.setItem('balance_today', $('#balance_today').text());
 
-                    ['worked_today', 'balance_today'].forEach(
-                        function (el) {
-                            var diff_minutes =
-                                moment().diff(moment(start_time), 'minutes');
-                            var matches = $('#' + el)
-                                .text().match(/^-?(\d{2}):(\d{2})$/);
-
-                            if (matches !== null && diff_minutes >= 1) {
-                                var hours = parseInt(matches[1]);
-                                var minutes = parseInt(matches[2]);
-
-                                var total_minutes = (minutes +
-                                    (hours * 60)) *
-                                    (matches[0].substring(0, 1) ===
-                                     '-' ? -1 : 1);
-                                var negative = total_minutes +
-                                    diff_minutes < 0;
-
-                                var new_total = Math.abs(total_minutes +
-                                    diff_minutes);
-                                var new_hours =
-                                    ('0' + Math.trunc(new_total / 60))
-                                        .slice(-2);
-                                var new_minutes =
-                                    ('0' + (new_total % 60)).slice(-2);
-
-                                $('#' + el).text((negative ? '-' : '') +
-                                    new_hours + ':' + new_minutes);
-
-                                if (el !== 'worked_today') {
-                                    $('#' + el).parent()
-                                        .get(0).style.color =
-                                    negative ? 'red' : 'green';
-                                }
-                                // We update the time for the next time difference
-                                window.localStorage.setItem('start_time', new Date())
-                            }
-                        }
-                    );
+                        // We don't want to update until next check in
+                        window.localStorage.setItem('check_in', false);
+                    }
+                    compute_hours('worked_today');
+                    compute_hours('balance_today');
                 }
             }, 5000
         );
-        return interval_id;
+        window.localStorage.setItem('interval_id', interval_id);
     }
 
     var stop_dynamic_hours = function() {
         var interval_id = window.localStorage.getItem('interval_id');
-        var trigger_source = window.localStorage.getItem('trigger_source');
-
-        // We don't clear the interval after the greeting message (the
-        // start() function won't be called afterward in that case)
-        if (interval_id && trigger_source !== 'back_from_update') {
+        if (interval_id) {
             clearInterval(interval_id);
             window.localStorage.removeItem('interval_id');
         }
-
-        // Check if we go to or leave greeting page
-        if (trigger_source === 'from_update_attendance') {
-            window.localStorage.setItem('trigger_source', 'back_from_update');
-        } else if (trigger_source === 'back_from_update') {
-            window.localStorage.setItem('trigger_source', 'other');
-        }
     }
 
-    window.localStorage.setItem('trigger_source', 'other');
     // We look for URL changes, corresponding we leave the actual page
     window.addEventListener('popstate', function (event) {
         stop_dynamic_hours();
     });
+
     // We look for focus on page, we want to retrigger the function
     window.onfocus = function() {
         stop_dynamic_hours();
@@ -130,16 +127,21 @@ odoo.define('hr_attendance_management.attendance', function (require) {
 
             // We make sure to remove any existing interval
             stop_dynamic_hours();
-            var interval_id = start_dynamic_hours();
-            window.localStorage.setItem('interval_id', interval_id);
-            // We save the time at which the widget was created
-            window.localStorage.setItem('start_time', new Date());
+            start_dynamic_hours();
 
             return result;
         },
         update_attendance: function () {
             // We don't want to clear interval because we stay on the same page
-            window.localStorage.setItem('trigger_source', 'from_update_attendance');
+            if ($('#state').text() === 'checked out') {
+                // This event corresponds to a check in
+                window.localStorage.setItem('check_in', true);
+
+                // We store the time of the check in
+                var now = new Date();
+                window.localStorage.setItem('initial_hours', now.getHours());
+                window.localStorage.setItem('initial_minutes', now.getMinutes());
+            }
             var loc_id = parseInt($('#location').val(), 10);
             this.getSession().user_context.default_location_id = loc_id;
             var self = this;


### PR DESCRIPTION
The code used to compute the time differences were computed according to a point in time that was updated through time. The time at which the log in occurred is now the only considered point in time for these computations. This increases the precision of the computation (on a day, it ended up two or three minutes off what it should have been), but the precision error is now a second in the worst possible case. Some refactoring as well as some simplifications of the code were also done, new comments were added to ease future modifications if some are required at some points.