### PR TITLE
CS-602 : wordpress email automatically saved under partner

### DIFF
--- a/crm_request/__manifest__.py
+++ b/crm_request/__manifest__.py
@@ -22,6 +22,7 @@
     "data": [
         "data/request_email_template.xml",
         "data/crm_request_data.xml",
+        "data/ignored_reporter.xml",
         "data/request_sequence.xml",
         "data/ir_cron.xml",
         "views/request.xml",

--- a/crm_request/data/ignored_reporter.xml
+++ b/crm_request/data/ignored_reporter.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<odoo noupdate="1">
+    <record model="ignored_reporter">
+        <field name="email">wordpress@compassion.ch</field>
+    </record>
+</odoo>

--- a/crm_request/models/__init__.py
+++ b/crm_request/models/__init__.py
@@ -6,3 +6,5 @@ from . import request_stage
 from . import mail_compose_message
 from . import mail_message
 from . import mail_mail
+from . import ignored_reporter
+from . import mail_thread

--- a/crm_request/models/ignored_reporter.py
+++ b/crm_request/models/ignored_reporter.py
@@ -1,0 +1,14 @@
+# Copyright (C) 2021 Compassion CH
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models, _, fields
+
+
+class IgnoredReporter(models.Model):
+    """
+
+    """
+    _name = 'ignored_reporter'
+    _order = "email asc"
+
+    email = fields.Char()

--- a/crm_request/models/mail_thread.py
+++ b/crm_request/models/mail_thread.py
@@ -1,0 +1,20 @@
+
+import email
+from email.message import Message
+from odoo.tools import pycompat
+
+from odoo import api, models, tools
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    @api.model
+    def message_parse(self, message, save_original=False):
+        msg_dict = super().message_parse(message, save_original)
+        if not isinstance(message, Message):
+            # message_from_string works on a native str
+            message = pycompat.to_native(message)
+            message = email.message_from_string(message)
+        msg_dict['reply_to'] = tools.decode_smtp_header(message.get('Reply-To'))
+        return msg_dict

--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -177,11 +177,21 @@ class CrmClaim(models.Model):
             "email_origin": msg.get("from"),
         }
 
+        ignored_reporter = self.env["ignored_reporter"].search([])
+        ignored_reporter = [i.email for i in ignored_reporter]
+
+        # If the mail is ignored_reporters use the email in the body instead
+        if defaults["email_origin"] in ignored_reporter:
+            email = msg["reply_to"]
+            defaults["email_origin"] = email
+            msg["from"] = email
+            msg["email_from"] = email
+
         if "partner_id" not in custom_values:
             match_obj = self.env["res.partner.match"]
             options = {"skip_create": True}
             partner = match_obj.match_partner_to_infos(
-                {"email": parseaddr(msg.get("from"))[1]}, options
+                {"email": parseaddr(defaults["email_origin"])[1]}, options
             )
             if partner:
                 defaults["partner_id"] = partner.id

--- a/crm_request/security/ir.model.access.csv
+++ b/crm_request/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 admin_access_holiday_closure,admin_access_holiday_closure,model_holiday_closure,sales_team.group_sale_manager,1,1,1,1
 access_crm_stages,access_crm_stages,model_crm_claim_stage,sales_team.group_sale_manager,1,1,1,1
 access_crm_categories,access_crm_categories,model_crm_claim_category,sales_team.group_sale_manager,1,1,1,1
+ignored_reporter,ignored_reporter,model_ignored_reporter,sales_team.group_sale_manager,1,1,1,1

--- a/crm_request/views/request.xml
+++ b/crm_request/views/request.xml
@@ -182,6 +182,23 @@
         </field>
     </record>
 
+    <!-- Ignored Reporters -->
+    <record model="ir.actions.act_window" id="ignored_reporters_action">
+      <field name="name">Ignored Reporters</field>
+      <field name="res_model">ignored_reporter</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
+    <record model="ir.ui.view" id="ignored_reporter">
+      <field name="name">Ignored Reporters</field>
+      <field name="model">ignored_reporter</field>
+      <field name="arch" type="xml">
+        <tree>
+          <field name="email"/>
+        </tree>
+      </field>
+    </record>
+
     <!-- Top menu -->
     <menuitem id="support_root"
               name="Support"
@@ -203,5 +220,9 @@
     <menuitem id="crm_holiday_act_menu" name="Holidays"
               groups="sales_team.group_sale_manager"
               parent="crm_claim.menu_crm_case_claim-act"/>
+    <menuitem id="crm_claim.menu_config_claim_ignored_reporters"
+              name="Ignored reporters"
+              action="ignored_reporters_action"
+              parent="crm_claim.menu_config_claim"/>
 
 </odoo>


### PR DESCRIPTION
- Used email from the form the in the request if the sender is in the ignored_reporter config model
- Use the reply-to email field instead of parsing the mail with regular expressions
- replace email_from with email