### PR TITLE
Re opening status

### DIFF
--- a/child_compassion/__manifest__.py
+++ b/child_compassion/__manifest__.py
@@ -58,6 +58,7 @@
         "views/notification_settings_view.xml",
         "views/child_pictures_view.xml",
         "views/demand_planning.xml",
+        "views/fcp_covid_status.xml",
         "views/res_lang_compassion_view.xml",
         "views/child_or_fcp_property_view.xml",
         "data/validity_checks_cron.xml",

--- a/child_compassion/models/__init__.py
+++ b/child_compassion/models/__init__.py
@@ -8,6 +8,7 @@ from . import child_assessment
 from . import child_lifecycle_event
 from . import household
 from . import fcp_property
+from . import fcp_covid_status_update
 from . import lang_compassion
 from . import project_lifecycle_event
 from . import global_partner

--- a/child_compassion/models/fcp_covid_status_update.py
+++ b/child_compassion/models/fcp_covid_status_update.py
@@ -1,0 +1,35 @@
+##############################################################################
+#
+#    Copyright (C) 2020 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: David Wulliamoz <dwulliamoz@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+
+
+from odoo import models, fields, api
+from datetime import datetime
+
+
+class ProjectCovidStatus(models.Model):
+    _name = "compassion.project.covid_update"
+    _description = "Project covid status"
+    _order = "update_date,id desc"
+
+    fcp_id = fields.Many2one(
+        "compassion.project", required=True, ondelete="cascade"
+    )
+    update_date = fields.Date("updated on", default=fields.Date.today)
+    re_opening_status = fields.Selection(
+        [
+            ("Distance Only (Calls etc)", "Distance Only (Calls etc)"),
+            ("Home Visits Only", "Home Visits Only"),
+            ("Meeting in Small Groups", "Meeting in Small Groups"),
+            ("Normal Program Activities", "Normal Program Activities"),
+        ],
+
+    )
+    comments = fields.Char()
+

--- a/child_compassion/models/fcp_covid_status_update.py
+++ b/child_compassion/models/fcp_covid_status_update.py
@@ -9,8 +9,7 @@
 ##############################################################################
 
 
-from odoo import models, fields, api
-from datetime import datetime
+from odoo import models, fields
 
 
 class ProjectCovidStatus(models.Model):
@@ -22,14 +21,5 @@ class ProjectCovidStatus(models.Model):
         "compassion.project", required=True, ondelete="cascade"
     )
     update_date = fields.Date("updated on", default=fields.Date.today)
-    re_opening_status = fields.Selection(
-        [
-            ("Distance Only (Calls etc)", "Distance Only (Calls etc)"),
-            ("Home Visits Only", "Home Visits Only"),
-            ("Meeting in Small Groups", "Meeting in Small Groups"),
-            ("Normal Program Activities", "Normal Program Activities"),
-        ],
-
-    )
+    re_opening_status = fields.Char()
     comments = fields.Char()
