### PR TITLE
AP-354 Odoo don't find notification if partner is not connected

### DIFF
--- a/mobile_app_connector/models/firebase_notification.py
+++ b/mobile_app_connector/models/firebase_notification.py
@@ -152,7 +152,6 @@ class FirebaseNotificationPartnerRead(models.Model):
         notif = self.env["firebase.notification.partner.read"].search(
             [
                 ("notification_id", "=", int(notif_id)),
-                ("partner_id", "=", self.env.user.partner_id.id),
             ]
         )
         notif.opened = True


### PR DESCRIPTION
We just have to remove the partner from the search odoo should be able to find the notification next