### PR TITLE
T0168 interaction resume add a full time one

### DIFF
--- a/crm_compassion/models/interaction_resume.py
+++ b/crm_compassion/models/interaction_resume.py
@@ -56,10 +56,11 @@ class InteractionResume(models.TransientModel):
     )
 
     @api.model
-    def populate_resume(self, partner_id):
+    def populate_resume(self, partner_id, full=False):
         """
         Creates the rows for the resume of given partner
         :param partner_id: the partner
+        :param full: boolean to define if we limit the interaction on a time period
         :return: True
         """
         original_partner = self.env["res.partner"].browse(partner_id)
@@ -69,7 +70,7 @@ class InteractionResume(models.TransientModel):
         partner_ids += self.env["res.partner"].search([("email", "!=", False), ("email", "=", partner_email), ("id", "not in", partner_ids)]).ids
         self.search([("partner_id", "in", partner_ids)]).unlink()
         self.env.cr.execute(
-            """
+            f"""
                     -- Partner Communications (both e-mail and physical)
                     SELECT DISTINCT ON(email_id, subject)
                         CASE pcj.send_mode
@@ -102,7 +103,7 @@ class InteractionResume(models.TransientModel):
                         FULL OUTER JOIN mail_tracking_email mt ON pcj.email_id = mt.mail_id
                         WHERE pcj.state = 'done'
                         AND pcj.partner_id = ANY(%s)
-                        AND pcj.date BETWEEN (NOW() - interval '3 year') AND NOW()
+                        {"" if full else "AND pcj.date BETWEEN (NOW() - interval '2 year') AND NOW()"}
             -- phonecalls
                     UNION (
                       SELECT
@@ -128,6 +129,7 @@ class InteractionResume(models.TransientModel):
                         false as has_attachment
                         FROM "crm_phonecall" as crmpc
                         WHERE crmpc.partner_id = ANY(%s) AND crmpc.state = 'done'
+                        {"" if full else "AND crmpc.date BETWEEN (NOW() - interval '2 year') AND NOW()"}
                         )
             -- outgoing e-mails
                     UNION (
@@ -159,7 +161,7 @@ class InteractionResume(models.TransientModel):
                         AND mt.partner_id = ANY(%s)
                         AND (mail.direction = 'out' OR mail.direction IS NULL)
                         AND m.model != 'partner.communication.job'
-                        AND m.date BETWEEN (NOW() - interval '1 year') AND NOW()
+                        {"" if full else "AND m.date BETWEEN (NOW() - interval '2 year') AND NOW()"}
                         )
 
             -- mass mailings sent from mailchimp (no associated email)
@@ -197,7 +199,7 @@ class InteractionResume(models.TransientModel):
                         WHERE mail.sent IS NOT NULL
                         AND tracking.mail_id IS NULL  -- skip if it's already in mail
                         AND mail.email = %s
-                        AND mail.create_date BETWEEN (NOW() - interval '1 year') AND NOW()
+                        {"" if full else "AND mail.create_date BETWEEN (NOW() - interval '2 year') AND NOW()"}
                         )
             -- incoming messages from partners
                     UNION (
@@ -226,7 +228,7 @@ class InteractionResume(models.TransientModel):
                         WHERE m.subject IS NOT NULL
                         AND m.message_type = 'email'
                         AND m.author_id = ANY(%s)
-                        AND m.date BETWEEN (NOW() - interval '1 year') AND NOW()
+                        {"AND m.date BETWEEN (NOW() - interval '2 year') AND NOW()" if full else ""}
                         )
             -- other interactions
                     UNION (
@@ -250,6 +252,7 @@ class InteractionResume(models.TransientModel):
                         false as has_attachment
                         FROM "partner_log_other_interaction" as o
                         WHERE o.partner_id = ANY(%s)
+                        {"" if full else "AND o.date BETWEEN (NOW() - interval '2 year') AND NOW()"}
                         )
             ORDER BY communication_date desc
                             """,

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -72,13 +72,13 @@ class Partner(models.Model):
                 ]
             )
 
-    def open_interaction(self):
+    def open_interaction(self, full=False):
         """
         Populates data for interaction resume and open the view
         :return: action opening the view
         """
         self.ensure_one()
-        self.env["interaction.resume"].populate_resume(self.id)
+        self.env["interaction.resume"].populate_resume(self.id, full)
         partners_with_same_email_ids = (
             self.env["res.partner"]
                 .search([("email", "!=", False), ("email", "=", self.email), ('id', 'not in', self.ids)])
@@ -97,28 +97,7 @@ class Partner(models.Model):
         }
 
     def open_interaction_full(self):
-        """
-        Populates data for interaction resume and open the view
-        :return: action opening the view
-        """
-        self.ensure_one()
-        self.env["interaction.resume"].populate_resume(self.id, full=True)
-        partners_with_same_email_ids = (
-            self.env["res.partner"]
-                .search([("email", "!=", False), ("email", "=", self.email)])
-                .ids
-        )
-        return {
-            "name": _("Interaction resume"),
-            "type": "ir.actions.act_window",
-            "res_model": "interaction.resume",
-            "view_type": "form",
-            "view_mode": "tree,form",
-            "domain": [("partner_id", "in",
-                        self.ids + partners_with_same_email_ids +
-                        self.other_contact_ids.ids)],
-            "target": "current",
-        }
+        return self.open_interaction(full=True)
 
 
     @api.multi

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -96,6 +96,31 @@ class Partner(models.Model):
             "target": "current",
         }
 
+    def open_interaction_full(self):
+        """
+        Populates data for interaction resume and open the view
+        :return: action opening the view
+        """
+        self.ensure_one()
+        self.env["interaction.resume"].populate_resume(self.id, full=True)
+        partners_with_same_email_ids = (
+            self.env["res.partner"]
+                .search([("email", "!=", False), ("email", "=", self.email)])
+                .ids
+        )
+        return {
+            "name": _("Interaction resume"),
+            "type": "ir.actions.act_window",
+            "res_model": "interaction.resume",
+            "view_type": "form",
+            "view_mode": "tree,form",
+            "domain": [("partner_id", "in",
+                        self.ids + partners_with_same_email_ids +
+                        self.other_contact_ids.ids)],
+            "target": "current",
+        }
+
+
     @api.multi
     def log_call(self):
         """ Prepare crm.phonecall creation. """

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -72,6 +72,7 @@ class Partner(models.Model):
                 ]
             )
 
+    @api.multi
     def open_interaction(self, full=False):
         """
         Populates data for interaction resume and open the view