-

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -336,7 +336,8 @@ class CompassionProject(models.Model):
         "compassion.project.ile", "project_id", "Lifecycle events", readonly=True
     )
     covid_status_ids = fields.One2many(
-        "compassion.project.covid_update", "fcp_id", "FCP Re-opening Status", readonly=True
+        "compassion.project.covid_update",
+        "fcp_id", "FCP Re-opening Status", readonly=True
     )
 
     suspension = fields.Selection(
@@ -374,17 +375,10 @@ class CompassionProject(models.Model):
     ######################
     description_en = fields.Text("English description", readonly=True)
 
-    re_opening_status = fields.Selection(
-        [
-            ("Distance Only (Calls etc)", "Distance Only (Calls etc)"),
-            ("Home Visits Only", "Home Visits Only"),
-            ("Meeting in Small Groups", "Meeting in Small Groups"),
-            ("Normal Program Activities", "Normal Program Activities"),
-        ],
-        compute="_compute_re_opening_state",
-        store=True,
-        track_visibility="onchange",
-    )
+    re_opening_status = fields.Char(compute="_compute_re_opening_state",
+                                    store=True,
+                                    track_visibility="onchange",
+                                    )
 
     ##########################################################################
     #                             FIELDS METHODS                             #
@@ -418,7 +412,6 @@ class CompassionProject(models.Model):
     def _compute_re_opening_state(self):
         for project in self.filtered("covid_status_ids"):
             project.re_opening_status = project.covid_status_ids[0].re_opening_status
-
 
     @api.model
     def _get_materials(self):
@@ -547,9 +540,9 @@ class CompassionProject(models.Model):
     @api.multi
     def get_activities(self, field, max_int=float("inf")):
         all_activities = (
-            self.mapped(field + "_babies_ids")
-            + self.mapped(field + "_kids_ids")
-            + self.mapped(field + "_ados_ids")
+                self.mapped(field + "_babies_ids")
+                + self.mapped(field + "_kids_ids")
+                + self.mapped(field + "_ados_ids")
         ).sorted()
         return all_activities[:max_int].mapped("value")
 

--- a/child_compassion/security/ir.model.access.csv
+++ b/child_compassion/security/ir.model.access.csv
@@ -62,3 +62,4 @@ access_gmc_message,Access gmc.message,message_center_compassion.model_gmc_messag
 access_gmc_mapping,Access compassion.mapping,message_center_compassion.model_compassion_mapping,group_sponsorship,1,0,0,0
 access_gmc_field_to_json,Access field.to.json,message_center_compassion.model_compassion_field_to_json,group_sponsorship,1,0,0,0
 access_gmc_action,Access gmc.action,message_center_compassion.model_gmc_action,group_sponsorship,1,0,0,0
+access_compassion_covid_update,Full access on compassion_covid_update,model_compassion_project_covid_update,group_sponsorship,1,1,1,1

--- a/child_compassion/views/fcp_covid_status.xml
+++ b/child_compassion/views/fcp_covid_status.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_compassion_project_covid_tree" model="ir.ui.view">
+        <field name="name">compassion.project.covid_update.tree</field>
+        <field name="model">compassion.project.covid_update</field>
+        <field name="arch" type="xml">
+            <tree string="FCP Re-opening Status">
+                <field name="fcp_id" />
+                <field name="update_date" />
+                <field name="re_opening_status" />
+                <field name="comments" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="open_view_project_covid_tree" model="ir.actions.act_window">
+        <field name="name">Covid status</field>
+        <field name="res_model">compassion.project.covid_update</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+        <field name="view_id" ref="view_compassion_project_covid_tree"/>
+    </record>
+
+    <menuitem id="menu_sponsorship_project_covid" parent="menu_field_section" name="Projects covid status" action="open_view_project_covid_tree" sequence="3"/>
+</odoo>

--- a/child_compassion/views/project_compassion_view.xml
+++ b/child_compassion/views/project_compassion_view.xml
@@ -50,6 +50,15 @@
                                     <field name="nb_csp_kids"/>
                                     <field name="nb_cdsp_kids"/>
                                 </group>
+                                <group string="FCP Re-opening Status">
+                                    <field name="covid_status_ids">
+                                        <tree>
+                                            <field name="update_date"/>
+                                            <field name="re_opening_status"/>
+                                            <field name="comments"/>
+                                        </tree>
+                                    </field>
+                                </group>
                                 <group string="Lifecycle">
                                     <field name="lifecycle_ids">
                                         <tree>
@@ -202,6 +211,7 @@
             <tree string="project">
                 <field name="name" />
                 <field name="fcp_id" />
+                <field name="re_opening_status" />
                 <field name="last_update_date" />
                 <field name="suspension" />
             </tree>


### PR DESCRIPTION
Re-opening Status fields/object to track covid pandemic phase-out in fcp's

- use re-opening-status select option as in xlsx provided (no short name for db)
- ability to import directly with the xlsx provided by GMC (import only the first tab... though) 
- data needs to be cleaned before import (no blank in the reopening status column)
