### PR TITLE
CO-3543

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -492,7 +492,8 @@ class EventCompassion(models.Model):
             "user_id": self.user_id.id,
             "partner_ids": [
                 (6, 0, (self.staff_ids |
-            #             self.partner_id |  #commented to avoid partner to get notified with meeting invite
+                        # self.partner_id |  has been commented to avoid
+                        # partner to get notified with meeting invites
                         self.user_id.partner_id).ids)],
             "start": self.start_date,
             "stop": self.end_date or self.start_date,

--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -492,7 +492,7 @@ class EventCompassion(models.Model):
             "user_id": self.user_id.id,
             "partner_ids": [
                 (6, 0, (self.staff_ids |
-                        self.partner_id |
+            #             self.partner_id |  #commented to avoid partner to get notified with meeting invite
                         self.user_id.partner_id).ids)],
             "start": self.start_date,
             "stop": self.end_date or self.start_date,


### PR DESCRIPTION
Not possible to remove only emails or attendees from the calendar.event.
So I just commented the partner_id to prevent him to be added to the calendar.event.