### PR TITLE
FIX: Add missing major_course_study selection

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -210,6 +210,7 @@ class CompassionChild(models.Model):
             ("Education", "Education"),
             ("Engineering", "Engineering"),
             ("English", "English"),
+            ("Environmental", "Environmental"),
             ("Fine Arts", "Fine Arts"),
             ("Government / Political Science", "Government / Political Science"),
             ("Graphic Arts", "Graphic Arts"),


### PR DESCRIPTION
Related issue: T0063 - Wrong value error on child get info

There was a missing value coming from GMC for the field major_course_sutdy.

Add selection value 'Environmental'