### PR TITLE
14.0 fix gift move

### DIFF
--- a/gift_compassion/models/sponsorship_gift.py
+++ b/gift_compassion/models/sponsorship_gift.py
@@ -204,7 +204,7 @@ class SponsorshipGift(models.Model):
 
     def _compute_currency(self):
         # Set gift currency depending on its invoice currency
-        self.currency_id = self.invoice_line_ids.move_id.currency_id
+        self.currency_id = self.mapped("invoice_line_ids.move_id.currency_id")[:1]
 
     def _compute_name(self):
         for gift in self:

--- a/gift_compassion/models/sponsorship_gift.py
+++ b/gift_compassion/models/sponsorship_gift.py
@@ -90,7 +90,7 @@ class SponsorshipGift(models.Model):
     )
     currency_id = fields.Many2one(
         "res.currency",
-        default=lambda s: s.env.user.company_id.currency_id,
+        compute="_compute_currency",
         readonly=False,
     )
     currency_usd = fields.Many2one(
@@ -201,6 +201,10 @@ class SponsorshipGift(models.Model):
                 gift.gift_date = max([d for d in inv_dates])
 
             gift.amount = sum(amounts)
+
+    def _compute_currency(self):
+        # Set gift currency depending on its invoice currency
+        self.currency_id = self.invoice_line_ids.move_id.currency_id
 
     def _compute_name(self):
         for gift in self:
@@ -514,12 +518,12 @@ class SponsorshipGift(models.Model):
         param_obj = self.env["res.config.settings"].with_company(company)
         account_credit = param_obj.get_param("gift_income_account_id")
         account_debit = param_obj.get_param("gift_expense_account_id")
+        journal_id = param_obj.get_param("gift_journal_id")
         if not account_credit or not account_debit:
             raise UserError(_("Please setup income and expense accounts for gifts before sending them to GMC."))
-        journal = self.env["account.journal"].search([("code", "=", "OD"), ("company_id", "=", company.id)])
         maturity = (self.date_sent and self.date_sent.date()) or fields.Date.today()
         move_data = {
-            "journal_id": journal.id,
+            "journal_id": journal_id,
             "ref": "Gift payment to GMC",
             "date": maturity,
         }

--- a/gift_compassion/static/mappings/mapping.json
+++ b/gift_compassion/static/mappings/mapping.json
@@ -16,7 +16,7 @@
     "GiftType": "attribution",
     "GlobalPartnerNote": {
       "field": "instructions",
-      "to_json_conversion": "odoo_value.replace('\"', ' ').replace(\"'\", \" \") if odoo_value else None"
+      "to_json_conversion": "odoo_value.replace('\"', ' ').replace(\"'\", \" \").replace('[', ' ').replace(']', ' ') if odoo_value else None"
     },
     "PartnerGiftDate": "gift_date",
     "PartnerGiftID": {
@@ -50,10 +50,11 @@
     "StatusChangeDate": "status_change_date",
     "UndeliverableReason": "undeliverable_reason",
     "CurrencyCode": {
-      "to_json_conversion": "self.env.user.currency_id.name"
+      "field": "currency_id.name",
+      "to_json_conversion": "odoo_value or None"
     },
     "Supporter_GlobalPartnerSupporterID": {
-      "to_json_conversion": "self.env.user.company_id.country_id.code"
+      "to_json_conversion": "gpid"
     }
   }
 }

--- a/gift_compassion/views/settings_view.xml
+++ b/gift_compassion/views/settings_view.xml
@@ -82,6 +82,10 @@
                                 <label for="gift_expense_account_id" class="col-md-5 o_light_label"/>
                                 <field name="gift_expense_account_id" domain="[('company_id', '=', context.company_id)]"/>
                             </div>
+                            <div class="row">
+                                <label for="gift_journal_id" class="col-md-5 o_light_label"/>
+                                <field name="gift_journal_id" domain="[('company_id', '=', context.company_id)]"/>
+                            </div>
                         </div>
                     </div>
                     <div class="col-xs-12 col-md-6 o_setting_box">

--- a/gift_compassion/wizards/gift_settings.py
+++ b/gift_compassion/wizards/gift_settings.py
@@ -36,6 +36,9 @@ class GiftNotificationSettings(models.TransientModel):
     gift_analytic_tag_id = fields.Many2one(
         "account.analytic.tag", "Gift analytic tag", config_parameter="gift_compassion.analytic_tag_id"
     )
+    gift_journal_id = fields.Many2one(
+        "account.journal", "Gift journal id",
+    )
 
     def _compute_gift_notify_ids(self):
         for rec in self:
@@ -57,6 +60,8 @@ class GiftNotificationSettings(models.TransientModel):
                 f"gift_compassion.gift_expense_account_{company_id}", 0)),
             "gift_income_account_id": int(param_obj.get_param(
                 f"gift_compassion.gift_income_account_{company_id}", 0)),
+            "gift_journal_id": int(param_obj.get_param(
+                f"gift_compassion.gift_journal_id{company_id}", 0)),
         })
         return res
 
@@ -67,6 +72,9 @@ class GiftNotificationSettings(models.TransientModel):
         )
         self.env["ir.config_parameter"].set_param(
             f"gift_compassion.gift_income_account_{company_id}", str(self.gift_income_account_id.id)
+        )
+        self.env["ir.config_parameter"].set_param(
+            f"gift_compassion.gift_journal_id{company_id}", str(self.gift_journal_id.id)
         )
         super().set_values()
 

--- a/sponsorship_compassion/wizards/generate_gift_wizard.py
+++ b/sponsorship_compassion/wizards/generate_gift_wizard.py
@@ -114,7 +114,7 @@ class GenerateGiftWizard(models.TransientModel):
             "move_type": "out_invoice",
             "partner_id": contract.gift_partner_id.id,
             "journal_id": journal_id,
-            'currency_id': contract.gift_partner_id.property_product_pricelist.currency_id.id,
+            'currency_id': contract.company_id.currency_id.id,
             "invoice_date": invoice_date,
             "payment_mode_id": contract.payment_mode_id.id,
             "company_id": contract.mapped('company_id')[:1].id,


### PR DESCRIPTION
Related issue : [CP-172](https://compassion-ch.atlassian.net/browse/CP-172)

# Issue: 
When a gift is sent to API, it is missing the journal id and the field currency is not set correctly

# Fix:
- Set gift currency from the company that manage the gift contract (invoice)
- Set gift journal_id from an added setting that depends on each companies instead of an hardcoded journal code
- Correct the gift mapping to escape special characters in the instruction field and to set correctly the currency and the global partner supporter id.


