### PR TITLE
AP-363 add options for limiting hub refresh

### DIFF
--- a/mobile_app_connector/models/app_hub.py
+++ b/mobile_app_connector/models/app_hub.py
@@ -104,8 +104,11 @@ class AppHub(models.AbstractModel):
         app_messages = partner.app_messages
 
         start = int(pagination.get("start", 0))
-        limit = int(pagination.get("limit", 10))
-        if start != 0:
+        limit = int(pagination.get("limit", 100))
+        force_refresh = pagination.get("force_refresh")
+
+        # No need to regenerate if sponsor is looking for old tiles or if hub is recent
+        if not force_refresh and start != 0 or not app_messages.needs_refresh:
             json_messages = json.loads(app_messages.json_messages)
             messages = json_messages[start:start+limit]
             for message in messages:
@@ -138,7 +141,7 @@ class AppHub(models.AbstractModel):
             _logger.info("END SORTING MESSAGES")
 
             app_messages.json_messages = json.dumps(messages, default=str)
-            app_messages.last_refresh_date = fields.Date.today()
+            app_messages.last_refresh_date = fields.Datetime.now()
 
             messages = messages[0:limit]
 

--- a/mobile_app_connector/models/app_messages.py
+++ b/mobile_app_connector/models/app_messages.py
@@ -7,7 +7,10 @@
 #
 ##############################################################################
 
-from odoo import models, fields
+from odoo import api, models, fields
+
+# Time in days after which the hub is reconstructed for fetching any new tiles
+HUB_REFRESH_DAYS = 3
 
 
 class AppMessages(models.Model):
@@ -17,4 +20,28 @@ class AppMessages(models.Model):
         "res.partner", "Partner", readonly=True, required=True, ondelete="cascade"
     )
     json_messages = fields.Char()
-    last_refresh_date = fields.Date()
+    last_refresh_date = fields.Datetime()
+    needs_refresh = fields.Boolean(compute="_compute_needs_refresh")
+    is_expired = fields.Boolean(compute="_compute_is_expired")
+    force_refresh = fields.Boolean(help="Force the hub of sponsor to refresh")
+
+    @api.multi
+    def _compute_needs_refresh(self):
+        for hub in self:
+            hub.needs_refresh = hub.force_refresh or hub.is_expired
+
+    @api.multi
+    def _compute_is_expired(self):
+        for hub in self:
+            if hub.last_refresh_date:
+                refresh_since = fields.Datetime.now() - hub.last_refresh_date
+                hub.is_expired = refresh_since.days > HUB_REFRESH_DAYS
+            else:
+                hub.is_expired = True
+
+    @api.multi
+    def write(self, vals):
+        # Reset force refresh hub when it is just refreshed.
+        if vals.get("last_refresh_date"):
+            vals["force_refresh"] = False
+        return super().write(vals)

--- a/mobile_app_connector/models/compassion_child.py
+++ b/mobile_app_connector/models/compassion_child.py
@@ -182,3 +182,9 @@ class CompassionChild(models.Model):
             if not value:
                 res[key] = None
         return res
+
+    def details_answer(self, vals):
+        self.mapped("sponsor_id.app_messages").write({
+            "force_refresh": True
+        })
+        return super().details_answer(vals)

--- a/mobile_app_connector/models/compassion_correspondence.py
+++ b/mobile_app_connector/models/compassion_correspondence.py
@@ -241,3 +241,18 @@ class CompassionCorrespondence(models.Model):
                 res["Date"] = res["Date"][:10]
                 break
         return res
+
+    def process_letter(self):
+        self.mapped("partner_id.app_messages").write({
+            "force_refresh": True
+        })
+        return super().process_letter()
+
+    @api.model
+    def create(self, vals):
+        letter = super().create(vals)
+        if vals.get("direction") == "Supporter To Beneficiary":
+            letter.mapped("partner_id.app_messages").write({
+                "force_refresh": True
+            })
+        return letter

--- a/mobile_app_connector/models/recurring_contract.py
+++ b/mobile_app_connector/models/recurring_contract.py
@@ -29,3 +29,19 @@ class CompassionRecurringContract(models.Model):
         """
         child = self.sudo().mapped("child_id")
         return child.get_app_json(multi)
+
+    @api.model
+    def create(self, vals):
+        contract = super().create(vals)
+        sponsors = self.mapped("partner_id") + self.mapped("correspondent_id")
+        sponsors.mapped("app_messages").write({
+            "force_refresh": True
+        })
+        return contract
+
+    def contract_active(self):
+        sponsors = self.mapped("partner_id") + self.mapped("correspondent_id")
+        sponsors.mapped("app_messages").write({
+            "force_refresh": True
+        })
+        return super().contract_active()

--- a/sbc_compassion/models/project_compassion.py
+++ b/sbc_compassion/models/project_compassion.py
@@ -18,7 +18,7 @@ class ProjectCompassion(models.Model):
         letters = self.env["correspondence"].search(
             [
                 ("child_id.code", "like", self.fcp_id),
-                ("direction", "=", "Supporter to Beneficiary"),
+                ("direction", "=", "Supporter To Beneficiary"),
                 ("kit_identifier", "=", False),
             ]
         )
@@ -28,7 +28,7 @@ class ProjectCompassion(models.Model):
         letters = self.env["correspondence"].search(
             [
                 ("child_id.code", "like", self.fcp_id),
-                ("direction", "=", "Supporter to Beneficiary"),
+                ("direction", "=", "Supporter To Beneficiary"),
                 ("kit_identifier", "=", False),
             ]
         )


### PR DESCRIPTION
- Refresh only after 3 days or any key event happening
- Events include info of child fetched, new letter, new sponsorship
- Add option to force refresh from the app with a parameter
- Add option to manually force refresh with a boolean field