### PR TITLE
FIX compute only done letter as translated

### DIFF
--- a/sbc_translation/models/translation_user.py
+++ b/sbc_translation/models/translation_user.py
@@ -45,7 +45,9 @@ class TranslationUser(models.Model):
     @api.depends("translated_letter_ids")
     def _compute_nb_translated_letters(self):
         for translator in self:
-            translator.nb_translated_letters = len(translator.translated_letter_ids)
+            translator.nb_translated_letters = len(translator.translated_letter_ids.filtered(
+                lambda letter: letter.translation_status == "done"
+            ))
 
     @api.multi
     @api.depends("translated_letter_ids")


### PR DESCRIPTION
Related ticket [T0409](https://erp.compassion.ch/web#id=1211&action=521&active_id=898&model=project.task&view_type=form&menu_id=924)

The compute method was counting letters as translated even when the translation was in progress, this change make sure that we count only the translation in a done translation state