### PR TITLE
FIX: improve skip param handling

### DIFF
--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -565,6 +565,13 @@ class GlobalChildSearch(models.TransientModel):
         if result["code"] == 200:
             self.nb_found = result["content"].get("NumberOfBeneficiaries", 0)
 
+            # When the skip param default value is higher than the available beneficiaries
+            # make a second request with a computed skip param to still get an available beneficiary when possible
+            if self.nb_found is not 0 and self.nb_found <= params['skip']:
+                # Set the 'skip' parameter to retrieve only middle urgent beneficiaries
+                params['skip'] = self.nb_found // 2
+                result = onramp.send_message(service_name, method, None, params)
+
             if not result["content"][result_name]:
                 raise UserError(_("No children found meeting criterias"))
             new_children = self.env["compassion.global.child"]

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -567,7 +567,7 @@ class GlobalChildSearch(models.TransientModel):
 
             # When the skip param default value is higher than the available beneficiaries
             # make a second request with a computed skip param to still get an available beneficiary when possible
-            if self.nb_found is not 0 and self.nb_found <= params['skip']:
+            if self.nb_found and self.nb_found <= params['skip']:
                 # Set the 'skip' parameter to retrieve only middle urgent beneficiaries
                 params['skip'] = self.nb_found // 2
                 result = onramp.send_message(service_name, method, None, params)

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -569,7 +569,7 @@ class GlobalChildSearch(models.TransientModel):
             # make a second request with a computed skip param to still get an available beneficiary when possible
             if self.nb_found and self.nb_found <= params['skip']:
                 # Set the 'skip' parameter to retrieve only middle urgent beneficiaries
-                params['skip'] = self.nb_found // 2
+                params['skip'] = self.nb_found // 2 if self.nb_found >= 2 else 0
                 result = onramp.send_message(service_name, method, None, params)
 
             if not result["content"][result_name]:


### PR DESCRIPTION
Related issue: [CP-310](https://compassion-ch.atlassian.net/browse/CP-310)

When we query our beneficiary API and get a response with less then 1000 available beneficiaries, it shows "No children found" to the user, this is because in the sms_sponsorship module, a `skip_value` is set to 1000 ([concerned code](https://github.com/CompassionCH/compassion-modules/blob/e2eb3e33aab39c840e64d69b9445881379869640/sms_sponsorship/models/sms_child_request.py#L299))
Therefore, I implemented a second request when this case is encountered asking for a middle position benificiary

Maybe it would be better to make a first request to get the number of available beneficiaries before setting `skip_value` to 1000 in an hardcoded way, and compute the value of skip_value depending on the total of available beneficiaries as 1000 is a too random number in my opinion, what do you think about this @ecino ? It will add a second request but as it will only concern the sms requests it could be viable?  

[CP-310]: https://compassion-ch.atlassian.net/browse/CP-310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