### PR TITLE
CO-3467 - fix household_id with get infos

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -501,6 +501,7 @@ class CompassionChild(models.Model):
         )
         if household:
             household.write(household_data)
+            data["household_id"] = household.id
         elif household_data:
             data["household_id"] = household.create(household_data).id
         return data


### PR DESCRIPTION
- now, when there is already partial information about the household (duties), the "get infos" procedure correctly defined the household_id column