### PR TITLE
T1630 - Change supporter 'Unreconciled items' filter (1/2)

### DIFF
--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -150,7 +150,7 @@ class ResPartner(models.Model):
                     ("reconciled", "=", False),
                     ("account_id.reconcile", "=", True),
                     ("account_id.code", "=", "1050"),
-                    ("parent_state", "=", "posted")
+                    ("parent_state", "=", "posted"),
                 ]
             )
             partner.receivable_items = move_line_obj.search_count(
@@ -285,8 +285,7 @@ class ResPartner(models.Model):
             "views": [(tree_view_id, "tree"), (form_view_id, "form")],
             "target": "current",
             "context": self.with_context(
-                search_default_partner_id=self.ids,
-                search_default_posted=1
+                search_default_partner_id=self.ids, search_default_posted=1
             ).env.context,
         }
         return action
@@ -313,8 +312,7 @@ class ResPartner(models.Model):
         account_ids = self.env["account.account"].search([("code", "=", "1050")]).ids
 
         return self.with_context(
-            search_default_unreconciled=1,
-            search_default_account_id=account_ids[0]
+            search_default_unreconciled=1, search_default_account_id=account_ids[0]
         ).show_move_lines()
 
     def open_contracts(self):
@@ -552,5 +550,15 @@ class ResPartner(models.Model):
             if data_invs:
                 invoices.update_open_invoices(data_invs)
 
-    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
-        return super(ResPartner, self)._search(args, offset, limit, order,  count, access_rights_uid)
+    def _search(
+        self,
+        args,
+        offset=0,
+        limit=None,
+        order=None,
+        count=False,
+        access_rights_uid=None,
+    ):
+        return super(ResPartner, self)._search(
+            args, offset, limit, order, count, access_rights_uid
+        )

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -550,15 +550,3 @@ class ResPartner(models.Model):
             if data_invs:
                 invoices.update_open_invoices(data_invs)
 
-    def _search(
-        self,
-        args,
-        offset=0,
-        limit=None,
-        order=None,
-        count=False,
-        access_rights_uid=None,
-    ):
-        return super(ResPartner, self)._search(
-            args, offset, limit, order, count, access_rights_uid
-        )

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -150,6 +150,7 @@ class ResPartner(models.Model):
                     ("reconciled", "=", False),
                     ("account_id.reconcile", "=", True),
                     ("account_id.code", "=", "1050"),
+                    ("parent_state", "=", "posted")
                 ]
             )
             partner.receivable_items = move_line_obj.search_count(
@@ -284,7 +285,8 @@ class ResPartner(models.Model):
             "views": [(tree_view_id, "tree"), (form_view_id, "form")],
             "target": "current",
             "context": self.with_context(
-                search_default_partner_id=self.ids
+                search_default_partner_id=self.ids,
+                search_default_posted=1
             ).env.context,
         }
         return action
@@ -308,13 +310,10 @@ class ResPartner(models.Model):
         }
 
     def unreconciled_transaction_items(self):
-        return self.with_context(
-            search_default_unreconciled=1
-        ).receivable_transaction_items()
-
-    def receivable_transaction_items(self):
         account_ids = self.env["account.account"].search([("code", "=", "1050")]).ids
+
         return self.with_context(
+            search_default_unreconciled=1,
             search_default_account_id=account_ids[0]
         ).show_move_lines()
 
@@ -552,3 +551,6 @@ class ResPartner(models.Model):
             data_invs = invoices._build_invoices_data(payment_term_id=payment_term_id)
             if data_invs:
                 invoices.update_open_invoices(data_invs)
+
+    def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
+        return super(ResPartner, self)._search(args, offset, limit, order,  count, access_rights_uid)

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -277,7 +277,7 @@ class ResPartner(models.Model):
         tree_view_id = self.env.ref("account.view_move_line_tree").id
         form_view_id = self.env.ref("account.view_move_line_form").id
         action = {
-            "name": _("1050 move lines"),
+            "name": _("Unreconciled Items"),
             "type": "ir.actions.act_window",
             "view_mode": "tree",
             "res_model": "account.move.line",


### PR DESCRIPTION
# Description
In the supporters page, there were two buttons "1050 Items" and "Unreconciled Items" that basically applied the same filters. So we remove the "1050 Items" button and only keep the other one.

# Technical Aspects
* Remove unused code
* Add `parent_state = posted` filter to the button
* Rename the page so that it corresponds better to the button