### PR TITLE
Add a link for SDS to follow the interaction they newly created

### DIFF
--- a/crm_compassion/wizards/partner_log_interaction_wizard.py
+++ b/crm_compassion/wizards/partner_log_interaction_wizard.py
@@ -7,7 +7,7 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-from odoo import models, api, fields
+from odoo import models, api, fields, _
 
 
 class LogInteractionWizard(models.TransientModel):
@@ -74,3 +74,8 @@ class LogInteractionWizard(models.TransientModel):
             ('mail_id', '=', mail.id)
         ]).unlink()
         mail_tracking_obj.sudo().create(vals)
+        self.partner_id.message_post(body=_(
+            "Your new interaction has been created! Click the link to access it: "
+            f"<a href=# data-oe-model={mail._name} data-oe-id={mail.id}>"
+            f"{mail.subject}</a>"
+        ))

--- a/crm_compassion/wizards/partner_log_other_interaction_wizard.py
+++ b/crm_compassion/wizards/partner_log_other_interaction_wizard.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import models, fields, _
 
 
 class LogOtherInteractionWizard(models.TransientModel):
@@ -21,8 +21,12 @@ class LogOtherInteractionWizard(models.TransientModel):
             "body": self.body,
             "date": self.date,
         }
-        self.env["partner.log.other.interaction"].create(data)
-
+        other_interaction = self.env["partner.log.other.interaction"].create(data)
+        self.partner_id.message_post(body=_(
+            "Your new interaction has been created! Click the link to access it: "
+            f"<a href=# data-oe-model={other_interaction._name} data-oe-id={other_interaction.id}>"
+            f"{other_interaction.subject + ' ' + other_interaction.other_type}</a>"
+        ))
 
 class OtherInteractions(models.Model):
     _name = "partner.log.other.interaction"


### PR DESCRIPTION
SDS now has to go through the interaction resume and open the interaction and the open their actual interaction they just created. that makes 3 to 4 clicks, in some case, that aren't necessary for them and make them loose a lot of time. This PR aim to provide an instant feedback on the log of an interaction and add a direct link to it.