### PR TITLE
AP-352 Donation's banner select correct fund and don't crash

### DIFF
--- a/mobile_app_connector/models/mobile_banner.py
+++ b/mobile_app_connector/models/mobile_banner.py
@@ -41,6 +41,7 @@ class AppBanner(models.Model):
     )
     button_text = fields.Char(translate=True)
     body = fields.Text(translate=True)
+    fund_type = fields.Many2one("product.product", "Fund product", readonly=False)
     image_url = fields.Char(translate=True)
     external_url = fields.Char(translate=True)
     date_start = fields.Date(readonly=True, states={"new": [("readonly", False)]})
@@ -102,6 +103,9 @@ class AppBanner(models.Model):
             res = {}
         res["IS_DELETED"] = "0"
         res["BLOG_DISPLAY_TYPE"] = "Tile"
+        if self.fund_type and self.fund_type.product_tmpl_id:
+            res["POST_TITLE"] = self.fund_type.name
+            res["POST_ID"] = self.fund_type.product_tmpl_id.id
         for key, value in list(res.items()):
             if not value:
                 res[key] = None

--- a/mobile_app_connector/views/app_banner_view.xml
+++ b/mobile_app_connector/views/app_banner_view.xml
@@ -24,6 +24,7 @@
                     </group>
                     <group>
                         <field name="body"/>
+                        <field name="fund_type"/>
                         <field name="button_text"/>
                         <field name="image_url"/>
                     </group>


### PR DESCRIPTION
On _Android_, the application used to crash when a banner for a donation fund was clicked. On both _iOS_ and _Android_, the correct fund was not selected. This happened because of a field that was ready on the application side but not on _Odoo_.
This _PR_ add this field to _Odoo_ and allow _iOS_ to work without any additional modification. For _Android_, however, a _PR_ was required and can be found here: https://github.com/CompassionCH/compassion_uk_android/pull/130