### PR TITLE
CO-3447 Removing writing_language field and adding default reading_language

### DIFF
--- a/sbc_compassion/migrations/12.0.1.0.4/post-migration.py
+++ b/sbc_compassion/migrations/12.0.1.0.4/post-migration.py
@@ -1,0 +1,48 @@
+from openupgradelib import openupgrade
+
+
+def _update_reading_language(cr, sponsorship_id, lang):
+    cr.execute(
+        "UPDATE recurring_contract "
+        "SET reading_language = %s "
+        "WHERE id = %s" % (lang, sponsorship_id)
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not version:
+        return
+
+    sponsorships_to_fill = env["recurring.contract"].search([
+        ("reading_language", "=", False)
+    ])
+
+    message_obj = env["gmc.message"]
+    action_id = env.ref("sponsorship_compassion.create_sponsorship").id
+
+    for sponsorship in sponsorships_to_fill:
+        correspondent_lang_id = False
+        for lang in sponsorship.correspondent_id.spoken_lang_ids:
+            if sponsorship.child_id.correspondence_language_id.id == lang.id:
+                _update_reading_language(
+                    env.cr,
+                    sponsorship.id,
+                    lang.id
+                )
+                continue
+            if sponsorship.correspondent_id.lang == lang.lang_id.code:
+                correspondent_lang_id = lang.id
+        if not sponsorship.reading_language and correspondent_lang_id:
+            _update_reading_language(
+                env.cr,
+                sponsorship.id,
+                correspondent_lang_id
+            )
+
+        message_obj.create({
+            "partner_id": sponsorship.correspondent_id.id,
+            "child_id": sponsorship.child_id.id,
+            "action_id": action_id,
+            "object_id": sponsorship.id,
+        }).process_messages()

--- a/sbc_compassion/migrations/12.0.1.0.4/post-migration.py
+++ b/sbc_compassion/migrations/12.0.1.0.4/post-migration.py
@@ -42,7 +42,7 @@ def migrate(env, version):
                 correspondent_lang_id
             )
 
-        if correspondent_lang_id:
+        if sponsorship.reading_language:
             message_obj.create({
                 "partner_id": sponsorship.correspondent_id.id,
                 "child_id": sponsorship.child_id.id,


### PR DESCRIPTION
The field `writing_language` was not used and so is removed from now on. The field `reading_language` is now set by default to be a match between the language in which the children write and one of the spoken languages of the correspondent. If there is no such match, then the preferred language of the correspondent is chosen.
A migration script is also included in that _PR_ to fill the field `reading_language` everywhere it is possible. There are some cases where a `res.lang.compassion` record of the spoken languages has no `lang_id` (`res.lang`), which makes the match to the default language of the correspondent (a `res.lang` field) impossible. This could be done in a future task with a new migration, to make this field available for all users.