### PR TITLE
Fixing small date / datetime bug

### DIFF
--- a/child_compassion/models/weekly_demand.py
+++ b/child_compassion/models/weekly_demand.py
@@ -41,7 +41,7 @@ class WeeklyDemand(models.Model):
         for week in self:
             date_week = week.week_start_date
             if date_week:
-                week.period_locked = date_week <= (
+                week.period_locked = date_week <= datetime.date(
                     datetime.today() + timedelta(weeks=8)
                 )
 


### PR DESCRIPTION
When starting my server, the _CRON_ `Demand Planning CRON` failed with a message error saying `TypeError: can't compare datetime.datetime to datetime.date`. The simple fix used here allows to prevent this issue from arising.