### PR TITLE
CS-667 Odoo created false partners

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -287,8 +287,9 @@ class CrmClaim(models.Model):
         which can occur for example with circular references
         """
         for _ in range(10):
-            if partner.contact_id:
-                partner = partner.contact_id
+            if not partner.contact_id:
+                break
+            partner = partner.contact_id
         return partner
 
     @api.multi


### PR DESCRIPTION
According to David, when a crm.claim was created when the email address was referring to a "Linked Partner", this alternative partner was used instead (this "Linked Partner" usually only have the alternative email address and the remaining fields are empty).
I couldn't reproduce this problem, on my testing environment the create methods was never called with "Linked Partner", but this code works in case it ever happens.

This commit also fix a problem that was partially fixed in a previous task which added "Wordpress Imports" as the crm.claim partner instead of the actual partner.
The email address : wordpress@compassion.ch or any other address must still be present in the ignored_reporter table.