### PR TITLE
change for muskathlon portal and together portal access.

### DIFF
--- a/cms_form_compassion/models/widgets.py
+++ b/cms_form_compassion/models/widgets.py
@@ -93,10 +93,10 @@ class CHDateWidget(models.AbstractModel):
     def get_placeholder(self):
         # Get correct placeholder depending on language
         placeholders = {
-            "fr_CH": "JJ.MM.AA",
-            "de_DE": "TT.MM.JJ",
-            "it_IT": "GG.MM.AA",
-            "en_US": "DD.MM.YY",
+            "fr_CH": "JJ.MM.AAAA",
+            "de_DE": "TT.MM.JJJJ",
+            "it_IT": "GG.MM.AAAA",
+            "en_US": "DD.MM.YYYY",
         }
         return placeholders.get(self.env.lang)
 

--- a/mobile_app_connector/security/access_rules.xml
+++ b/mobile_app_connector/security/access_rules.xml
@@ -33,7 +33,7 @@
     <record id="my_contacts" model="ir.rule">
         <field name="name">My contacts</field>
         <field name="model_id" ref="model_res_partner"/>
-        <field name="domain_force">[('id', 'in', (user.partner_id.mapped('sponsorship_ids.correspondent_id')+user.partner_id.mapped('sponsorship_ids.partner_id')).ids)]</field>
+        <field name="domain_force">[('id', 'in', (user.partner_id.mapped('sponsorship_ids.correspondent_id')+user.partner_id.mapped('sponsorship_ids.partner_id')+user.partner_id.mapped('church_id')).ids)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="False"/>

--- a/mobile_app_connector/security/ir.model.access.csv
+++ b/mobile_app_connector/security/ir.model.access.csv
@@ -54,3 +54,4 @@ access_user_field_office,access_user_field_office,model_compassion_field_office,
 access_field_office,access_field_office,model_compassion_field_office,base.group_portal,1,0,0,0
 access_user_learning_info,access_user_learning_info,child_compassion.model_field_office_learning,base.group_user,1,0,0,0
 access_learning_info,access_learning_info,child_compassion.model_field_office_learning,base.group_portal,1,0,0,0
+access_compassion_mapping_portal_user,access_compassion_mapping,model_compassion_mapping,base.group_portal,1,0,0,0


### PR DESCRIPTION
- change the helper of the date, to match the format required
- add rule for portal access: read access on the church record link to the portal user
- add rule for portal access: read access on the compassion.mapping

those two last rules are already configured in production
