### PR TITLE
CO-3481 Adding GDPR route and compatibility with My Account

### DIFF
--- a/partner_communication/models/res_partner.py
+++ b/partner_communication/models/res_partner.py
@@ -27,7 +27,6 @@ class ResPartner(models.Model):
         default="auto_digital",
         required=True,
         help="Delivery preference for Global Communication",
-        groups="base.group_user",
     )
     communication_count = fields.Integer(
         compute="_compute_comm_count", groups="base.group_user"

--- a/sponsorship_compassion/__init__.py
+++ b/sponsorship_compassion/__init__.py
@@ -8,6 +8,8 @@
 #
 ##############################################################################
 
+from . import controllers
+from . import forms
 from . import models
 from . import wizards
 from odoo.addons.message_center_compassion.tools.load_mappings \

--- a/sponsorship_compassion/__manifest__.py
+++ b/sponsorship_compassion/__manifest__.py
@@ -36,6 +36,7 @@
     "website": "http://www.compassion.ch",
     "depends": [
         "recurring_contract",  # compassion-accounting
+        "cms_form_compassion",  # compassion-modules
         "utm",
         "crm",
         "child_compassion",

--- a/sponsorship_compassion/controllers/__init__.py
+++ b/sponsorship_compassion/controllers/__init__.py
@@ -1,0 +1,10 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from . import privacy_statement

--- a/sponsorship_compassion/controllers/privacy_statement.py
+++ b/sponsorship_compassion/controllers/privacy_statement.py
@@ -1,0 +1,86 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from odoo import http, _
+from odoo.http import request
+
+from odoo.addons.cms_form.controllers.main import FormControllerMixin
+
+
+class PrivacyStatementController(http.Controller, FormControllerMixin):
+    @http.route(
+        route="/partner/<string:reg_uid>/privacy-statement-agreement",
+        auth="public",
+        website=True,
+    )
+    def privacy_statement_agreement(
+            self, reg_uid, form_id=None, redirect=None, **kwargs
+    ):
+        """
+        This page allows a partner to sign the child protection charter.
+        :param reg_uid: The uuid associated with the partner.
+        :param form_id:
+        :param redirect: The redirection link for the confirmation page.
+        :param kwargs: The remaining query string parameters.
+        :return: The rendered web page.
+        """
+        # Need sudo() to bypass domain restriction on res.partner for anonymous
+        # users.
+        partner = request.env["res.partner"].sudo().search([("uuid", "=", reg_uid)])
+
+        if not partner:
+            return request.redirect("/")
+
+        values = kwargs.copy()
+
+        privacy_statement_id = request.env["compassion.privacy.statement"]\
+            .sudo().search([]).sorted("version")[:1]
+        if not privacy_statement_id:
+            raise ValueError("There is no privacy statement in database.")
+
+        values["privacy_statement_id"] = privacy_statement_id
+
+        form_model_key = "cms.form.partner.privacy.statement"
+        # Do not use self.get_form() because it does not have sufficient rights
+        # to search for the partner object (by the id).
+        privacy_statement_form = request.env[form_model_key].form_init(
+            request, main_object=partner, **values
+        )
+        privacy_statement_form.form_process()
+
+        partner.env.clear()
+        values.update(
+            {
+                "partner": partner,
+                "privacy_statement_form": privacy_statement_form,
+            }
+        )
+
+        if partner.privacy_statement_ids:
+            confirmation_message = _(
+                "We successfully received your agreement to the Privacy "
+                "Statement."
+            )
+
+            values.update(
+                {
+                    "confirmation_title": _("Thank you!"),
+                    "confirmation_message": confirmation_message,
+                    "redirect": redirect,
+                }
+            )
+            return request.render(
+                "sponsorship_compassion." +
+                "privacy_statement_agreement_confirmation_page",
+                values,
+            )
+        else:
+            return request.render(
+                "sponsorship_compassion.privacy_statement_agreement_page", values
+            )

--- a/sponsorship_compassion/forms/__init__.py
+++ b/sponsorship_compassion/forms/__init__.py
@@ -1,0 +1,10 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from . import agreement_privacy_statement_form

--- a/sponsorship_compassion/forms/agreement_privacy_statement_form.py
+++ b/sponsorship_compassion/forms/agreement_privacy_statement_form.py
@@ -1,0 +1,82 @@
+##############################################################################
+#
+#    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
+#    @author: Théo Nikles <theo.nikles@gmail.com>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+from datetime import datetime
+
+from odoo.http import request
+from odoo import models, fields, _
+
+
+class PrivacyStatementForm(models.AbstractModel):
+    """ Form to display the privacy statement and make the user accept it.
+     The statement id that is displayed should be passed to the method
+     form_init using the key privacy_statement_id """
+
+    _name = "cms.form.partner.privacy.statement"
+    _inherit = "cms.form"
+
+    _form_model = "res.partner"
+
+    privacy_statement_id = None
+    privacy_statement_agreement = fields.Boolean(
+        "Check to agree to the privacy statement"
+    )
+
+    _form_model_fields = ["privacy_statement_agreement"]
+    _form_required_fields = ["privacy_statement_agreement"]
+
+    def form_init(self, req, main_object=None, **kw):
+        form = super(PrivacyStatementForm, self).form_init(
+            req, main_object, **kw
+        )
+        form.privacy_statement_id = kw["privacy_statement_id"]
+        return form
+
+    @property
+    def form_msg_success_updated(self):
+        return _("Thank you for reading the privacy statement carefully.")
+
+    @property
+    def _form_fieldsets(self):
+        return [
+            {
+                "id": "agreements",
+                "description": _(
+                    "I acknowledge that I have read and "
+                    "fully understood the content of the privacy statement. "
+                    "I agree with all the conditions mentioned above. "
+                    "If I do not comply with these conditions,"
+                    "Compassion reserves the right to deactivate my "
+                    "translator account and cancel my sponsorships."
+                ),
+                "fields": ["privacy_statement_agreement"],
+            }
+        ]
+
+    def form_cancel_url(self, main_object=None):
+        """URL to redirect to after click on "cancel" button."""
+        redirect = request.httprequest.args.get("redirect")
+        return redirect if redirect else request.httprequest.full_path
+
+    def form_before_create_or_update(self, write_values, extra_values):
+        pass
+
+    def form_after_create_or_update(self, values, extra_values):
+        if extra_values.get("privacy_statement_agreement"):
+            agreement = request.env["privacy.statement.agreement"].sudo()\
+                .create({
+                    "partner_id": self.main_object.id,
+                    "agreement_date": datetime.today(),
+                    "privacy_statement_id": self.privacy_statement_id.id,
+                    "version": self.privacy_statement_id.version,
+                    "origin_signature": "my_account",
+                })
+            self.main_object.write({
+                "privacy_statement_ids": [(6, 0, [agreement.id])]
+            })

--- a/sponsorship_compassion/models/privacy_statement.py
+++ b/sponsorship_compassion/models/privacy_statement.py
@@ -58,6 +58,7 @@ class PrivacyStatementAgreement(models.Model):
     origin_signature = fields.Selection(
         [
             ("new_letter", "Website new letter"),
+            ("my_account", "Website My Account"),
             ("new_sponsorship", "Website new sponsorship"),
             ("new_gift", "Website new gift"),
             ("first_payment", "First payment"),

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -209,7 +209,7 @@ class ResPartner(models.Model):
         # Retrieve all the categories and check if one is Church
         church_category = (
             self.env["res.partner.category"]
-                .with_context(lang="en_US")
+                .with_context(lang="en_US").sudo()
                 .search([("name", "=", "Church")], limit=1)
         )
         for record in self:

--- a/sponsorship_compassion/views/privacy_statement.xml
+++ b/sponsorship_compassion/views/privacy_statement.xml
@@ -1,6 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <odoo>
+    <!-- Confirmation page -->
+    <template id="privacy_statement_agreement_confirmation_page" name="Privacy Statement Agreement Confirmation Page">
+        <t t-call="website.layout">
+            <t t-set="head">
+                <meta name="robots" content="noindex"/>
+            </t>
+            <div id="wrap">
+                <div class="container">
+                    <div class="row mb32">
+                        <div class="col-md-9">
+                            <h2 t-esc="confirmation_title"/>
+                            <div class="jumbotron">
+                                <p t-raw="confirmation_message"/>
+                                <t t-if="redirect">
+                                    <p>
+                                        <a class="btn btn-primary" t-attf-href="#{redirect}">Return</a>
+                                    </p>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="row mb32">
+                        <div class="col-md-9">
+                            <!-- Privacy Statement Text Accordion -->
+                            <div class="panel-group" id="accordion-privacy-statement" role="tablist" aria-multiselectable="true">
+                                <div class="panel panel-default">
+                                    <div class="panel-heading" role="tab" id="heading-privacy-statement">
+                                        <h4 class="panel-title">
+                                            <b>
+                                                <a role="button" data-toggle="collapse" data-parent="accordion-privacy-statement" href="#collapse-privacy-statement" aria-expanded="true" aria-controls="collapse-contract">Privacy Statement agreement</a>
+                                            </b>
+                                        </h4>
+                                    </div>
+                                    <div id="collapse-privacy-statement" t-attf-class="panel-collapse collapse" role="tabpanel" aria-labelledby="heading-privacy-statement">
+                                        <div class="panel-body">
+                                            <t t-raw="privacy_statement_id.text"/>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="oe_structure"/>
+            </div>
+        </t>
+    </template>
+
+
+    <template id="privacy_statement_agreement_page" name="Privacy Statement Agreement">
+        <t t-call="website.layout">
+            <t t-set="head">
+                <meta name="robots" content="noindex"/>
+            </t>
+            <div id="wrap">
+                <div class="container">
+                    <div class="row mb32">
+                        <div class="col-md-9">
+                            <div class="panel-body cms_form_wrapper">
+                                <t t-raw="privacy_statement_id.text"/>
+
+                                <!-- Privacy Statement Form -->
+                                <t t-raw="privacy_statement_form.form_render()"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="oe_structure"/>
+            </div>
+        </t>
+    </template>
+
     <record id="res_personal_data_agreement_tree" model="ir.ui.view">
         <field name="name">Privacy Statement Tree View</field>
         <field name="model">compassion.privacy.statement</field>


### PR DESCRIPTION
This _PR_ adds a route for the _GDPR_, based on how it is done for the _child protection charter_, as well as some functionalities required for _My Account_ to work properly.

It is parallel to: https://github.com/CompassionCH/compassion-switzerland/pull/1269 (draft)