### PR TITLE
CP-266 UpsertPartner messages aren't created for GMC

### DIFF
--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -8,9 +8,9 @@
 #
 ##############################################################################
 
+import json
 import logging
 import os
-import json
 from datetime import datetime
 
 from dateutil.relativedelta import relativedelta
@@ -719,12 +719,6 @@ class SponsorshipContract(models.Model):
         and activate gift contracts.
         Send messages to GMC.
         """
-        for contract in self.filtered(lambda c: "S" in c.type):
-            # UpsertConstituent Message
-            partner = contract.correspondent_id
-            partner.upsert_constituent()
-            contract.upsert_sponsorship()
-
         not_active = self.filtered(lambda c: not c.is_active)
         if not_active:
             not_active.write({"activation_date": fields.Datetime.now()})
@@ -767,6 +761,12 @@ class SponsorshipContract(models.Model):
             raise UserError(
                 _("Please verify the partner before validating the sponsorship")
             )
+        # Creating the messages to send to GMC when a sponsorship is activated
+        for contract in self.filtered(lambda c: "S" in c.type):
+            # UpsertConstituent Message
+            partner = contract.correspondent_id
+            partner.upsert_constituent()
+            contract.upsert_sponsorship()
         return True
 
     def contract_cancelled(self):


### PR DESCRIPTION
Has_sponsorship isn't updated when we try to call the creation of the messages for GMC. Delay the creation of the messages so it can be called on activation of a contract