### PR TITLE
CO-3834 Improvements

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -524,7 +524,7 @@ class CompassionChild(models.Model):
                 "child_id": child.id,
             }
             message = message_obj.create(message_vals)
-            if message.state == "failure" and not self.env.context.get("async_mode"):
+            if "failure" in message.state and not self.env.context.get("async_mode"):
                 raise UserError(message.failure_reason)
         return True
 

--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -205,8 +205,10 @@ class CompassionHold(models.Model):
 
     @api.multi
     def write(self, vals):
-        if "expiration_date" in vals and self.filtered(lambda h: h.expiration_date < datetime.now()):
-            raise UserError(_("The expiration date as been reach and thus can't be changed."))
+        if "expiration_date" in vals and self.filtered(
+                lambda h: h.expiration_date < datetime.now()):
+            raise UserError(_(
+                "The expiration date as been reach and thus can't be changed."))
 
         res = super().write(vals)
         notify_vals = ["primary_owner", "type", "expiration_date"]
@@ -245,7 +247,7 @@ class CompassionHold(models.Model):
             }
             messages += message_obj.create(message_vals)
         messages.process_messages()
-        failed = messages.filtered(lambda m: m.state == "failure")
+        failed = messages.filtered(lambda m: "failure" in m.state)
         if failed:
             self.env.cr.rollback()
             raise UserError("\n\n".join(failed.mapped("failure_reason")))

--- a/child_compassion/models/compassion_reservation.py
+++ b/child_compassion/models/compassion_reservation.py
@@ -122,7 +122,7 @@ class CompassionReservation(models.Model):
                     .filtered(lambda r: r.state == "active")
                     .handle_reservation()
             )
-            failed = messages.filtered(lambda m: m.state == "failure")
+            failed = messages.filtered(lambda m: "failure" in m.state)
             if failed:
                 raise UserError("\n\n".join(failed.mapped("failure_reason")))
         return res

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -624,7 +624,7 @@ class CompassionProject(models.Model):
             "object_id": self.id,
         }
         message = message_obj.create(message_vals)
-        if message.state == "failure":
+        if "failure" in message.state:
             raise UserError(message.failure_reason)
 
         return True

--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -495,7 +495,7 @@ class CompassionIntervention(models.Model):
             .with_context(async_mode=False)
             .create({"action_id": action_id, "object_id": self.id})
         )
-        if message.state == "failure":
+        if "failure" in message.state:
             raise UserError(message.failure_reason)
         return True
 
@@ -689,7 +689,7 @@ class CompassionIntervention(models.Model):
                 .with_context(hold_update=False)
                 .create(message_vals)
             )
-            if message.state == "failure":
+            if "failure" in message.state:
                 raise UserError(message.failure_reason)
         return True
 
@@ -703,7 +703,7 @@ class CompassionIntervention(models.Model):
             .with_context(async_mode=False)
             .create({"action_id": action_id, "object_id": self.id})
         )
-        if message.state == "failure":
+        if "failure" in message.state:
             raise UserError(message.failure_reason)
         return True
 

--- a/intervention_compassion/wizards/commitment_wizard.py
+++ b/intervention_compassion/wizards/commitment_wizard.py
@@ -67,6 +67,6 @@ class HoldWizard(models.TransientModel):
         if not test_mode:
             self.env.cr.commit()  # pylint: disable=invalid-commit
         message.with_context(async_mode=False).process_messages()
-        if message.state == "failure":
+        if "failure" in message.state:
             raise UserError(message.failure_reason)
         return True

--- a/intervention_compassion/wizards/hold_wizard.py
+++ b/intervention_compassion/wizards/hold_wizard.py
@@ -96,7 +96,7 @@ class HoldWizard(models.TransientModel):
             .with_context(async_mode=False)
             .create({"action_id": create_hold.id, "object_id": self.id, })
         )
-        if message.state == "failure":
+        if "failure" in message.state:
             raise UserError(message.failure_reason)
 
         return {

--- a/message_center_compassion/views/gmc_message_view.xml
+++ b/message_center_compassion/views/gmc_message_view.xml
@@ -11,7 +11,7 @@
         <field name="model">gmc.message</field>
         <field name="priority">17</field>
         <field name="arch" type="xml">
-            <tree decoration-danger="state == 'failure'"
+            <tree decoration-danger="state in ('failure', 'odoo_failure')"
                   decoration-primary="state == 'new'"
                   decoration-muted="state == 'success'">
                 <field name="action_id" />
@@ -28,7 +28,7 @@
         <field name="model">gmc.message</field>
         <field name="priority">12</field>
         <field name="arch" type="xml">
-            <tree decoration-danger="state == 'failure'"
+            <tree decoration-danger="state in ('failure', 'odoo_failure')"
                   decoration-primary="state == 'new'"
                   decoration-muted="state == 'success'">
                 <field name="action_id" />
@@ -50,7 +50,7 @@
             <form string="GMC Message" create="false">
                 <header>
                     <field name="state" widget="statusbar" statusbar_visible="new,pending,success" />
-                    <button name="process_messages" type="object" class="oe_highlight" string="Process Message" states="new" />
+                    <button name="process_messages" type="object" class="oe_highlight" string="Process Message" states="new,failure,odoo_failure" />
                     <button name="reset_message" type="object" string="Set back to New" states="failure,pending"/>
                     <button name="force_success" type="object" string="Success" groups="base.group_erp_manager" attrs="{'invisible':[('state','in',['postponed', 'success'])]}"/>
                     <button name="open_related" type="object" string="Related"/>
@@ -155,7 +155,7 @@
                 <filter string="Outgoing" name="outgoing" domain="[('direction','=','out')]" context="{'group_by':'action_id'}" />
                 <separator />
                 <filter string="Pending" name="pending" domain="['|', ('state','=','pending'), ('state','=','new')]" />
-                <filter string="Failed" name="failure" domain="[('state','=','failure')]" />
+                <filter string="Failed" name="failure" domain="[('state','in',('failure','odoo_failure'))]" />
                 <filter string="Success" name="success" domain="[('state','=','success')]" />
                 <group expand="0" string="Group By...">
                     <filter string="Status" name="status" domain="[]" context="{'group_by':'state'}"/>

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -552,7 +552,7 @@ class Correspondence(models.Model):
             [
                 ("action_id", "=", gmc_action.id),
                 ("object_id", "in", self.ids),
-                ("state", "in", ["new", "failure", "postponed"]),
+                ("state", "in", ["new", "failure", "odoo_failure", "postponed"]),
             ]
         )
         gmc_messages.unlink()
@@ -832,7 +832,7 @@ class Correspondence(models.Model):
             [
                 ("action_id", "=", gmc_action.id),
                 ("object_id", "in", self.ids),
-                ("state", "in", ["new", "failure"]),
+                ("state", "in", ["new", "failure", "odoo_failure"]),
             ]
         )
         gmc_messages.write({"state": "postponed"})

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -404,7 +404,7 @@ class ResPartner(models.Model):
                     }
                 )
             )
-            if message.state == "failure":
+            if "failure" in message.state:
                 answer = message.get_answer_dict()
                 raise UserError(
                     answer


### PR DESCRIPTION
- Add state "odoo_failure" in GMC messages in order to differentiate errors at our side
  and being able to replay the message without calling back GMC if we already received
  a success from them.
- Change further the procedure of changing correspondent to make sure we can replay the failed
  messages at any step.
- Other fixes regarding data.