### PR TITLE
T0662

### DIFF
--- a/partner_communication_crm_phone/__manifest__.py
+++ b/partner_communication_crm_phone/__manifest__.py
@@ -36,7 +36,7 @@
     "website": "https://github.com/CompassionCH/compassion-modules",
     "depends": [
         "partner_communication",
-        "crm_phone",  # OCA/connector-telephony
+        "crm_phonecall",  # OCA/connector-telephony
     ],
     "external_dependencies": {"python": ["phonenumbers"]},
     "data": [

--- a/partner_communication_crm_phone/views/crm_phone_view.xml
+++ b/partner_communication_crm_phone/views/crm_phone_view.xml
@@ -3,7 +3,7 @@
     <record id="crm_phonecall_view" model="ir.ui.view">
         <field name="name">crm.phonecall.view</field>
         <field name="model">crm.phonecall</field>
-        <field name="inherit_id" ref="crm_phone.crm_phonecall_form" />
+        <field name="inherit_id" ref="crm_phonecall.crm_case_phone_form_view" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='priority']" position="after">
                 <field name="communication_id" />


### PR DESCRIPTION
"crm_phone" module removed and performed a migration for "partner_communication_crm_phone" module from "crm_phone" to "crm_phonecall", which is maintained in next odoo versions. (minor changes due to pre-commit).