### PR TITLE
T0394 can't reply to letter comment due to tree view in the wizard

### DIFF
--- a/sbc_translation/data/mail_template.xml
+++ b/sbc_translation/data/mail_template.xml
@@ -1,4 +1,4 @@
-<odoo>
+<odoo noupdate="1">
     <record id="translation_issue_notification" model="mail.template">
         <field name="name">Translation issue notification</field>
         <field name="subject">A translation issue was raised</field>
@@ -19,7 +19,8 @@
         <p>Dear <span t-field="object.new_translator_id.partner_id.name"/>,</p>
         <p>You just received a reply regarding your comments on the translation:</p>
         <p t-raw="reply"/>
-        <hr/>
+        <p>Thank you for your help.</p>
+        <br/><hr/><br/>
         <table>
             <tr>
                 <th style="width: 40%">Paragraph</th>

--- a/sbc_translation/data/mail_template.xml
+++ b/sbc_translation/data/mail_template.xml
@@ -33,13 +33,14 @@
                     </tr>
                 </t>
             </t>
-        </br><p>Thank you for your help,
+        </table>
+        <hr/>
+        <p><a t-att-href="object.translation_url">Open the letter in the translation platform</a></p>
+        <hr/>
+        <br/><p>Thank you for your help,
         % if user and user.signature:
         ${user.signature | safe}
         % endif
         </p>
-        </table>
-        <hr/>
-        <p><a t-att-href="object.translation_url">Open the letter in the translation platform</a></p>
     </template>
 </odoo>

--- a/sbc_translation/data/mail_template.xml
+++ b/sbc_translation/data/mail_template.xml
@@ -19,8 +19,7 @@
         <p>Dear <span t-field="object.new_translator_id.partner_id.name"/>,</p>
         <p>You just received a reply regarding your comments on the translation:</p>
         <p t-raw="reply"/>
-        <p>Thank you for your help.</p>
-        <br/><hr/><br/>
+        <hr/>
         <table>
             <tr>
                 <th style="width: 40%">Paragraph</th>
@@ -34,6 +33,11 @@
                     </tr>
                 </t>
             </t>
+        </br><p>Thank you for your help,
+        % if user and user.signature:
+        ${user.signature | safe}
+        % endif
+        </p>
         </table>
         <hr/>
         <p><a t-att-href="object.translation_url">Open the letter in the translation platform</a></p>

--- a/sbc_translation/wizards/reply_to_comments_view.xml
+++ b/sbc_translation/wizards/reply_to_comments_view.xml
@@ -6,15 +6,6 @@
         <field name="arch" type="xml">
             <form string="Reply to comments">
                 <group>
-                    <field name="paragraph_ids">
-                        <tree default_order="page_id asc, sequence asc">
-                            <field name="original_text"/>
-                            <field name="translated_text"/>
-                            <field name="comments"/>
-                        </tree>
-                    </field>
-                </group>
-                <group>
                     <field name="answer"/>
                 </group>
                 <footer>

--- a/sbc_translation/wizards/reply_to_comments_view.xml
+++ b/sbc_translation/wizards/reply_to_comments_view.xml
@@ -7,6 +7,7 @@
             <form string="Reply to comments">
                 <group>
                     <field name="answer"/>
+                    <p class="text-muted">Your reply will be added in an automatic email with greetings.</p>
                 </group>
                 <footer>
                     <button name="send_reply" string="Send reply" type="object" class="btn-primary"/>


### PR DESCRIPTION
When the tree view is available in the wizard the button doesn't work if we take out the tree view direclty of the view it works all good. The translator supervisor has the comment and the letter paragraph behind the wizard in gray.