### PR TITLE
[T1383] - Fix: Log notes in request

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -214,7 +214,7 @@ class CrmClaim(models.Model):
         if "mail_server_id" in kwargs and not self.env.context.get("keep_stage"):
             resolved_stage = self.env.ref("crm_claim.stage_claim2")
             self.write({"stage_id": resolved_stage.id})
-        return result
+        return result.id
 
     @api.onchange("partner_id")
     def onchange_partner_id(self):


### PR DESCRIPTION
Log notes in request in post_message had to return the integer id of message but he was passing an object. Now fixed.