### PR TITLE
CO-3610 change won sponsorship count

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -353,6 +353,11 @@ class EventCompassion(models.Model):
                 event.calendar_event_id = calendar_event
         return True
 
+    @api.multi
+    def force_update_won_sponsorships_count(self):
+        for event in self:
+            event.origin_id._compute_won_sponsorships()
+
     ##########################################################################
     #                             VIEW CALLBACKS                             #
     ##########################################################################

--- a/crm_compassion/views/event_compassion_view.xml
+++ b/crm_compassion/views/event_compassion_view.xml
@@ -148,6 +148,17 @@
         </field>
     </record>
 
+    <record id="action_update_won_sponsorships_count" model="ir.actions.server">
+        <field name="name">Update won sponsorship count</field>
+        <field name="type">ir.actions.server</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="model_crm_event_compassion"/>
+        <field name="binding_model_id" ref="model_crm_event_compassion"/>
+        <field name="code">
+            records.force_update_won_sponsorships_count()
+        </field>
+    </record>
+
     <!-- Sidebar action, called from menu_recurring_contract_form menuitem -->
     <record id="action_events_compassion" model="ir.actions.act_window">
         <field name="name">Events</field>

--- a/sponsorship_compassion/models/contract_origin.py
+++ b/sponsorship_compassion/models/contract_origin.py
@@ -103,8 +103,10 @@ class ContractOrigin(models.Model):
     @api.multi
     def _compute_won_sponsorships(self):
         for origin in self.filtered("contract_ids"):
-            contract_ids = origin.contract_ids
-            origin.won_sponsorships = len(contract_ids)
+            # not tacking sponsors with parent_id or in cancelled state.
+            contract_ids = origin.contract_ids.filtered(lambda c: not c.parent_id)
+            origin.won_sponsorships = len(contract_ids.filtered(lambda c: c.state != "cancelled"))
+            # sponsor who cancelled their sponsorship are used to compute conversion_rate to avoid bias
             origin.conversion_rate = (
                 len(contract_ids.filtered("activation_date"))
                 / float(len(contract_ids))


### PR DESCRIPTION
- count only sponsorship not cancelled and with no parent_id
- add an action in backend to update old event where computed field wouldn't be triggered anymore