### PR TITLE
CO-3521 fix hour reset to 01:00 on event creation

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -243,9 +243,9 @@ class EventCompassion(models.Model):
         - Create an origin for sponsorships.
         """
         # Avoid putting twice the date in linked objects name
+        event_year = str(datetime.today().year)
         if vals.get("start_date") and isinstance(vals["start_date"], str):
-            vals["start_date"] = fields.Date.from_string(vals["start_date"])
-        event_year = str(vals.get("start_date", datetime.today()).year)
+            event_year = str(fields.Date.from_string(vals["start_date"]).year)
         event_name = vals.get("name", "0000")
         if event_name[-4:] == event_year:
             vals["name"] = event_name[:-4]


### PR DESCRIPTION
start date was reset with the return of _fields.Date.from_string_. Often date conversion applies on date only (not hour). storing the value on an other variable did the trick