### PR TITLE
 [T0648] FIX rename type beneficiary to participant

### DIFF
--- a/child_compassion/models/child_lifecycle_event.py
+++ b/child_compassion/models/child_lifecycle_event.py
@@ -26,6 +26,7 @@ class ChildLifecycleEvent(models.Model):
     type = fields.Selection(
         [
             ("Beneficiary Update", "Beneficiary Update"),
+            ("Participant Update", "Participant Update"),
             ("Home Based Caregiver Death", "Home Based Caregiver Death"),
             ("Planned Exit", "Planned Exit"),
             ("Registration", "Registration"),

--- a/child_compassion/models/child_lifecycle_event.py
+++ b/child_compassion/models/child_lifecycle_event.py
@@ -25,7 +25,7 @@ class ChildLifecycleEvent(models.Model):
     date = fields.Date(readonly=True)
     type = fields.Selection(
         [
-            ("Participant Update", "Participant Update"),
+            ("Beneficiary Update", "Beneficiary Update"),
             ("Home Based Caregiver Death", "Home Based Caregiver Death"),
             ("Planned Exit", "Planned Exit"),
             ("Registration", "Registration"),

--- a/child_compassion/models/child_lifecycle_event.py
+++ b/child_compassion/models/child_lifecycle_event.py
@@ -25,7 +25,7 @@ class ChildLifecycleEvent(models.Model):
     date = fields.Date(readonly=True)
     type = fields.Selection(
         [
-            ("Beneficiary Update", "Beneficiary Update"),
+            ("Participant Update", "Participant Update"),
             ("Home Based Caregiver Death", "Home Based Caregiver Death"),
             ("Planned Exit", "Planned Exit"),
             ("Registration", "Registration"),

--- a/child_compassion/models/household.py
+++ b/child_compassion/models/household.py
@@ -79,10 +79,10 @@ class Household(models.Model):
     def _compute_siblings(self):
         for household in self:
             brothers = household.member_ids.filtered(
-                lambda member: member.role in ("Brother", "Beneficiary - Male")
+                lambda member: member.role in ("Brother", "Beneficiary - Male", "Participant - Male")
             )
             sisters = household.member_ids.filtered(
-                lambda member: member.role in ("Sister", "Beneficiary - Female")
+                lambda member: member.role in ("Sister", "Beneficiary - Female", "Participant - Female")
             )
             household.nb_brothers = (
                 len(brothers) - 1
@@ -127,7 +127,8 @@ class Household(models.Model):
             lambda member: member.is_caregiver
             and member.role
             not in ("Brother", "Sister", "Beneficiary - Male",
-                    "Beneficiary - Female")
+                    "Participant - Male", "Beneficiary - Female",
+                    "Participant - Female")
         )
         return caregivers
 
@@ -277,6 +278,7 @@ class HouseholdMembers(models.Model):
             ("Godfather", _("godfather")),
             ("Brother", _("brother")),
             ("Beneficiary - Male", "Beneficiary - Male"),
+            ("Participant - Male", "Participant - Male")
         ]
 
     @api.model
@@ -290,6 +292,7 @@ class HouseholdMembers(models.Model):
             ("Godmother", _("godmother")),
             ("Sister", _("sister")),
             ("Beneficiary - Female", "Beneficiary - Female"),
+            ("Participant - Female", "Participant - Female")
         ]
 
     @api.model

--- a/child_compassion/wizards/child_description.py
+++ b/child_compassion/wizards/child_description.py
@@ -330,9 +330,9 @@ class ChildDescription(models.TransientModel):
             caregiver = household.primary_caregiver_id
             if caregiver:
                 caregiver_role = household.primary_caregiver
-                if caregiver_role == "Beneficiary - Male":
+                if caregiver_role == "Beneficiary - Male" or caregiver_role == "Participant - Male":
                     caregiver_role = _("brother")
-                if caregiver_role == "Beneficiary - Female":
+                if caregiver_role == "Beneficiary - Female" or caregiver_role == "Participant - Female":
                     caregiver_role = _("sister")
                 live_with += (
                     _("with")


### PR DESCRIPTION
Related ticket: [T0648](https://erp.compassion.ch/web#id=1224&action=521&active_id=895&model=project.task&view_type=form&menu_id=924)

Beneficiary has been renamed to Participant