### PR TITLE
FIX: set report from attachment instead of self

### DIFF
--- a/partner_communication/models/communication_attachment.py
+++ b/partner_communication/models/communication_attachment.py
@@ -109,7 +109,7 @@ class CommunicationAttachment(models.Model):
             else:
                 to_print = attachment.data
 
-            report = self.report_id.with_context(lang=attachment.communication_id.partner_id.lang)
+            report = attachment.report_id.with_context(lang=attachment.communication_id.partner_id.lang)
             behaviour = report.behaviour()
             printer = behaviour.pop("printer", False)
             if behaviour.pop("action", "client") != "client" and printer:


### PR DESCRIPTION
Related Issue: T0075 - Print reminder print duplex

After testing all reports, there is an issue when a communication is set with multiple attachments, 
As a communication can have many attachment, the report has to be set from the attachment variable instead of self.