### PR TITLE
added default selection of tag = Correspondance by Compassion in s2b generator

### DIFF
--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -49,7 +49,7 @@ class CorrespondenceS2bGenerator(models.Model):
     template_id = fields.Many2one(required=True, domain=[("type", "=", "s2b")])
     background = fields.Image(related="template_id.template_image")
     selection_domain = fields.Char(
-        default=[("state", "=", "active"), ("child_id", "!=", False)]
+        default=[("partner_id.category_id", "=", "Correspondance by Compassion"), ("state", "=", "active"), ("child_id", "!=", False)]
     )
     sponsorship_ids = fields.Many2many(
         "recurring.contract", string="Sponsorships", required=True, readonly=False


### PR DESCRIPTION
added in the default selection when generating a s2b the `partner_id._category_id = Correspondance by compassion` in [sbc_compassion/models/correspondence_s2b_generator.py](sbc_compassion/models/correspondence_s2b_generator.py) line 52.