### PR TITLE
Co-3925 Cannot see old communications when coming from the sponsor view

### DIFF
--- a/crm_compassion/views/res_partner_view.xml
+++ b/crm_compassion/views/res_partner_view.xml
@@ -65,10 +65,4 @@
         <field name="binding_model_id" ref="model_res_partner"/>
         <field name="binding_type">action</field>
     </record>
-
-    <!-- Replace domain of communications button to display only pending communications -->
-    <record id="partner_communication.action_communication_job_partner" model="ir.actions.act_window">
-        <field name="domain">[('state', '!=', 'done')]</field>
-    </record>
-
 </odoo>

--- a/partner_communication/views/communication_job_view.xml
+++ b/partner_communication/views/communication_job_view.xml
@@ -143,7 +143,7 @@
         <field name="view_type">form</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{'default_user_id': uid}</field>
-        <field name="domain">[('state', '!=', 'cancel'), ('partner_id', '=', active_id)]</field>
+        <field name="domain">[('partner_id', '=', active_id)]</field>
     </record>
 
     <!-- Send communication actions -->


### PR DESCRIPTION
Fix the limited communication jobs presented, two domains were set:
- filter out cancelled jobs
- filter out done jobs (overwriting previous domain)

Both were removed as the initial filtering is made with a custom defined filter for "pending" jobs, as such removing this filter brings back expected behavior of listing all items.