### PR TITLE
correctly retrieve intervention id

### DIFF
--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -773,9 +773,8 @@ class CompassionIntervention(models.Model):
         intervention_local_ids = []
 
         for milestone in milestones_data:
-            intervention_vals = self.json_to_data(commkit_data)
             milestone_id = milestone.get("InterventionReportingMilestone_ID")
-            intervention_id = intervention_vals.get("intervention_id")
+            intervention_id = milestone.get("Intervention_ID")
             intervention = self.search([("intervention_id", "=", intervention_id)])
             if intervention:
                 intervention_local_ids.append(intervention.id)


### PR DESCRIPTION
This issue might bring new issues to light...
Given the history of processed GMC messages and their success, this fix should make it possible to retrieve the intervention identifier. Note that multiple other GMC handling methods might incorrectly try to retrieve some values.

This is probably related to how the compassion_modules/message_center_compassion/models/compassion_mapped_model::json_to_data method works (various fixes were applied to it)