### PR TITLE
CO-3916: Only cancel invoices if marked as draft

### DIFF
--- a/cms_form_compassion/models/invoice.py
+++ b/cms_form_compassion/models/invoice.py
@@ -27,6 +27,6 @@ class AccountInvoice(models.Model):
 
     @api.multi
     def auto_cancel(self):
-        invoices = self.filtered(lambda i: i.state in ["draft", "open"])
+        invoices = self.filtered(lambda i: i.state == "draft")
         invoices.write({"auto_cancel_date": False})
         invoices.action_invoice_cancel()


### PR DESCRIPTION
This avoids having open invoices being automatically cancelled

Please review as I am not sure if this is expected behavior. From my understanding the invoices should be automatically closed when their state is draft only (as stated here: https://jira.compassion.ch/browse/CO-3907).