### PR TITLE
CO-3544 linking existing leave to new attendance day require sudo

### DIFF
--- a/hr_attendance_management/models/hr_holidays.py
+++ b/hr_attendance_management/models/hr_holidays.py
@@ -36,7 +36,7 @@ class HrLeave(models.Model):
                 ]
             )
 
-            rd.attendance_day_ids = att_days
+            rd.sudo().attendance_day_ids = att_days
 
             for att_day in att_days:
                 att_day.leave_ids = att_day.leave_ids | self


### PR DESCRIPTION
When a new attendance day is created during an employee's leave it is then linked to the existing leave trough a computation function. writing on a leave require a sudo elevation that employees might not have thus creating the permission issue.  