### PR TITLE
T0322 FIX correspondence sponsor sex declaration

### DIFF
--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -417,7 +417,7 @@ class Correspondence(models.Model):
             "sponsor": {
                 "preferredName": partner.preferred_name,
                 "fullName": partner.name,
-                "sex": partner.gmc_gender[0],
+                "sex": partner.title.name,
                 "age": partner.age,
                 "ref": partner.ref
             },


### PR DESCRIPTION
Related Ticket: T0322 - Sponsor is always declared as woman

Fix the issue where the sponsor's sex was always declared wrong. 
the gmc_gender was returning an undefined value, 

I refactored the view on the translation platform to show the title instead of the sex, this is better for our translators.
https://github.com/CompassionCH/translation-platform-web/pull/21