### PR TITLE
T0354 Handle None value for ICP in JSON

### DIFF
--- a/intervention_compassion/models/compassion_intervention.py
+++ b/intervention_compassion/models/compassion_intervention.py
@@ -849,7 +849,7 @@ class CompassionIntervention(models.Model):
     @api.multi
     def json_to_data(self, json, mapping_name=None):
         json = json.get("InterventionAmendmentKitRequest", json)
-        if "ICP" in json:
+        if "ICP" in json and json["ICP"] is not None:
             json["ICP"] = json["ICP"].split("; ")
         return super().json_to_data(json, mapping_name)
 


### PR DESCRIPTION
Related Ticket: T0354

Fix the error encountering when ICP value was null
AttributeError: 'NoneType' object has no attribute 'split' 

This needs to be fix in branch 14.0 also, [see related PR](https://github.com/CompassionCH/compassion-modules/pull/1795)