### PR TITLE
CO-3522 correct amount computation in thank you letters

### DIFF
--- a/thankyou_letters/models/account_invoice_line.py
+++ b/thankyou_letters/models/account_invoice_line.py
@@ -53,6 +53,10 @@ class AccountInvoiceLine(models.Model):
             )
             if len(product_configs) == 1:
                 communication_config = product_configs[0]
+                # avoid taking into account lines with no communication config defined (amount would be wrong)
+                invoice_lines = invoice_lines.filtered(
+                    lambda x: x.product_id.partner_communication_config == communication_config)
+
             else:
                 _logger.warning(
                     f"{len(product_configs)} product thank you config found, "


### PR DESCRIPTION
Bug append when :

- Invoice with multiple lines
- A single type of communication config is found but some lines have undefined communication config

All lines where use to compute total donated amount although only a portion of them where directed to the fund
mentioned by the only communication config found. 

Solution:

When a single config is found filter the lines to make sure that we only take into consideration
lines with given communication config