### PR TITLE
T1628 missing attachment multi refresh communications

### DIFF
--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -727,7 +727,7 @@ class CommunicationJob(models.Model):
                                     "data": data[1],
                                 }
                             )
-                            self.attachment_ids += attachment_id
+                            job.attachment_ids += attachment_id
                 except Exception:
                     _logger.error("Error during attachment creation", exc_info=True)
                     job.env.clear()


### PR DESCRIPTION

## Task
### Context

In Odoo, sometimes we need to refresh a communication, to reload the dynamics value coming from the template handling by a communication rule.

When we do a "Refresh communication" from the record directly, there is no issue, the attachment is computed and present, but when we do it from the list view of the communications, with the Action Refresh communication,

the attachment are not linked properly.

This was working well in Odoo12. Odoo14 changed the way of how works attachment, we need to adapt the code when refreshing more than one communication object.

SDS should be aware of this issue from today, July 12 2024. They need this functionality, currently they are losing a lot of time by refreshing the communication one by one when needed.

 

### Todo

Investigate the issue, and fix the related code.

