### PR TITLE
CO-3679 add a cron to remind user of unaddressed support request

### DIFF
--- a/crm_request/__manifest__.py
+++ b/crm_request/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
     "category": "CRM",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.0.1",
     # Python dependencies
     "external_dependencies": {"python": ["detectlanguage"]},
     # any module necessary for this one to work correctly
@@ -24,6 +24,7 @@
         "data/request_email_template.xml",
         "data/crm_request_data.xml",
         "data/request_sequence.xml",
+        "data/ir_cron.xml",
         "views/request.xml",
         "views/request_category.xml",
         "views/holiday_automated_response_view.xml",

--- a/crm_request/data/ir_cron.xml
+++ b/crm_request/data/ir_cron.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <record id="crm_request_reminder_cron" model="ir.cron">
+            <field name="name">Send weekly reminder to user for new or waiting support request</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+            <field name="numbercall">-1</field>
+            <field name="active" eval="True"/>
+            <field name="model_id" ref="crm_claim.model_crm_claim"/>
+            <field name="state">code</field>
+            <field name="code">model.cron_reminder_request()</field>
+        </record>
+    </data>
+</odoo>

--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -3,6 +3,7 @@
 
 import logging
 from email.utils import parseaddr
+from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, exceptions, _
 from odoo.tools import config
@@ -320,7 +321,8 @@ class CrmClaim(models.Model):
 
         request_to_notify = self.search([
             ("stage_id", "in", [new_stage_id, wait_support_stage_id]),
-            ("user_id", "!=", False)
+            ("user_id", "!=", False),
+            ("write_date", "<", fields.datetime.now() - relativedelta(weeks=1))
         ])
 
         for req in request_to_notify:


### PR DESCRIPTION
Use activity schedule to send a mail to user with unaddressed support issue
cron is executed each week