### PR TITLE
T0202 avoid matching only email

### DIFF
--- a/partner_auto_match/models/res_partner_match.py
+++ b/partner_auto_match/models/res_partner_match.py
@@ -122,12 +122,13 @@ class ResPartnerMatch(models.AbstractModel):
         Each of the listed method must take a partner_obj and the infos as
         their parameter. They must also return a recordset of partner.
         """
-        return ["email", "name_and_zip"]
+        return ["email_and_name", "name_and_zip"]
 
     @api.model
-    def _match_email(self, vals):
+    def _match_email_and_name(self, vals):
         email = vals["email"].strip()
         return self.env["res.partner"].search([
+            ("name", "ilike", vals["name"]),
             ("email", "=ilike", email),
         ])
 


### PR DESCRIPTION
In case a partner enter an already used email it might change some important data. We avoid too big security failure by checking the name too.