### PR TITLE
CO-3802 Adapt payment forms for new payment gateway

### DIFF
--- a/cms_form_compassion/controllers/payment_controller.py
+++ b/cms_form_compassion/controllers/payment_controller.py
@@ -1,20 +1,20 @@
 ##############################################################################
 #
-#    Copyright (C) 2019 Compassion CH (http://www.compassion.ch)
+#    Copyright (C) 2019-2021 Compassion CH (http://www.compassion.ch)
 #    @author: Emanuel Cino <ecino@compassion.ch>
 #
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import json
-
 from werkzeug.exceptions import NotFound
 
 from odoo.exceptions import MissingError
-from odoo.http import request, route, Response, Controller
+from odoo.http import request, route
+
+from odoo.addons.account_payment.controllers.portal import PortalAccount
 
 
-class PaymentFormController(Controller):
+class PaymentFormController(PortalAccount):
 
     @route(
         ["/compassion/payment/invoice/<int:invoice_id>"],
@@ -24,75 +24,32 @@ class PaymentFormController(Controller):
         auth="public",
         sitemap=False,
     )
-    def payment_transaction(self, invoice_id, success_url=None, error_url=None,
-                            display_type="full", **kwargs):
+    def payment_transaction(self, invoice_id, return_url=None,
+                            access_token=None, **kwargs):
         """
         Payment route in order to pay an invoice, without using the default
         template showing the invoice. This is useful for donations or to be called
         from a cms.form where we don't need a recap on what the user will pay for.
         :param invoice_id:      id of the invoice to pay
-        :param success_url:     return page for success. If not provided, it will
-                                redirect to the default portal invoice view.
-        :param error_url:       return page for error. If not provided, it will
-                                redirect to the default portal invoice view.
-        :param display_type:    full/modal (useful for embedding the view in a modal
-                                form)
+        :param return_url:     return page after payment. If not provided, it will
+                               redirect to the default portal invoice view.
+        :param access_token:    access token for authorizing view when public user
         :param kwargs:          All other request parameters
         :return: Renders the page
         """
         try:
             invoice = request.env["account.invoice"].sudo().browse(invoice_id)
         except MissingError:
-            invoice = request.env["account.invoice"]
+            invoice = request.env["account.invoice"].sudo()
         if invoice.state == "paid":
             return request.render("cms_form_compassion.payment_already_done")
         if not invoice.exists():
             raise NotFound()
 
-        acquirers = request.env["payment.acquirer"].search([
-            ("website_published", "=", True),
-            ("company_id", "=", invoice.company_id.id)
-        ])
+        values = self._invoice_get_page_view_values(invoice, access_token, **kwargs)
         invoice_url = invoice.get_portal_url()
-        values = {
+        values.update({
             "invoice": invoice,
-            # Taken from /website_payment/pay route
-            "acquirers": [acq for acq in acquirers
-                          if acq.payment_flow in ['form', 's2s']],
-            "pms": request.env['payment.token'].search([
-                ('acquirer_id', 'in', acquirers.filtered(
-                    lambda x: x.payment_flow == 's2s').ids)]),
-            "success_url": success_url or invoice_url,
-            "error_url": error_url or invoice_url,
-        }
-        template = "payment_submit_full" if display_type == "full" else \
-            "modal_payment_submit"
-        return request.render(f"cms_form_compassion.{template}", values)
-
-    def _form_redirect(self, response, full_page=False):
-        """
-        Utility for payment form that are called by AJAX and can send back
-        a redirection. Instead of pushing back the redirection which will
-        fail over HTTPS, we wrap it inside JSON response and let the client
-        perform the redirection.
-        :param response: original response
-        :param full_page: optional parameter to force full page rendering
-                          (useful for modal forms that must close the modal)
-        :return: Response object for client
-        """
-        if response.status_code in (302, 303):
-            location = ""
-            if (
-                    response.status_code == 303
-                    and request.env.lang != request.website.default_lang_code
-            ):
-                # Prepend with lang, to avoid 302 redirection
-                location += "/" + request.env.lang
-            location += response.location
-            res = Response(
-                json.dumps({"redirect": location, "full_page": full_page}),
-                status=200,
-                mimetype="application/json",
-            )
-            return res
-        return response
+            "return_url": return_url or invoice_url,
+        })
+        return request.render("cms_form_compassion.payment_submit", values)

