### PR TITLE
CS-636: Events are not consistently linked with contacts/churches in Odoo

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -497,8 +497,7 @@ class EventCompassion(models.Model):
             "user_id": self.user_id.id,
             "partner_ids": [
                 (6, 0, (self.staff_ids |
-                        # self.partner_id |  has been commented to avoid
-                        # partner to get notified with meeting invites
+                        self.partner_id |
                         self.user_id.partner_id).ids)],
             "start": self.start_date,
             "stop": self.end_date or self.start_date,


### PR DESCRIPTION
Re-add the event customer to the event