### PR TITLE
540 notification remove intervention hold is failing

### DIFF
--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -743,7 +743,7 @@ class CompassionIntervention(models.Model):
         # erroneous data
         del ihrn["InterventionType_Name"]
 
-        vals = self.json_to_data(commkit_data)
+        vals = self.json_to_data(ihrn)
         intervention_id = vals["intervention_id"]
 
         intervention = self.env["compassion.intervention"].search(


### PR DESCRIPTION
The way the JSON was given to the message processing wasn't correct so the mapping wasn't working at all.