--- a/cms_form_compassion/forms/payment_form.py
+++ b/cms_form_compassion/forms/payment_form.py
@@ -17,10 +17,6 @@ class PaymentForm(models.AbstractModel):
     _description = "Payment Form"
     _inherit = "cms.form"
 
-    # Can either be "modal" or "full" depending if the payment form is
-    # displayed in a modal view or in a full page.
-    _display_type = "modal"
-
     # Internal field for the payment process: it will use the generated invoice
     # for payment. All the display of the form and the logic for invoice creation
     # must be implemented in inherited forms.
@@ -28,11 +24,7 @@ class PaymentForm(models.AbstractModel):
 
     # Properties for page redirect after payment
     @property
-    def _payment_success_redirect(self):
-        return ""
-
-    @property
-    def _payment_error_redirect(self):
+    def _payment_redirect(self):
         return ""
 
     @property
@@ -48,9 +40,8 @@ class PaymentForm(models.AbstractModel):
     def form_next_url(self, main_object=None):
         # Redirect to payment controller
         return (
-            f"/compassion/payment/invoice/{self.invoice_id.id}?success_url="
-            f"{self._payment_success_redirect}&error_url="
-            f"{self._payment_error_redirect}&display_type={self._display_type}"
+            f"/compassion/payment/invoice/{self.invoice_id.id}?return_url="
+            f"{self._payment_redirect}"
         )
 
     def generate_invoice(self):

--- a/cms_form_compassion/static/src/js/modal_form.js
+++ b/cms_form_compassion/static/src/js/modal_form.js
@@ -1,6 +1,5 @@
 odoo.define('cms_form_compassion.modal_form', function (require) {
     "use strict";
-    var PaymentForm = require('payment.payment_form');
     var DateWidget = require('cms_form.date_widget');
     var Widget = require("web.Widget");
     var core = require('web.core');
@@ -49,21 +48,7 @@ odoo.define('cms_form_compassion.modal_form', function (require) {
                         }
                         var result_html = $('<div></div>');
                         result_html.load(data.redirect, function() {
-                            var payment_compassion = result_html.find('#payment_compassion');
-                            if (payment_compassion.length) {
-                                // Special case for payment form, we load payment JS otherwise the payment is not working.
-                                var modal_body = modal.find('.modal-body');
-                                modal_body.html(result_html.html());
-                                modal_body.find('.o_payment_form').each(function () {
-                                    var $elem = $(this);
-                                    var form = new PaymentForm(null, $elem.data());
-                                    form.attachTo($elem);
-                                });
-                                // Auto submit the payment form after 3 seconds
-                                // setTimeout(function() { modal_body.find('#o_payment_form_pay').click(); }, 3000);
-                            } else {
-                                self.on_receive_back_html_result(result_html.html());
-                            }
+                            self.on_receive_back_html_result(result_html.html());
                         });
                     } else {
                         self.on_receive_back_html_result(data);
@@ -164,20 +149,5 @@ odoo.define('cms_form_compassion.modal_form', function (require) {
             $(button).find('span.o_loader').remove();
         },
     });
-
-    $(function () {
-        // TODO This was taken from payment/payment_form.js module, but apparently there could be a better way
-        // of loading the widget into the view. We can see how this one will evolve maybe.
-        if (!$('.cms_modal_form').length) {
-            console.log("DOM doesn't contain '.cms_modal_form'");
-            return;
-        }
-        $('.cms_modal_form').each(function () {
-            var $elem = $(this);
-            var form = new ModalForm(null, $elem.data());
-            form.attachTo($elem);
-        });
-    });
-
     return ModalForm;
 });

--- a/cms_form_compassion/static/src/js/modal_form.js
+++ b/cms_form_compassion/static/src/js/modal_form.js
@@ -149,5 +149,20 @@ odoo.define('cms_form_compassion.modal_form', function (require) {
             $(button).find('span.o_loader').remove();
         },
     });
+
+    $(function () {
+        // TODO This was taken from payment/payment_form.js module, but apparently there could be a better way
+        // of loading the widget into the view. We can see how this one will evolve maybe.
+        if (!$('.cms_modal_form').length) {
+            console.log("DOM doesn't contain '.cms_modal_form'");
+            return;
+        }
+        $('.cms_modal_form').each(function () {
+            var $elem = $(this);
+            var form = new ModalForm(null, $elem.data());
+            form.attachTo($elem);
+        });
+    });
+
     return ModalForm;
 });

