### PR TITLE
Remove attachment header when returning PDF

### DIFF
--- a/sbc_translation/controllers/download_correspondence.py
+++ b/sbc_translation/controllers/download_correspondence.py
@@ -8,7 +8,6 @@
 ##############################################################################
 import logging
 
-from odoo.addons.web.controllers.main import content_disposition
 from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from odoo import http

--- a/sbc_translation/controllers/download_correspondence.py
+++ b/sbc_translation/controllers/download_correspondence.py
@@ -36,6 +36,5 @@ class RestController(http.Controller):
             binary,
             [
                 ("Content-Type", "application/pdf"),
-                ("Content-Disposition", content_disposition(correspondence.file_name)),
             ],
         )


### PR DESCRIPTION
Providing the attachment header forces the browser to open the file in a new tab