### PR TITLE
FIX: Rule definition correction for Letter object

### DIFF
--- a/mobile_app_connector/security/access_rules.xml
+++ b/mobile_app_connector/security/access_rules.xml
@@ -43,7 +43,7 @@
     <record id="my_correspondence" model="ir.rule">
         <field name="name">My correspondence</field>
         <field name="model_id" ref="sbc_compassion.model_correspondence"/>
-        <field name="domain_force">[('partner_id', '=', user.partner_id.id)]</field>
+        <field name="domain_force">['|', ('partner_id.id', '=', user.partner_id.id), '&', ('sponsorship_id.partner_id.portal_sponsorships', '=', 'all_info'), ('sponsorship_id.partner_id.id', '=', user.partner_id.id)]</field>
         <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
         <field name="perm_read" eval="True"/>
         <field name="perm_write" eval="True"/>


### PR DESCRIPTION
Related CP:  [CP-259](https://compassion-ch.atlassian.net/browse/CP-259)

Partners with the configuration set to 'all_info' on the portal_sponsorship field can't access their sponsor's letters. 

This was caused because of a record rule giving too strict permissions. 

I changed the related rule definition (domain) like so :   
If the current user is related to the correspondent partner OR (if the  portal_sponsorship is set on 'all_info' AND the user is related to the sponsorship partner).

[CP-259]: https://compassion-ch.atlassian.net/browse/CP-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