### PR TITLE
FIX Sub Child Hold state

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -632,7 +632,8 @@ class CompassionChild(models.Model):
         for child in self:
             values = {"sponsor_id": False}
             update_hold = False
-            if child.hold_id.type == HoldType.NO_MONEY_HOLD.value:
+            hold_types_to_consigned = [HoldType.NO_MONEY_HOLD.value, HoldType.SUB_CHILD_HOLD.value]
+            if child.hold_id.type in hold_types_to_consigned:
                 update_hold = True
                 values["state"] = "N"
             else:


### PR DESCRIPTION
###  Related Issue
SUB Child Holds are never released

### Description 
When a SUB Sponsorship is made, the child is put on SUB Child Hold. If we change the child associated to the sponsorship, or we delete the sponsorship, it should change the hold type of the child from SUB Child Hold to Consignment Hold, so that it can be later be released. It works for No Money Hold types but not for SUB Child Hold types which should be the case.

### Fix
Added Sub Hold type value in the condition that updates the hold type to 'Consignment Hold' 