### PR TITLE
CO-3644 add a default sentence if no thanks_name were found

### DIFF
--- a/mobile_app_connector/models/account_invoice.py
+++ b/mobile_app_connector/models/account_invoice.py
@@ -177,6 +177,7 @@ class AccountInvoice(models.Model):
         lines = self.mapped("invoice_line_ids").with_context(context)
         children = lines.mapped("contract_id.child_id")
         amount, for_text = lines.get_donations()
+        for_text = for_text or _("one of our fund")
         if children:
             if len(children) > 1:
                 for_text = children.get_number()


### PR DESCRIPTION
add a translatable default text. This text is used by default if no thanks_name were found