--- a/crm_compassion/views/res_partner_view.xml
+++ b/crm_compassion/views/res_partner_view.xml
@@ -12,14 +12,23 @@
         <field eval="18" name="priority"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="open_events" string="Events" type="object" groups="sales_team.group_sale_salesman" class="oe_stat_button" icon="fa-calendar"/>
+                <button name="open_events" string="Events" type="object" groups="sales_team.group_sale_salesman"
+                        class="oe_stat_button" icon="fa-calendar"/>
             </xpath>
             <xpath expr="//div[@name='button_box']/button[@name='action_view_partner_invoices']" position="after">
                 <button name="open_interaction"
-                    string ="Interaction Resume"
-                    type="object"
-                    class="oe_stat_button"
-                    icon="fa-envelope-o">
+                        string="Newest Interactions"
+                        title="Interaction for this partner on the last two years"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-envelope-o">
+                </button>
+                <button name="open_interaction_full"
+                        string="Full Interactions"
+                        title="Interaction for this partner since the beginning"
+                        type="object"
+                        class="oe_stat_button"
+                        icon="fa-envelope-o">
                 </button>
             </xpath>
         </field>


### PR DESCRIPTION
This commits add the button to open a full time interaction_resume. Improvement possible: Add a setting preference that would allow the users to define what button they want to see on the interface (both (full/newest) or only one of them they prefer).



DEPENDS ON https://github.com/CompassionCH/compassion-switzerland/pull/1557