### PR TITLE
Update contracts.py

### DIFF
--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -850,7 +850,7 @@ class SponsorshipContract(models.Model):
                 contract.state = "waiting"
             elif contract.type in ["SC", "SWP"]:
                 # Activate directly correspondence sponsorships
-                contract.contract_active()
+                return contract.contract_active()
         return super().contract_waiting()
 
     @api.multi


### PR DESCRIPTION
without the return, it will check again the state in the super and throw an error.

this change is already in production and seems to be ok