### PR TITLE
FIX: send report object instead of report.report_name

### DIFF
--- a/partner_communication/models/communication_attachment.py
+++ b/partner_communication/models/communication_attachment.py
@@ -109,10 +109,7 @@ class CommunicationAttachment(models.Model):
             else:
                 to_print = attachment.data
 
-            report = self.env["ir.actions.report"]._get_report_from_name(
-                attachment.report_name
-            ).with_context(
-                lang=attachment.communication_id.partner_id.lang)
+            report = self.report_id.with_context(lang=attachment.communication_id.partner_id.lang)
             behaviour = report.behaviour()
             printer = behaviour.pop("printer", False)
             if behaviour.pop("action", "client") != "client" and printer:
@@ -122,5 +119,5 @@ class CommunicationAttachment(models.Model):
                     print_options["output_tray"] = output_tray
                 printer.with_context(
                     print_name=self.env.user.firstname[:3] + " " + attachment.name,
-                ).print_document(attachment.report_name, to_print, **print_options)
+                ).print_document(report, to_print, **print_options)
         return True

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -867,7 +867,7 @@ class CommunicationJob(models.Model):
         if behaviour["action"] == "server" and printer:
             # Get pdf should directly send it to the printer
             to_print = report.render_qweb_pdf(self.ids)
-            printer.print_document(report.report_name, to_print[0], **print_options)
+            printer.print_document(report, to_print[0], **print_options)
 
         return print_options
 


### PR DESCRIPTION
_Related Issue: T0075 - Print reminder print duplex_

Send the report as a report object instead of report.report_name to ensure the handling of the right report afterwards

Related Pull Request: [1548](https://github.com/CompassionCH/compassion-switzerland/pull/1548), [5](https://github.com/CompassionCH/report-print-send/pull/5)