--- a/cms_form_compassion/templates/payment_templates.xml
+++ b/cms_form_compassion/templates/payment_templates.xml
@@ -17,43 +17,25 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
     </template>
 
     <!-- Called after submission of form, display form for redirecting to Payment Provider -->
-    <template id="modal_payment_submit" name="Payment form redirection page">
-        <div class="text-center" style="margin-top: 50px;">
-            <p>Thank you for your submission. If you are not automatically redirected to the payment page, please click on the Next button.</p>
-            <t t-set="tx_ids"
-               t-value="invoice.transaction_ids.filtered(lambda tx: tx.state in ('authorized', 'done'))"/>
-            <div t-if="not tx_ids and invoice.state == 'open' and invoice.amount_total" id="payment_compassion">
-                <div t-if="pms or acquirers">
-                    <!-- Portal payment code from account_payment.portal_invoice_payment -->
-                    <div class="row" id="portal_pay">
-                        <div id="pay_with">
-                            <h3 class="modal-title">Pay with</h3>
-                            <div t-if="pms or acquirers" id="payment_method" class="text-left col-md-13">
-                                <t t-call="payment.payment_tokens_list">
-                                    <t t-set="mode" t-value="'payment'"/>
-                                    <t t-set="partner_id"
-                                       t-value="invoice.partner_id.id if request.env.user._is_public() else request.env.user.partner_id.id"/>
-                                    <t t-set="callback_method" t-value="''"/> <!-- TODO -->
-                                    <t t-set="form_action"
-                                       t-value="'/invoice/pay/' + str(invoice.id) + '/s2s_token_tx/'"/>
-                                    <t t-set="prepare_tx_url"
-                                       t-value="'/invoice/pay/' + str(invoice.id) + '/form_tx/'"/>
-                                    <t t-set="submit_txt">Next</t>
-                                    <t t-set="icon_class" t-value="'fa-lock'"/>
-                                </t>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </template>
-
-    <template id="payment_submit_full" name="Payment redirection page">
+    <template id="payment_submit" name="Payment redirection page">
         <t t-call="website.layout">
             <div id="wrap">
                 <div class="container">
-                    <t t-call="cms_form_compassion.modal_payment_submit"/>
+                    <!-- Use portal invoice payment route but override return URLs to avoid being redirected back to the portal after the payment. -->
+                    <!-- In the portal, the payment method is displayed in a modal. Here we want to make the modal visible in full page. -->
+                    <t t-call="account_payment.portal_invoice_payment"/>
+                    <script type="text/javascript">
+                        var content = $("#pay_with").find(".modal-content");
+                        $("#pay_with").parent().html(content.html());
+                        $("#portal_pay").addClass("mt-4");
+                        $("button.close").hide();
+                        <t t-if="return_url">
+                            $("input[name='success_url']").val('<t t-esc="return_url"/>)');
+                            $("input[name='error_url']").val('<t t-esc="return_url"/>)');
+                            $("form.o_payment_form").attr("data-success-url", "<t t-esc="return_url"/>");
+                            $("form.o_payment_form").attr("data-error-url", "<t t-esc="return_url"/>");
+                        </t>
+                    </script>
                 </div>
             </div>
         </t>

--- a/mobile_app_connector/forms/registration_form.py
+++ b/mobile_app_connector/forms/registration_form.py
@@ -244,7 +244,6 @@ class RegistrationNotSupporter(models.AbstractModel):
     _inherit = "cms.form.res.users"
 
     _form_model = "res.users"
-    _display_type = "full"
 
     gtc_accept = fields.Boolean("Terms and conditions", required=True)
 
@@ -318,7 +317,6 @@ class RegistrationSupporterForm(models.AbstractModel):
 
     _form_model = "res.users"
     _form_required_fields = ["partner_email", "gtc_accept"]
-    _display_type = "full"
 
     gtc_accept = fields.Boolean("Terms and conditions", required=True)
 

--- a/sms_sponsorship/__manifest__.py
+++ b/sms_sponsorship/__manifest__.py
@@ -19,7 +19,6 @@
         "cms_form_compassion",  # compassion-modules
         "base_phone",  # OCA/connector_telephony
         "stock",  # source/addons
