### PR TITLE
FIX associated child event

### DIFF
--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -122,19 +122,8 @@ class SmsChildRequest(models.Model):
     @api.multi
     @api.depends("date")
     def _compute_event(self):
-        limit_date = datetime.today() - relativedelta(days=7)
-        for request in self.filtered(lambda r: r.source == "SMS" and r.date):
-            event_id = self.env["crm.event.compassion"].search(
-                [
-                    ("accepts_sms_booking", "=", True),
-                    ("start_date", "<=", request.date),
-                    ("start_date", ">=", limit_date),
-                ],
-                order="start_date desc",
-                limit=1,
-            )
-            # event_id is None if start_date of most recent event is>1 week old
-            request.event_id = event_id
+        for request in self:
+            request.event_id = self.child_id.hold_event
 
     def _inverse_event(self):
         # Allows to manually set an event

--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -215,7 +215,7 @@ class SmsChildRequest(models.Model):
         """ Release current child and take another."""
         self.hold_id.write({"sms_request_id": False})
         self.write(
-            {"state": "new", "child_id": False, "is_trying_to_fetch_child": True}
+            {"state": "new", "is_trying_to_fetch_child": True}
         )
         return self.reserve_child()
 

--- a/sms_sponsorship/models/sms_child_request.py
+++ b/sms_sponsorship/models/sms_child_request.py
@@ -125,20 +125,21 @@ class SmsChildRequest(models.Model):
         for request in self:
             if request.child_id.hold_event:
                 request.event_id = request.child_id.hold_event
-            else:
+            elif request.source == "SMS" and request.date:
                 limit_date = datetime.today() - relativedelta(days=7)
-                for sms_request in self.filtered(lambda r: r.source == "SMS" and r.date):
-                    event_id = self.env["crm.event.compassion"].search(
-                        [
-                            ("accepts_sms_booking", "=", True),
-                            ("start_date", "<=", sms_request.date),
-                            ("start_date", ">=", limit_date),
-                        ],
-                        order="start_date desc",
-                        limit=1,
-                    )
-                    # event_id is None if start_date of most recent event is > 1 week old
-                    sms_request.event_id = event_id
+                event_id = self.env["crm.event.compassion"].search(
+                    [
+                        ("accepts_sms_booking", "=", True),
+                        ("start_date", "<=", request.date),
+                        ("start_date", ">=", limit_date),
+                    ],
+                    order="start_date desc",
+                    limit=1,
+                )
+                # event_id is None if start_date of most recent event is > 1 week old
+                request.event_id = event_id
+            else:
+                request.event_id = False
 
 
     def _inverse_event(self):


### PR DESCRIPTION
# Related Issue
When scanning qrcode from childpack, the event linked with the child dossier is not reported on the sponsorship

# Description
[1] When a child was associated for an event, the sponsorship created by the mobile sponsorship process did not put the event as origin in the sponsorship.

[2] When clicking on the "Other Child" button on the mobile sponsorship process, the other child given was the same as before.

# Fix
[1] Refactor the function _compute_event to manage the QR case by getting the event_id from the child_id.hold_event

[2] refactor the code that release the current child and choose another by not deleting the last child id, so the function that choose another child can fetch a different child_id from the previous one.

