### PR TITLE
571 - Bug fixes

### DIFF
--- a/sbc_compassion/models/last_writing_report.py
+++ b/sbc_compassion/models/last_writing_report.py
@@ -21,7 +21,7 @@ class LastWritingReport(models.Model):
     sponsorship_id = fields.Many2one(
         "recurring.contract", "Sponsorship", readonly=False
     )
-    name = fields.Char(related="sponsorship_id.name")
+    name = fields.Char(related="sponsorship_id.display_name")
     partner_id = fields.Many2one("res.partner", "Partner", readonly=False)
     child_id = fields.Many2one("compassion.child", "Child", readonly=False)
     sponsorship_type = fields.Selection(related="sponsorship_id.type")

--- a/sponsorship_compassion/data/gmc_action.xml
+++ b/sponsorship_compassion/data/gmc_action.xml
@@ -47,6 +47,7 @@
             <field name="connect_outgoing_wrapper">CorrespondentList</field>
             <field name="connect_answer_wrapper">CorrespondentCreateResponseList</field>
             <field name="request_type">POST</field>
+            <field name="success_method">correspondence_updated</field>
             <field name="batch_send">1</field>
             <field name="priority">50</field>
         </record>

--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -135,7 +135,6 @@ class SponsorshipContract(models.Model):
     sub_sponsorship_id = fields.Many2one(
         "recurring.contract", "sub sponsorship", readonly=True, copy=False, index=True
     )
-    name = fields.Char(store=True, compute="name_get", copy=False)
     partner_id = fields.Many2one(
         "res.partner",
         "Partner",
@@ -152,7 +151,8 @@ class SponsorshipContract(models.Model):
     )
     gmc_correspondent_commitment_id = fields.Char(
         readonly=True,
-        help="Id of the correspondent commitment."
+        help="Id of the correspondent commitment.",
+        tracking=True
     )
     type = fields.Selection(
         [
@@ -359,7 +359,6 @@ class SponsorshipContract(models.Model):
                     name += " - " + contract.child_code
                 elif contract.contract_line_ids:
                     name += " - " + contract.contract_line_ids[0].product_id.name
-                contract.name = name
                 result.append((contract.id, name))
         return result
 
@@ -541,6 +540,8 @@ class SponsorshipContract(models.Model):
         old_partners = self.env["res.partner"]
         if "partner_id" in vals:
             old_partners = self.mapped("partner_id")
+        if "correspondent_id" in vals:
+            old_partners |= self.mapped("correspondent_id")
 
         # Change the sub_sponsorship_id value in the previous parent_id
         if "parent_id" in vals:
@@ -563,7 +564,7 @@ class SponsorshipContract(models.Model):
         if "reading_language" in vals:
             (self - updated_correspondents)._on_language_changed()
 
-        if "partner_id" in vals:
+        if old_partners:
             self.mapped("partner_id").update_number_sponsorships()
             old_partners.update_number_sponsorships()
 
@@ -613,6 +614,12 @@ class SponsorshipContract(models.Model):
         # Force refresh some fields in case they are not in sync
         self.mapped("partner_id").update_number_sponsorships()
         self._compute_active()
+        return True
+
+    def correspondence_updated(self, vals):
+        # Called after answer from GMC when changing the correspondent
+        self.write({"gmc_correspondent_commitment_id": vals["gmc_correspondent_commitment_id"]})
+        self.correspondent_id.update_number_sponsorships()
         return True
 
     def cancel_sent(self, vals):
@@ -858,6 +865,8 @@ class SponsorshipContract(models.Model):
 
     def _change_correspondent(self):
         self.ensure_one()
+        if not self.correspondent_id.global_id:
+            self.correspondent_id.upsert_constituent().process_messages()
         message_obj = self.env["gmc.message"].with_context({"async_mode": False})
         upsert_correspondent_gmc = self.env.ref("sponsorship_compassion.upsert_correspondent_commitment")
 
@@ -865,7 +874,6 @@ class SponsorshipContract(models.Model):
             raise UserError(_("You can't change the correspondent of a"
                               " cancelled or terminated sponsorship"))
 
-        # Cancel sponsorship at GMC
         message = message_obj.create(
             {
                 "action_id": upsert_correspondent_gmc.id,
@@ -886,8 +894,6 @@ class SponsorshipContract(models.Model):
             raise UserError(_("GMC returned an error :") + "\n" + error_message)
         elif message.state == "odoo_failure":
             logger.warning(message.failure_reason)
-
-        self.correspondent_id.update_number_sponsorships()
         return True
 
     def add_correspondent(self):

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -435,11 +435,11 @@ class ResPartner(models.Model):
     #                             PUBLIC METHODS                             #
     ##########################################################################
     def upsert_constituent(self):
-        """If partner has active contracts, UPSERT Constituent in GMC."""
+        """UPSERT Constituent in GMC."""
         message_obj = self.env["gmc.message"].with_context(async_mode=False)
         messages = message_obj
         action_id = self.env.ref("sponsorship_compassion.upsert_partner").id
-        for partner in self.filtered("has_sponsorships"):
+        for partner in self:
             if not partner.ref:
                 partner.ref = self.env["ir.sequence"].next_by_code("partner.ref")
             # UpsertConstituent Message if not one already pending

--- a/sponsorship_compassion/views/res_partner_view.xml
+++ b/sponsorship_compassion/views/res_partner_view.xml
@@ -115,7 +115,7 @@
                             <tree decoration-info="state == 'draft'" decoration-bf="state == 'active'"
                                   decoration-success="state == 'waiting'"
                                   decoration-muted="state in ('terminated','cancelled')">
-                                <field name="name"/>
+                                <field name="display_name"/>
                                 <field name="create_date"/>
                                 <field name="start_date"/>
                                 <field name="end_date"/>

--- a/sponsorship_compassion/views/sponsorship_contract_view.xml
+++ b/sponsorship_compassion/views/sponsorship_contract_view.xml
@@ -24,7 +24,7 @@
             </xpath>
             <!-- Hide reference -->
             <field name="reference" position="replace">
-                <field name="name" readonly="True"/>
+                <field name="display_name" readonly="True"/>
             </field>
 
             <field name="comment" position="after">
@@ -211,7 +211,7 @@
                                 <div class="oe_product_desc">
                                     <a type="open">
                                         <h4>
-                                            <field name="name"/>
+                                            <field name="display_name"/>
                                         </h4>
                                     </a>
                                     <ul>


### PR DESCRIPTION
- [Unrelated] name field in contracts is not needed and was causing infinite loops in some cases when it was recomputed
- [IMP] Track the changes of correspondent_gmc_id values
- [FIX] Correctly update the number of sponsorships of previous and new correspondent
- [FIX] Declare new correspondent if it was not existing at GMC side
- [FIX] Avoid infinite loop when receiving answer from GMC (because it was writing again the correspondent_id field and restarting the process)