### PR TITLE
Fix t1306 crm teams empty opportunities not shown

### DIFF
--- a/crm_compassion/models/crm_lead.py
+++ b/crm_compassion/models/crm_lead.py
@@ -97,9 +97,11 @@ class CrmLead(models.Model):
             search_domain = [
                 *(["|"] * (len(team_id_domain) - 1) + team_id_domain),
             ]
-            res += stages.browse(stages._search(
-                search_domain, order=order, access_rights_uid=SUPERUSER_ID
-            ))
+            res += stages.browse(
+                stages._search(
+                    search_domain, order=order, access_rights_uid=SUPERUSER_ID
+                )
+            )
 
             # Order is lost by the merge and empty stages are pushed back, so we need
             # to sort them.

--- a/crm_compassion/models/crm_lead.py
+++ b/crm_compassion/models/crm_lead.py
@@ -10,7 +10,7 @@
 
 import datetime
 
-from odoo import api, fields, models, SUPERUSER_ID
+from odoo import SUPERUSER_ID, api, fields, models
 
 
 class CrmLead(models.Model):
@@ -84,26 +84,34 @@ class CrmLead(models.Model):
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order):
-        team_id = self._context.get('default_team_id')
+        team_id = self._context.get("default_team_id")
 
         # default behavior of parent
         if team_id:
-            search_domain = ['|',
-                             ('id', 'in', stages.ids),
-                             '|',
-                             ('team_id', '=', False),
-                             ('team_id', '=', team_id)]
+            search_domain = [
+                "|",
+                ("id", "in", stages.ids),
+                "|",
+                ("team_id", "=", False),
+                ("team_id", "=", team_id),
+            ]
         else:
-            search_domain = ['|',
-                             ('id', 'in', stages.ids),
-                             ('team_id', '=', False)]
+            search_domain = ["|", ("id", "in", stages.ids), ("team_id", "=", False)]
 
         # if the domain contains team_id filters, add them to the search domain
-        team_id_domain = [cond for cond in domain if hasattr(cond, "__getitem__") and cond[0] == "team_id"]
+        team_id_domain = [
+            cond
+            for cond in domain
+            if hasattr(cond, "__getitem__") and cond[0] == "team_id"
+        ]
         if len(team_id_domain) > 0:
-            search_domain = ['|',
-                             *search_domain,
-                             *(['|'] * (len(team_id_domain) - 1) + team_id_domain)]
+            search_domain = [
+                "|",
+                *search_domain,
+                *(["|"] * (len(team_id_domain) - 1) + team_id_domain),
+            ]
 
-        stage_ids = stages._search(search_domain, order=order, access_rights_uid=SUPERUSER_ID)
+        stage_ids = stages._search(
+            search_domain, order=order, access_rights_uid=SUPERUSER_ID
+        )
         return stages.browse(stage_ids)

--- a/crm_compassion/models/crm_lead.py
+++ b/crm_compassion/models/crm_lead.py
@@ -114,4 +114,6 @@ class CrmLead(models.Model):
         stage_ids = stages._search(
             search_domain, order=order, access_rights_uid=SUPERUSER_ID
         )
-        return stages.browse(stage_ids)
+        return stages.browse(stage_ids) + super(CrmLead, self)._read_group_stage_ids(
+            stages, domain, order
+        )

--- a/crm_compassion/models/crm_lead.py
+++ b/crm_compassion/models/crm_lead.py
@@ -10,8 +10,10 @@
 
 import datetime
 
-from odoo import api, fields, models
+from odoo import api, fields, models, SUPERUSER_ID
 
+import logging
+_logger = logging.getLogger(__name__)
 
 class CrmLead(models.Model):
     _inherit = "crm.lead"
@@ -81,3 +83,28 @@ class CrmLead(models.Model):
         for lead in self:
             if not lead.name and lead.partner_id and lead.partner_id.name:
                 lead.name = lead.partner_id.name
+
+    @api.model
+    def _read_group_stage_ids(self, stages, domain, order):
+        team_id = self._context.get('default_team_id')
+        if team_id:
+            search_domain = ['|',
+                             ('id', 'in', stages.ids),
+                             '|',
+                             ('team_id', '=', False),
+                             ('team_id', '=', team_id)]
+        else:
+            team_id_domain = [cond for cond in domain if cond[0] == "team_id"]
+            if len(team_id_domain) is not 0:
+                search_domain = ['|',
+                                 ('id', 'in', stages.ids),
+                                 '|',
+                                 ('team_id', '=', False),
+                                 *team_id_domain]
+            else:
+                search_domain = ['|',
+                                 ('id', 'in', stages.ids),
+                                 ('team_id', '=', False)]
+
+        stage_ids = stages._search(search_domain, order=order, access_rights_uid=SUPERUSER_ID)
+        return stages.browse(stage_ids)

--- a/crm_compassion/models/crm_lead.py
+++ b/crm_compassion/models/crm_lead.py
@@ -101,6 +101,8 @@ class CrmLead(models.Model):
                 search_domain, order=order, access_rights_uid=SUPERUSER_ID
             ))
 
-        # Order is lost by the merge and empty stages are pushed back, so we need
-        # to sort them.
-        return res.sorted()
+            # Order is lost by the merge and empty stages are pushed back, so we need
+            # to sort them.
+            res = res.sorted()
+
+        return res


### PR DESCRIPTION
### Description

When a CRM stage (column) has 0 opportunities (cards) in it, it is not shown to its belonging sales team members (if a sales team is set in the stage parameters) in the kanban view.

We need to show the stage to the team members even when there is 0 opportunities in it.

It could be related to a wrong XML parameter somewhere on the compassion CRM module.

### How to reproduce

- In CRM Module, create your Sale Team and add your user to it

- On the Pipeline view, create a new column, edit it with the wheel icon, set the Sale Team to yours

- Hard Refresh the page