### PR TITLE
FIX: check existence of skip param

### DIFF
--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -568,7 +568,7 @@ class GlobalChildSearch(models.TransientModel):
 
             # When the skip param default value is higher than the available beneficiaries
             # make a second request with a computed skip param to still get an available beneficiary when possible
-            if self.nb_found and self.nb_found <= params['skip']:
+            if self.nb_found and 'skip' in params and self.nb_found <= params['skip']:
                 # Set the 'skip' parameter to retrieve only middle urgent beneficiaries
                 params['skip'] = self.nb_found // 2 if self.nb_found >= 2 else 0
                 result = onramp.send_message(service_name, method, None, params)


### PR DESCRIPTION
Related issue: [CP-409](https://compassion-ch.atlassian.net/browse/CP-409)

Fix KeyError: 'skip' issue when searching a child on global childpool



[CP-409]: https://compassion-ch.atlassian.net/browse/CP-409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