### PR TITLE
CO-3503 - Fix name sponsorship_compassion

### DIFF
--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -132,7 +132,7 @@ class SponsorshipContract(models.Model):
     sub_sponsorship_id = fields.Many2one(
         "recurring.contract", "sub sponsorship", readonly=True, copy=False, index=True
     )
-    name = fields.Char(store=True)
+    name = fields.Char(store=True, compute="name_get")
     partner_id = fields.Many2one(
         "res.partner",
         "Partner",

--- a/sponsorship_compassion/views/sponsorship_contract_view.xml
+++ b/sponsorship_compassion/views/sponsorship_contract_view.xml
@@ -8,7 +8,7 @@
 
             <!-- Hide reference -->
             <field name="reference" position="replace">
-                <field name="name"/>
+                <field name="name" readonly="True"/>
             </field>
 
             <field name="last_paid_invoice_date" position="before">


### PR DESCRIPTION
Now, the name is a compute field and is set when the field correspondent_id and child_id changed