### PR TITLE
T0010 Feat: Change the error logging to be more precise.

### DIFF
--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -16,8 +16,8 @@ from io import BytesIO
 
 from jinja2 import TemplateSyntaxError
 
+from odoo.exceptions import UserError, QWebException, MissingError
 from odoo import _, api, fields, models, tools
-from odoo.exceptions import QWebException, UserError
 
 _logger = logging.getLogger(__name__)
 testing = tools.config.get("test_enable")
@@ -502,21 +502,21 @@ class CommunicationJob(models.Model):
                         .with_context(lang=lang)
                         .get_generated_fields(job.email_template_id, [job.id])
                     )
-                    assert fields["body_html"] and fields["subject"]
-                    job.write(
-                        {
-                            "body_html": fields["body_html"],
-                            "subject": fields["subject"],
-                            "state": job.state if job.state != "failure" else "pending",
-                        }
-                    )
-                except (UserError, QWebException, TemplateSyntaxError, AssertionError):
-                    _logger.error("Failed to generate communication", exc_info=True)
+                    if not fields["body_html"] and not fields["subject"]:
+                        raise MissingError("Fields don't have a subject and a body")
+                    job.write({
+                        "body_html": fields["body_html"],
+                        "subject": fields["subject"],
+                        "state": job.state if job.state != "failure" else "pending"
+                    })
+                except (MissingError, UserError, QWebException, TemplateSyntaxError) as e:
+                    _logger.error("Failed to generate communication {}".format(str(e)), exc_info=True)
                     job.env.clear()
                     if job.state == "pending":
-                        job.write(
-                            {"state": "failure", "body_html": "Error in template"}
-                        )
+                        job.write({
+                            "state": "failure",
+                            "body_html": "{} {}".format(str(type(e)), str(e))
+                        })
         return True
 
     def quick_refresh(self):


### PR DESCRIPTION
When generating a communication, if the template in use is set with wrong values, or have a wrong behavior, the communication state is set to failure, and the error message is always “Error in template”. This error message is not enough and need to contains more details. This error message is visible to the user, when the user encounter it, he report it to the IT team. The IT team then correct the template.

In the same time we change an assert into a raise to clean the code