### PR TITLE
CO-3887 Contact Scheduled Activity cannot be marked as done.

### DIFF
--- a/crm_compassion/models/mail_activity.py
+++ b/crm_compassion/models/mail_activity.py
@@ -57,4 +57,7 @@ class MailActivity(models.Model):
         if feedback:
             vals["description"] = feedback
         self.mapped("phonecall_id").with_context(from_activity=True).write(vals)
+        related_partner = self.env[self.res_model].browse(self.res_id)
+        if not related_partner.message_ids:
+            related_partner.message_post(body='System note', message_type='comment', subtype='mail.mt_note')
         return super().action_feedback(feedback)


### PR DESCRIPTION
Log a system note before marking done so that odoo can find a previous message

This is probably due to the fact that crm_compassion/res_partner defines a domain on top of message_ids but I'm not sure... Anyway odoo performs a record.message_ids[0] which resolves to nothing in certain cases, thus logging a simple note before it will make it work correctly.