-        "payment_ogone",  # source/addons
     ],
     "data": [
         "security/ir.model.access.csv",

--- a/sms_sponsorship/controllers/main.py
+++ b/sms_sponsorship/controllers/main.py
@@ -241,19 +241,18 @@ class SmsSponsorshipWebsite(Controller, FormControllerMixin):
         """
         sponsorship = request.env["recurring.contract"].sudo().browse(sponsorship_id)
         values = {"sponsorship": sponsorship}
-        web_payment = post.get("payment")
-        if web_payment:
-            if web_payment == "success":
-                sponsorship.sms_request_id.complete_step2()
-            else:
-                request.website.add_status_message(
-                    _(
-                        "The payment was not successful, but your sponsorship has "
-                        "still been activated! You will be able to pay later using "
-                        "your selected payment method."
-                    ),
-                    type_="danger",
-                )
+        web_payment = post.get("payment", "success")
+        if web_payment == "success":
+            sponsorship.sms_request_id.complete_step2()
+        else:
+            request.website.add_status_message(
+                _(
+                    "The payment was not successful, but your sponsorship has "
+                    "still been activated! You will be able to pay later using "
+                    "your selected payment method."
+                ),
+                type_="danger",
+            )
         return request.render("sms_sponsorship.sms_registration_confirmation", values)
 
     @route(

--- a/sms_sponsorship/forms/sms_sponsorship_registration_form.py
+++ b/sms_sponsorship/forms/sms_sponsorship_registration_form.py
@@ -22,7 +22,6 @@ class PartnerSmsRegistrationForm(models.AbstractModel):
     _form_model = "recurring.contract"
     _form_model_fields = ["partner_id", "payment_mode_id"]
     _form_required_fields = ("partner_id", "payment_mode_id", "gtc_accept")
-    _display_type = "full"
 
     origin_text = fields.Char("I have heard of Compassion through")
 
@@ -38,14 +37,9 @@ class PartnerSmsRegistrationForm(models.AbstractModel):
     gtc_accept = fields.Boolean("Terms and conditions", required=True)
 
     @property
-    def _payment_success_redirect(self):
+    def _payment_redirect(self):
         return "/sms_sponsorship/step2/" + str(self.main_object.id) + \
-               "/confirm?payment=success"
-
-    @property
-    def _payment_error_redirect(self):
-        return "/sms_sponsorship/step2/" + str(self.main_object.id) + \
-               "/confirm?payment=error"
+               "/confirm"
 
     @property
     def form_title(self):
@@ -145,7 +139,7 @@ class PartnerSmsRegistrationForm(models.AbstractModel):
         if self.pay_first_month_ebanking:
             return super().form_next_url(main_object)
         else:
-            return self._payment_success_redirect
+            return self._payment_redirect
 
     def _edit_transaction_values(self, tx_values, form_vals):
         """ Add invoice link and change reference. """

--- a/thankyou_letters/models/account_invoice.py
+++ b/thankyou_letters/models/account_invoice.py
@@ -129,7 +129,7 @@ class AccountInvoice(models.Model):
             invoice_lines = self.mapped("invoice_line_ids").filtered(
                 lambda l: l.partner_id == partner
             )
-            invoice_lines.generate_thank_you()
+            invoice_lines.with_delay().generate_thank_you()
 
     @api.multi
     def _filter_invoice_to_thank(self):

--- a/thankyou_letters/models/account_invoice_line.py
+++ b/thankyou_letters/models/account_invoice_line.py
@@ -11,6 +11,7 @@
 import logging
 
 from odoo import models, api
+from odoo.addons.queue_job.job import job
 
 _logger = logging.getLogger(__name__)
 
@@ -36,6 +37,7 @@ class AccountInvoiceLine(models.Model):
         return total_string, res_name
 
     @api.multi
+    @job
     def generate_thank_you(self):
         """
         Creates a thank you letter communication.


### PR DESCRIPTION
- Remove custom code and replace by odoo account_payment template inheritance
- Use javascript to override return_url after payment and redirect to a custom confirmation page if needed (bypasses the invoice portal website)
- Remove ability to make the payment inside a modal popup, because the javascript code for this is too complex. When redirected for the payment, it's always full page.
- The success and error return pages are merged into a single one (return_url) in order to match the standard odoo process. The return page is responsible for checking the transaction state and displaying the proper result depending on the transaction state.