### PR TITLE
CO-3582 explicitly specify state for child after release

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -671,7 +671,14 @@ class CompassionChild(models.Model):
     @api.multi
     def child_released(self, state="R"):
         """ Is called when a child is released to the global childpool. """
-        self.write({"sponsor_id": False, "state": state, "hold_id": False})
+        # if the state is consigned we want to keep to link to the hold.
+        remove_link_to_hold = state not in ["N"]
+
+        update_dic = {"sponsor_id": False, "state": state}
+        if remove_link_to_hold:
+            update_dic.update({"hold_id": False})
+
+        self.write(update_dic)
         # Check if it was a depart and retrieve lifecycle event
         self.get_lifecycle_event()
 

--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -592,7 +592,7 @@ class SponsorshipContract(models.Model):
                 if contract.child_id.sponsor_id == contract.correspondent_id:
                     child = contract.child_id.with_context({})
                     child.child_unsponsored()
-                    child.child_released()
+                    child.child_released('N')
         return super().unlink()
 
     ##########################################################################


### PR DESCRIPTION
When a sponsorship end while in draft state the desire target state for the child after release should be passed to the function `child_realease()`. The desire state in this case is `'N'` (consigned)