### PR TITLE
T0399 Duplication of gift invoice shouldn't keep the gift_id

### DIFF
--- a/gift_compassion/models/account_invoice_line.py
+++ b/gift_compassion/models/account_invoice_line.py
@@ -14,4 +14,4 @@ from odoo import models, fields
 class InvoiceLine(models.Model):
     _inherit = "account.invoice.line"
 
-    gift_id = fields.Many2one("sponsorship.gift", "GMC Gift", readonly=False)
+    gift_id = fields.Many2one("sponsorship.gift", "GMC Gift", readonly=False, copy=False)

--- a/gift_compassion/models/sponsorship_gift.py
+++ b/gift_compassion/models/sponsorship_gift.py
@@ -57,7 +57,7 @@ class SponsorshipGift(models.Model):
         readonly=False,
     )
     invoice_line_ids = fields.One2many(
-        "account.invoice.line", "gift_id", string="Invoice lines", readonly=True
+        "account.invoice.line", "gift_id", string="Invoice lines", readonly=True, copy=False
     )
     payment_id = fields.Many2one(
         "account.move", "GMC Payment", copy=False, readonly=False


### PR DESCRIPTION
We shouldn't copy the gift id when we duplicate an invoice.