### PR TITLE
CO-3105 Interaction resume now considers all sent paper communications

### DIFF
--- a/crm_compassion/models/interaction_resume.py
+++ b/crm_compassion/models/interaction_resume.py
@@ -91,8 +91,7 @@ class InteractionResume(models.TransientModel):
                         FULL OUTER JOIN utm_source source
                             ON c.source_id = source.id
                             AND source.name != 'Default communication'
-                        WHERE pcj.state = 'done'
-                        AND pcj.send_mode = 'physical'
+                        WHERE pcj.sent_date IS NOT NULL
                         AND (p.contact_id = %s OR p.id = %s)
             -- phonecalls
                     UNION (


### PR DESCRIPTION
Some paper communications did not appear in _interaction resume_ previously because they were in a special state `call` even though they were printed and sent. Instead of checking the state, we now check if the database field `sent_date` is set: if so, we know for sure that the letter has been sent and should appear in the interaction resume. Otherwise, it need to be sent before appearing in the view.