### PR TITLE
14.0 t1636 fix mail subject encoding

### DIFF
--- a/partner_communication/__manifest__.py
+++ b/partner_communication/__manifest__.py
@@ -8,8 +8,9 @@
 #                        /_/
 #                            in Jesus' name
 #
-#    Copyright (C) 2016-2022 Compassion CH (http://www.compassion.ch)
+#    Copyright (C) 2016-2024 Compassion CH (https://www.compassion.ch)
 #    @author: Emanuel Cino <ecino@compassion.ch>
+#    @author: Noé Berdoz <nberdoz@compassion.ch>
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU Affero General Public License as
@@ -22,7 +23,7 @@
 #    GNU Affero General Public License for more details.
 #
 #    You should have received a copy of the GNU Affero General Public License
-#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 ##############################################################################
 
@@ -40,6 +41,7 @@
         "queue_job",  # OCA/queue
         "mass_mailing_sms",  # OCA/queue
         "utm",
+        "mail",
     ],
     "external_dependencies": {"python": ["wand"]},
     "data": [

--- a/partner_communication/models/__init__.py
+++ b/partner_communication/models/__init__.py
@@ -1,8 +1,9 @@
 ##############################################################################
 #
-#    Copyright (C) 2016 Compassion CH (http://www.compassion.ch)
+#    Copyright (C) 2016-2024 Compassion CH (https://www.compassion.ch)
 #    Releasing children from poverty in Jesus' name
 #    @author: Emanuel Cino <ecino@compassion.ch>
+#    @author: Noé Berdoz <nberdoz@compassion.ch>
 #
 #    The licence is in the file __manifest__.py
 #
@@ -16,6 +17,7 @@ from . import (
     email,
     ir_actions,
     ir_attachment,
+    mail_mail,
     mail_template,
     queue_job,
     res_partner,

--- a/partner_communication/models/mail_mail.py
+++ b/partner_communication/models/mail_mail.py
@@ -1,0 +1,49 @@
+##############################################################################
+#
+#    Copyright (C) 2024 Compassion CH (https://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Noé Berdoz <nberdoz@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+import re
+from email.header import Header
+
+from odoo import api, models
+
+
+def _sanitize_subject(subject):
+    """
+    Sanitize the email subject line by removing characters that are not compliant
+    with RFC 2822.
+
+    Args:
+        subject (str): the original email subject
+
+    Returns:
+        str: the sanitized email subject
+    """
+
+    # Remove all line breaks (newlines, carriage returns)
+    subject = re.sub(r"[\r\n]+", " ", subject)
+
+    # Encode the subject to ensure RFC 2822 compliance
+    header = Header(subject, "utf-8")
+    sanitized_subject = str(header)
+
+    return sanitized_subject
+
+
+class MailMail(models.Model):
+    """Override the create method to sanitize the email"""
+
+    _inherit = "mail.mail"
+
+    @api.model_create_multi
+    def create(self, values_list):
+        for values in values_list:
+            if "subject" in values:
+                values["subject"] = _sanitize_subject(values["subject"])
+
+        return super().create(values_list)

--- a/partner_communication/models/mail_mail.py
+++ b/partner_communication/models/mail_mail.py
@@ -28,6 +28,9 @@ def _sanitize_subject(subject):
     # Remove all line breaks (newlines, carriage returns)
     subject = re.sub(r"[\r\n]+", " ", subject)
 
+    # Remove extra whitespace
+    subject = subject.strip()
+
     # Encode the subject to ensure RFC 2822 compliance
     header = Header(subject, "utf-8")
     sanitized_subject = str(header)


### PR DESCRIPTION
Related ticket: [T1636](https://erp.compassion.ch/web#id=2228&model=project.task&view_type=form&cids=1&menu_id=)

The proposed code ensure that the mail subject is RFC 2822 compliant.

Odoo 14.0 operates under the RFC 2822 standard for email formats. This RFC specifies the format for email headers and bodies and mandates that certain characters be sanitized or encoded properly. More information [here](https://datatracker.ietf.org/doc/html/rfc2822)

