### PR TITLE
T0641 FEAT: Change invoice matching

### DIFF
--- a/account_reconcile_compassion/__manifest__.py
+++ b/account_reconcile_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Bank Statement Reconcile for Compassion CH",
-    "version": "14.0.1.1.0",
+    "version": "14.0.1.1.1",
     "author": "Compassion CH",
     "license": "AGPL-3",
     "category": "Finance",
@@ -54,6 +54,7 @@
         "views/statement_view.xml",
         "views/statement_operation_view.xml",
         "views/view_bank_statement_form.xml",
+        "views/view_account_reconcile_compassion.xml",
     ],
     "qweb": ["static/src/xml/account_move_reconciliation.xml"],
     "auto_install": False,

--- a/account_reconcile_compassion/views/view_account_reconcile_compassion.xml
+++ b/account_reconcile_compassion/views/view_account_reconcile_compassion.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_reconcile_view_form" model="ir.ui.view">
+        <field name="name">account.reconcile.model.form</field>
+        <field name="model">account.reconcile.model</field>
+        <field name="inherit_id" ref="account.view_account_reconcile_model_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='past_months_limit']" position="after">
+                <field name="only_this_month" attrs="{'invisible': [('past_months_limit', '!=', 0)]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
 Modify the invoice matching query to be able to take only the current month.  In the same time we modify the date used in the query to use the line date and not the invoice date