### PR TITLE
CS-493 Emails info@ handled when employee in holiday

### DIFF
--- a/crm_request/__manifest__.py
+++ b/crm_request/__manifest__.py
@@ -7,7 +7,7 @@
     "license": "AGPL-3",
     "website": "http://www.compassion.ch",
     "category": "CRM",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.1.1",
     # Python dependencies
     "external_dependencies": {"python": ["detectlanguage", "pandas"]},
     # any module necessary for this one to work correctly

--- a/crm_request/data/request_email_template.xml
+++ b/crm_request/data/request_email_template.xml
@@ -1,5 +1,6 @@
 <odoo>
     <data noupdate="1">
+        <!-- Template email when business is closed for holiday -->
         <record id="business_closed_email_template" model="mail.template">
             <field name="name">Holiday - Automated response</field>
             <field name="model_id" ref="model_crm_claim"/>
@@ -22,6 +23,34 @@
                     <br/>
                     <br/>
                     ${closure.signature | safe}
+                </div>
+            </field>
+        </record>
+
+        <!-- Template email when assigned contact is in holiday -->
+        <record id="assigned_contact_holiday_email_template" model="mail.template">
+            <field name="name">Assigned contact in holiday</field>
+            <field name="model_id" ref="model_crm_claim"/>
+            <field name="email_from">"${object.user_id.company_id.name}" &lt;compassion@compassion.ch&gt;</field>
+            <field name="email_to">${object.email_from}</field>
+            <field name="lang">${object.language}</field>
+            <field name="reply_to">info@compassion.ch</field>
+            <field name="subject">Your assigned contact is in holiday</field>
+            <field name="body_html" type="html">
+                <div>
+                    % set claim = object
+                    % set partner = object.partner_id
+                </div>
+                <div>
+                    ${partner.salutation or "Dear friends of Compassion"},
+                    <br/>
+                    <br/>
+                    Your assigned contact at Compassion is currently in holiday. You might not have an answer before [his/her] return on the [return_date].
+                    If your request requires an urgent answer, please reply to this email or reach to us by phone.
+                    Thank you for your comprehension.
+                    <br/>
+                    <br/>
+                    Kind regards,
                 </div>
             </field>
         </record>


### PR DESCRIPTION
When an employee gets a reply from a partner during his/her holidays the request is set to new and unassigned to this employee so that someone else can take it on.

Added a new template for fast reply to inform partner of the situation.
/!\ This template needs to be translated!