### PR TITLE
CO-3436 Adding communication revision history system

### DIFF
--- a/partner_communication_revision/__manifest__.py
+++ b/partner_communication_revision/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Partner Communication Revisions",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     "category": "Other",
     "author": "Compassion CH",
     "license": "AGPL-3",
@@ -46,6 +46,7 @@
         "views/communication_config_view.xml",
         "views/revision_preview_view.xml",
         "views/communication_revision_view.xml",
+        "views/communication_revision_history_view.xml",
         "views/communication_keyword_view.xml",
         "views/cancel_revision_wizard_view.xml",
         "views/submit_revision_wizard_view.xml",

--- a/partner_communication_revision/migrations/12.0.1.0.1/pre-migration.py
+++ b/partner_communication_revision/migrations/12.0.1.0.1/pre-migration.py
@@ -1,0 +1,15 @@
+def migrate(cr, version):
+    if not version:
+        return
+
+    revisions = cr.env["partner.communication.revision"].search([])
+    for revision in revisions:
+        cr.env["partner.communication.revision.history"].create({
+            "revision_number": revision.revision_number,
+            "revision_date": revision.revision_date,
+            "lang": revision.lang,
+            "subject": revision.subject,
+            "simplified_text": revision.simplified_text,
+            "body_html": revision.body_html,
+            "linked_revision_id": revision.id,
+        })

--- a/partner_communication_revision/models/__init__.py
+++ b/partner_communication_revision/models/__init__.py
@@ -11,3 +11,4 @@
 from . import communication_revision
 from . import communication_config
 from . import communication_keyword
+from . import communication_revision_history

--- a/partner_communication_revision/models/communication_revision.py
+++ b/partner_communication_revision/models/communication_revision.py
@@ -242,15 +242,13 @@ class CommunicationRevision(models.Model):
         if "active_rev_history_id" in vals and self.active_rev_history_id:
             self.active_rev_history_id.save_revision_state()
             backup = self.env["partner.communication.revision.history"]\
-                .sudo().browse(vals["active_rev_history_id"])
+                .browse(vals["active_rev_history_id"])
             if backup:
                 # Restore all fields from the backup
-                self.revision_number = backup.revision_number
-                self.revision_date = backup.revision_date
-                self.lang = backup.lang
-                self.subject = backup.subject
-                self.simplified_text = backup.simplified_text
-                self.body_html = backup.body_html
+                self.write(backup.read([
+                    "revision_number", "revision_date", "lang", "subject",
+                    "simplified_text", "body_html"
+                ])[0])
 
         if "correction_user_id" in vals:
             user = self.env["res.users"].browse(vals["correction_user_id"])
@@ -585,13 +583,10 @@ class CommunicationRevision(models.Model):
         backup = self._get_backup(backup_revision_number)
         if backup:
             # Restore all fields from the backup
-            self.revision_number = backup.revision_number
-            self.revision_date = backup.revision_date
-            self.lang = backup.lang
-            self.subject = backup.subject
-            self.simplified_text = backup.simplified_text
-            self.body_html = backup.body_html
-            self.active_rev_history_id = backup.id
+            self.write(backup.read([
+                "revision_number", "revision_date", "lang", "subject",
+                "simplified_text", "body_html"
+            ])[0])
         else:
             # Create new backup since none exist for this revision number
             self.active_rev_history_id =\

--- a/partner_communication_revision/models/communication_revision_history.py
+++ b/partner_communication_revision/models/communication_revision_history.py
@@ -1,0 +1,51 @@
+##############################################################################
+#
+#    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import models, fields, api
+
+
+class CommunicationRevisionHistory(models.Model):
+    _name = "partner.communication.revision.history"
+    _rec_name = "revision_number"
+    _description = "Communication template revision history"
+
+    revision_number = fields.Float(required=True)
+    revision_date = fields.Date(required=True)
+    lang = fields.Selection(
+        lambda self: self.env["res.lang"].sudo().get_installed(),
+        "Language", required=True
+    )
+    subject = fields.Char()
+    simplified_text = fields.Html(sanitize=False)
+    body_html = fields.Html()
+    linked_revision_id = fields.Many2one(
+        comodel_name="partner.communication.revision",
+        string="Revision history"
+    )
+
+    @api.multi
+    def name_get(self):
+        names = []
+        for backup in self:
+            name = "{:.2f}".format(round(backup.revision_number, 2))
+            names.append((backup.id, name))
+        return names
+
+    def save_revision_state(self):
+        self.ensure_one()
+        self.revision_number = self.linked_revision_id.revision_number
+        self.revision_date = self.linked_revision_id.revision_date
+        self.lang = self.linked_revision_id.lang
+        self.subject = self.linked_revision_id.subject
+        self.simplified_text = self.linked_revision_id.simplified_text
+        self.body_html = self.linked_revision_id.body_html
+
+    @api.multi
+    def set_as_default_revision(self):
+        self.linked_revision_id.restore_backup(self.revision_number)

--- a/partner_communication_revision/models/communication_revision_history.py
+++ b/partner_communication_revision/models/communication_revision_history.py
@@ -39,12 +39,10 @@ class CommunicationRevisionHistory(models.Model):
 
     def save_revision_state(self):
         self.ensure_one()
-        self.revision_number = self.linked_revision_id.revision_number
-        self.revision_date = self.linked_revision_id.revision_date
-        self.lang = self.linked_revision_id.lang
-        self.subject = self.linked_revision_id.subject
-        self.simplified_text = self.linked_revision_id.simplified_text
-        self.body_html = self.linked_revision_id.body_html
+        self.write(self.linked_revision_id.read([
+            "revision_number", "revision_date", "lang", "subject",
+            "simplified_text", "body_html"
+        ])[0])
 
     @api.multi
     def set_as_default_revision(self):

