### PR TITLE
AP-378 add language to registration objects

### DIFF
--- a/firebase_connector/controllers/firebase_controller.py
+++ b/firebase_connector/controllers/firebase_controller.py
@@ -32,8 +32,8 @@ def verify_and_retrieve(registration_id, partner_id=None):
             raise Unauthorized()
     existing = (
         request.env["firebase.registration"]
-        .sudo()
-        .search([("registration_id", "=", registration_id)])
+            .sudo()
+            .search([("registration_id", "=", registration_id)])
     )
 
     assert len(existing) < 2, "Two firebase registration with same id"
@@ -44,16 +44,31 @@ class RestController(http.Controller):
     @http.route(
         "/firebase/register", type="http", methods=["PUT"], auth="public", csrf=False
     )
-    def firebase_register(self, registration_id, partner_id=None, **kwargs):
+    def firebase_register(self, registration_id, partner_id=None, language=None, **kwargs):
         existing = verify_and_retrieve(registration_id, partner_id)
         if existing:
             existing.partner_id = partner_id
         else:
+
+            languages_map = {
+                "en": "en_US",
+                "fr": "fr_CH",
+                "de": "de_DE",
+                "it": "it_IT",
+            }
+
+            partner_lang = request.env.user.partner_id.lang if partner_id else False
+
+            # get the communication language.
+            communication_language = partner_lang if partner_lang else languages_map.get(language, False)
+
             existing = (
                 request.env["firebase.registration"]
-                .sudo()
-                .create(
-                    {"registration_id": registration_id, "partner_id": partner_id, })
+                    .sudo()
+                    .create(
+                    {"registration_id": registration_id,
+                     "partner_id": partner_id,
+                     "language": communication_language})
             )
 
         return str(existing.id)

--- a/firebase_connector/models/firebase_notification.py
+++ b/firebase_connector/models/firebase_notification.py
@@ -66,6 +66,11 @@ class FirebaseNotification(models.Model):
         string="Partner read status of the notification",
         readonly=True,
     )
+    language = fields.Selection([('fr_CH', 'French'),
+                                 ('de_DE', 'German'),
+                                 ('it_IT', 'Italian'),
+                                 ('en_US', 'English')], required=True)
+
     res_model = fields.Char()
     res_id = fields.Integer()
     test_mode = fields.Boolean()
@@ -142,6 +147,11 @@ class FirebaseNotification(models.Model):
                     [("partner_id", "=", False)]
                 )
 
+            # filter registration based on language
+            if notif.language:
+                registration_ids = registration_ids.filtered(
+                    lambda reg: not reg.language or reg.language == notif.language)
+
             kwargs.update({
                 "notification_id": str(notif.id),
                 "title": notif.title, "body": notif.body
@@ -160,7 +170,7 @@ class FirebaseNotification(models.Model):
                         self.env["firebase.notification.partner.read"].create([
                             {"partner_id": partner.id, "notification_id": notif.id}
                             for partner in registration_ids[i: i + split].exists()
-                            .mapped("partner_id")
+                                .mapped("partner_id")
                         ])
                         self.env.cr.commit()
                 notif.sent = status_ok

--- a/firebase_connector/models/firebase_notification.py
+++ b/firebase_connector/models/firebase_notification.py
@@ -66,11 +66,7 @@ class FirebaseNotification(models.Model):
         string="Partner read status of the notification",
         readonly=True,
     )
-    language = fields.Selection([('fr_CH', 'French'),
-                                 ('de_DE', 'German'),
-                                 ('it_IT', 'Italian'),
-                                 ('en_US', 'English')], required=True)
-
+    language = fields.Selection("_get_lang")
     res_model = fields.Char()
     res_id = fields.Integer()
     test_mode = fields.Boolean()

--- a/firebase_connector/models/firebase_notification.py
+++ b/firebase_connector/models/firebase_notification.py
@@ -78,6 +78,11 @@ class FirebaseNotification(models.Model):
     failed_ratio = fields.Integer(compute="_compute_statistics")
     opened_ratio = fields.Integer(compute="_compute_statistics")
 
+    @api.model
+    def _get_lang(self):
+        langs = self.env["res.lang"].search([])
+        return [(l.code, l.name) for l in langs]
+
     @api.onchange('stage_id')
     def onchange_stage_id(self):
         for notification in self:

--- a/firebase_connector/models/firebase_registration.py
+++ b/firebase_connector/models/firebase_registration.py
@@ -29,6 +29,7 @@ class FirebaseRegistration(models.Model):
     registration_id = fields.Char("Firebase Registration ID", required=True, index=True)
     partner_id = fields.Many2one("res.partner", "Partner", readonly=False)
     partner_name = fields.Char(related="partner_id.name", readonly=True)
+    language = fields.Char()
 
     _sql_constraints = [
         (

--- a/firebase_connector/views/firebase_notification.xml
+++ b/firebase_connector/views/firebase_notification.xml
@@ -53,6 +53,7 @@
                     <group>
                         <field name="title" attrs="{'readonly': [('sent', '=', True)]}"/>
                         <field name="body" attrs="{'readonly': [('sent', '=', True)]}"/>
+                        <field name="language" attrs="{'readonly': [('sent', '=', True)]}"/>
                         <field name="send_date" attrs="{'readonly': [('sent', '=', True)]}"/>
                         <field name="send_to_logged_out_devices" attrs="{'readonly': [('sent', '=', True)]}"/>
                         <field name="test_mode"/>

--- a/firebase_connector/views/firebase_registration.xml
+++ b/firebase_connector/views/firebase_registration.xml
@@ -9,6 +9,7 @@
                     <group>
                         <field name="partner_id"/>
                         <field name="registration_id"/>
+                        <field name="language"/>
                         <button class="oe_inline oe_stat_button"
                                 string="Send Notification"
                                 type="object"
@@ -29,6 +30,7 @@
             <tree>
                 <field name="partner_name"/>
                 <field name="registration_id"/>
+                <field name="language"/>
             </tree>
         </field>
     </record>

--- a/mobile_app_connector/models/firebase_registration.py
+++ b/mobile_app_connector/models/firebase_registration.py
@@ -124,14 +124,8 @@ class GetPartnerMessage(models.Model):
 
         firebase_id = params["firebaseId"]
         operation = params["operation"]
-        partner_id = params.get("supId", None)
-        language = params.get("language", None)
-
-        if partner_id == "":
-            partner_id = None
-
-        if language == "":
-            language = None
+        partner_id = params.get("supId") or None
+        language = params.get("language") or None
 
         _logger.debug(
             operation

--- a/mobile_app_connector/models/firebase_registration.py
+++ b/mobile_app_connector/models/firebase_registration.py
@@ -125,8 +125,14 @@ class GetPartnerMessage(models.Model):
         firebase_id = params["firebaseId"]
         operation = params["operation"]
         partner_id = params.get("supId", None)
+        language = params.get("language", None)
+
         if partner_id == "":
             partner_id = None
+
+        if language == "":
+            language = None
+
         _logger.debug(
             operation
             + "ing a Firebase ID from partner id: "
@@ -137,7 +143,7 @@ class GetPartnerMessage(models.Model):
 
         if operation == "Insert":
             response = Firebase().firebase_register(
-                registration_id=firebase_id, partner_id=partner_id,
+                registration_id=firebase_id, partner_id=partner_id,language=language
             )
         elif operation == "Delete":
             response = Firebase().firebase_unregister(


### PR DESCRIPTION
Server changes to handle firebase registration language. 
a notification must be created with a language. on send each registration is filter with the notification language