### PR TITLE
FIX: Remove sanitize overcoat on body field

### DIFF
--- a/partner_communication/wizards/mail_compose_message.py
+++ b/partner_communication/wizards/mail_compose_message.py
@@ -14,8 +14,6 @@ from odoo import models, api, fields
 class EmailComposeMessage(models.TransientModel):
     _inherit = "mail.compose.message"
 
-    body = fields.Html(sanitize=False)
-
     @api.model
     def create_emails(self, template, res_ids, default_mail_values=None):
         """ Helper to generate a new e-mail given a template and objects.


### PR DESCRIPTION
Related ticket: T0179

The code causing the issue was added during the migration to 14.0
[Related commit](https://github.com/CompassionCH/compassion-modules/commit/89909be6d0e549f934cfc4134556b850528f751b#diff-df647e3c61da703e2d34a86fa76e8c918e7555817a34201bcc9830c0a20c9e09)

It was making the field body to be sanitize, but as this field it is already sanitized in the base mails addons, it was sanitizing the byte object as a string. 

As this field isn't used anywhere in the wizard, I removed it.