--- a/partner_communication_revision/security/ir.model.access.csv
+++ b/partner_communication_revision/security/ir.model.access.csv
@@ -1,3 +1,4 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_communication_revision,Full access on communication revision,model_partner_communication_revision,base.group_user,1,1,1,1
+access_communication_revision_history,Full access on communication revision history,model_partner_communication_revision_history,base.group_user,1,1,1,1
 access_communication_keyword,Full access on communication keywords,model_partner_communication_keyword,base.group_user,1,1,1,1

--- a/partner_communication_revision/views/communication_config_view.xml
+++ b/partner_communication_revision/views/communication_config_view.xml
@@ -21,19 +21,21 @@
                         <field name="revision_ids" context="{'default_config_id': id, 'form_view_ref': 'partner_communication_revision.revision_simplified_form'}">
                             <tree
                                     decoration-primary="state in ('pending','submit','corrected')"
-                                    decoration-success="state=='approved'">
+                                    decoration-success="state=='approved'"
+                                    editable="top">
                                 <field name="config_id" invisible="1"/>
-                                <field name="lang"/>
-                                <field name="user_id"/>
-                                <field name="correction_user_id"/>
+                                <field name="lang" readonly="1"/>
+                                <field name="user_id" readonly="1"/>
+                                <field name="correction_user_id" readonly="1"/>
                                 <button name="edit_proposition" type="object" icon="fa-file" context="{'config_id': config_id}" string="Show/Edit revision text"/>
-                                <field name="revision_number"/>
-                                <field name="revision_date"/>
-                                <field name="update_user_id"/>
+                                <field name="active_rev_history_id"/>
+                                <field name="revision_date" readonly="1"/>
+                                <field name="update_user_id" readonly="1"/>
                                 <button name="show_revision" type="object" icon="fa-eye" string="Show active text"/>
                                 <button name="edit_revision" type="object" icon="fa-edit" string="Correct active text"/>
                                 <button name="new_revision" type="object" icon="fa-plus-square" states="approved" groups="base.group_erp_manager"/>
-                                <field name="state"/>
+                                <field name="state" readonly="1"/>
+                                <button name="save_current_revision" type="object" icon="fa-save" string="Create backup of actual revision" attrs="{'invisible': ['|', ('state', '!=', 'active'), ('active_rev_history_id', '!=', False)]}"/>
                             </tree>
                         </field>
                     </group>

--- a/partner_communication_revision/views/communication_revision_history_view.xml
+++ b/partner_communication_revision/views/communication_revision_history_view.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id='revision_history_action' model='ir.actions.act_window'>
+        <field name="name">Revision history</field>
+        <field name="res_model">partner.communication.revision.history</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <record model="ir.ui.view" id="revision_history_form">
+        <field name="name">communication.revision.history.form</field>
+        <field name="model">partner.communication.revision.history</field>
+        <field name="arch" type="xml">
+            <form>
+                <header>
+                    <button name="set_as_default_revision" string="Use as default" type="object"/>
+                </header>
+                <group>
+                    <field name="linked_revision_id"/>
+                    <field name="revision_number"/>
+                    <field name="lang"/>
+                    <field name="body_html"/>
+                </group>
+            </form>
+        </field>
+    </record>
+
+    <menuitem name="My revision history" id="revision_history_base_menu" />
+    <menuitem name="Revision history" id="revision_history_menu" parent="revision_history_base_menu" action="revision_history_action"/>
+</odoo>

--- a/partner_communication_revision/views/communication_revision_view.xml
+++ b/partner_communication_revision/views/communication_revision_view.xml
@@ -9,6 +9,7 @@
                     <field name="lang"/>
                     <field name="config_id" invisible="1"/>
                     <field name="state" invisible="1"/>
+                    <field name="active_rev_history_id"/>
                 </group>
             </form>
         </field>
@@ -27,6 +28,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="lang" invisible="1"/>
                             <field name="subject"/>
                         </group>
                         <group>
@@ -70,6 +72,7 @@
                         <button class="oe_stat_button" name="open_preview" icon="fa-search-plus" string="Preview" type="object"/>
                     </div>
                     <group>
+                        <field name="lang" invisible="1"/>
                         <field name="raw_subject"/>
                     </group>
                     <field name="simplified_text" widget="html" readonly="1"/>
@@ -124,10 +127,12 @@
                     </div>
                     <group>
                         <group>
+                            <field name="lang" invisible="1"/>
                             <field name="user_id" attrs="{'required': [('state', '=', 'pending')], 'readonly': ['|', ('is_proposer', '=', False), ('state', '!=', 'pending')]}"/>
                         </group>
                         <group>
                             <field name="correction_user_id" attrs="{'required': [('state', '=', 'pending')], 'readonly': [('is_proposer', '=', False)]}"/>
+                            <field name="active_rev_history_id"/>
                         </group>
                     </group>
                     <group>


### PR DESCRIPTION
This _PR_ proposes a system to store and restore _backups_ of the different communications that are used in _Odoo_. Creating or updating a revision will create a backup of its previous version (if applicable) and this older version can then be restored by two different means:
- One edits directly the `Many2One` field present in the `communication_revision_config` view
- One uses the button present in a `communication_revision_history` view
The history of a revision is given by the model it revises, the language in which it is written. Then a backup is completely determined by the two previous variables and a `revision_number`: a unique identifier, increasing for each new version.
With the actual implementation, the version that are newer than the actual revision are overwritten by a new version. For instance, if a document has revision 1.00, 1.01 and 2.00. We go back to version 1.00 and make a minor modification. The old version 1.01 will be overwritten with our newer version.