### PR TITLE
CP-205 Test if partner has other contracts

### DIFF
--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -138,10 +138,11 @@ class ResPartner(models.Model):
                 + partner.contracts_paid
                 + partner.contracts_fully_managed
             )
-            partner.other_contract_ids = False #contract_obj.search(
-        #        [("partner_id", "=", partner.id), ("type", "not in", ["S", "SC", "SWP"])],
-        #        order="start_date desc",
-        #    ).ids
+            other_contract_ids = contract_obj.search(
+                [("partner_id", "=", partner.id), ("type", "not in", ["S", "SC", "SWP"])],
+                order="start_date desc",
+            ).ids
+            partner.other_contract_ids = other_contract_ids if other_contract_ids else None
 
 
     def _compute_count_items(self):


### PR DESCRIPTION
Related issue : [CP-205](https://compassion-ch.atlassian.net/jira/software/c/projects/CP/boards/6?modal=detail&selectedIssue=CP-205)
When we open sponsorship partners the other contracts weren't displaying because of a hardcoded value in res.partner. We have to test if the partner has other contracts to not make the opening form crashing.
