### PR TITLE
FIX: Set Gift instructions value into narration field

### DIFF
--- a/account_reconcile_compassion/models/bank_statement_line.py
+++ b/account_reconcile_compassion/models/bank_statement_line.py
@@ -170,14 +170,17 @@ class BankStatementLine(models.Model):
                 ("company_id", "=", self.company_id.id)
             ], limit=1).id
         )
+
         avoid_thankyou = any(map(lambda mvl: mvl.pop("avoid_thankyou_letter"), mv_line_dicts))
+        comment = ";".join([d.pop("comment", "") for d in mv_line_dicts])
+
         return {
             "move_type": "out_invoice",
             "partner_id": self.partner_id.id,
             "journal_id": journal_id,
             "invoice_date": self.date,
             "ref": ref,
-            "invoice_origin": ";".join([d.get("comment", "") for d in mv_line_dicts]),
+            "narration": comment,
             "currency_id": self.currency_id.id,
             "payment_mode_id": self.statement_id.journal_id.payment_mode_id.id,
             "avoid_thankyou_letter": avoid_thankyou,

--- a/gift_compassion/models/sponsorship_gift.py
+++ b/gift_compassion/models/sponsorship_gift.py
@@ -379,7 +379,7 @@ class SponsorshipGift(models.Model):
                 {
                     "sponsorship_id": sponsorship.id,
                     "invoice_line_ids": [(4, invoice_line.id)],
-                    "instructions": invoice_line.name,
+                    "instructions": invoice_line.move_id.narration,
                 }
             )
 


### PR DESCRIPTION
Related Issue : [CP-177](https://compassion-ch.atlassian.net/browse/CP-177)

When reconciling an invoice, if the Gift instruction field in the form was set, the reconcilement was failing.

The value from Gift instruction is stored as 'comment', and this value needed to be popped out of the dictionnary mv_line_dicts.

After that, the comment value shouldn't be stored as the account_move.name as this field is a unique value field.
As discussed with David, I setted the value in the narration field instead of name.