### PR TITLE
CO-3284 Pending state is now replaced by an activity

### DIFF
--- a/cms_form_compassion/__manifest__.py
+++ b/cms_form_compassion/__manifest__.py
@@ -43,8 +43,7 @@
         "queue_job",  # oca_addons/queue
         "base_automation",  # source/addons
         "link_tracker",  # source/addons
-        "base_location",  # oca_addons/partner-contact
-        "message_center_compassion"
+        "base_location"  # oca_addons/partner-contact
     ],
     "data": [
         "data/ir.config_parameter.xml",

--- a/cms_form_compassion/__manifest__.py
+++ b/cms_form_compassion/__manifest__.py
@@ -43,7 +43,8 @@
         "queue_job",  # oca_addons/queue
         "base_automation",  # source/addons
         "link_tracker",  # source/addons
-        "base_location"  # oca_addons/partner-contact
+        "base_location",  # oca_addons/partner-contact
+        "message_center_compassion"
     ],
     "data": [
         "data/ir.config_parameter.xml",
@@ -51,6 +52,7 @@
         "templates/assets.xml",
         "templates/form_widgets.xml",
         "templates/payment_templates.xml",
+        "views/config_view.xml",
         "views/ir_logging.xml",
     ],
     "demo": [],

--- a/cms_form_compassion/models/match_partner.py
+++ b/cms_form_compassion/models/match_partner.py
@@ -94,7 +94,16 @@ class MatchPartner(models.AbstractModel):
         create_infos = self.match_process_create_infos(infos, options)
         create_infos.setdefault("lang", self.env.lang)
         create_infos.setdefault("tz", "Europe/Zurich")
-        return partner_obj.create(create_infos)
+        partner = partner_obj.create(create_infos)
+        partner.activity_schedule(
+            'mail.mail_activity_data_todo',
+            date_deadline=datetime.date(datetime.today() + timedelta(weeks=1)),
+            summary="Verify new partner",
+            note="Please verify that this partner doesn't already exist",
+            user_id=self.env["ir.config_parameter"].sudo().get_param(
+                "cms_form_compassion.match_validation_responsible")
+        )
+        return partner
 
     @api.model
     def match_process_create_infos(self, infos, options=None):

--- a/cms_form_compassion/views/config_view.xml
+++ b/cms_form_compassion/views/config_view.xml
@@ -4,9 +4,9 @@
     <record id="view_cms_form_settings_form" model="ir.ui.view">
         <field name="name">cms.form.settings.form</field>
         <field name="model">res.config.settings</field>
-        <field name="inherit_id" ref="message_center_compassion.compassion_settings"/>
+        <field name="inherit_id" ref="base_setup.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@name='compassion_settings']" position='inside'>
+            <xpath expr="//div[hasclass('app_settings_block')][@data-key='general_settings']" position='inside'>
                 <h2>Match partner validation check responsible</h2>
                 <div class="row mt16 o_settings_container">
                     <div class="col-md-12 o_setting_box">

--- a/cms_form_compassion/views/config_view.xml
+++ b/cms_form_compassion/views/config_view.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<odoo>
+    <!-- Match partner validation -->
+    <record id="view_cms_form_settings_form" model="ir.ui.view">
+        <field name="name">cms.form.settings.form</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="message_center_compassion.compassion_settings"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='compassion_settings']" position='inside'>
+                <h2>Match partner validation check responsible</h2>
+                <div class="row mt16 o_settings_container">
+                    <div class="col-md-12 o_setting_box">
+                        <div name="view_cms_form_settings_form">
+                            <div class="o_setting_right_pane">
+                                <div class="row mt16">
+                                    <label class="col-md-6 o_light_label"
+                                           for="match_validation_responsible"/>
+                                    <field class="col-md-6"
+                                           name="match_validation_responsible"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/cms_form_compassion/wizards/__init__.py
+++ b/cms_form_compassion/wizards/__init__.py
@@ -1,15 +1,10 @@
 ##############################################################################
 #
 #    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
-#    Releasing children from poverty in Jesus' name
-#    @author: Emanuel Cino <ecino@compassion.ch>
+#    @author: Théo Nikles <theo.nikles@gmail.com>
 #
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
 
-from . import models
-from . import forms
-from . import controllers
-from . import tools
-from . import wizards
+from . import cms_form_settings

--- a/cms_form_compassion/wizards/cms_form_settings.py
+++ b/cms_form_compassion/wizards/cms_form_settings.py
@@ -1,0 +1,42 @@
+##############################################################################
+#
+#    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import api, models, fields
+
+
+class CMSFormSettings(models.TransientModel):
+    """ Settings configuration for any Notifications."""
+
+    _inherit = "res.config.settings"
+
+    match_validation_responsible = fields.Many2one(
+        "res.users",
+        string="Match partner validation responsible for activity schedule",
+        domain=[("share", "=", False)],
+        readonly=False,
+    )
+
+    @api.multi
+    def set_values(self):
+        super().set_values()
+        # This is stored in page template for additional B2S pages
+        config = self.env["ir.config_parameter"].sudo()
+        config.set_param(
+            "cms_form_compassion.match_validation_responsible", str(self.match_validation_responsible.id or 0)
+        )
+
+    @api.model
+    def get_values(self):
+        res = super().get_values()
+        config = self.env["ir.config_parameter"].sudo()
+
+        res["match_validation_responsible"] = int(
+            config.get_param("cms_form_compassion.match_validation_responsible", 0)
+        )
+        return res


### PR DESCRIPTION
Previously, when an unmatched partner was created, its state was put under `pending` until someone would check that it really did not exist (check here: https://github.com/CompassionCH/compassion-switzerland/pull/1229). Now, an activity is created instead and assigned to someone determined beforehand using a general setting.
A delay of one week is given to the person responsible to do the task.