### PR TITLE
CO-3831 : mapping issue prevent from sending intervention hold

### DIFF
--- a/intervention_compassion/static/mappings/hold_create_mapping.json
+++ b/intervention_compassion/static/mappings/hold_create_mapping.json
@@ -6,7 +6,8 @@
       "field": "intervention_id.intervention_id"
     },
     "HoldID": {
-      "field": "created_intervention_id.hold_id"
+      "field": "created_intervention_id.hold_id",
+      "relational_write_mode": ""
     },
     "ExpirationDate": {
       "field": "expiration_date"


### PR DESCRIPTION
- Change the Relational Write Mode for the Hold Creation mapping from "override" (default behaviour) to ""

This JSON should be re-applied on the prod DB