### PR TITLE
T0837 -  Fix translator manual change

### DIFF
--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -411,8 +411,8 @@ class Correspondence(models.Model):
     def _compute_beneficiary_language_ids(self):
         for letter in self:
             letter.beneficiary_language_ids = (
-                    letter.child_id.project_id.field_office_id.spoken_language_ids
-                    + letter.child_id.project_id.field_office_id.translated_language_ids
+                letter.child_id.project_id.field_office_id.spoken_language_ids
+                + letter.child_id.project_id.field_office_id.translated_language_ids
             )
 
     ##########################################################################

--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -158,6 +158,15 @@ class Correspondence(models.Model):
             ("other", _("Other issue")),
         ]
 
+    @api.onchange("new_translator_id")
+    def onchange_new_translator_id(self):
+        """
+         When a translator is set, the letter should always be on "in progress" status to ensure that the letter can
+         be found under the translator's saved letters in the Translation Platform.
+        """
+        if self.new_translator_id:
+            self.translation_status = "in progress"
+
     ##########################################################################
     #                              ORM METHODS                               #
     ##########################################################################


### PR DESCRIPTION
Related task : [T0837](https://erp.compassion.ch/web#id=1429&action=521&active_id=895&model=project.task&view_type=form&menu_id=924)

**Issue**
When an internal user was manually setting a local translator to a correspondence, the translator user wasn't able to see the letter in his Saved Letters in the Translation Platform. This was related to the fact that the Translation Platform only retrieves letters that are in state "in progress" for saved letters.

**Fix**
As a correspondence that has a new translator set should always be in the status "In progress", a function with an onchange decorator can handle this case. 
