### PR TITLE
T1629 - New Biennial communication sends old picture of child

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -352,12 +352,14 @@ class CompassionChild(models.Model):
     @api.depends("pictures_ids")
     def _compute_portrait(self):
         for child in self:
-            child.portrait = child.pictures_ids.sorted()[0].headshot
+            if child.pictures_ids:
+                child.portrait = child.pictures_ids.sorted()[0].headshot
 
     @api.depends("pictures_ids")
     def _compute_fullshot(self):
         for child in self:
-            child.fullshot = child.pictures_ids.sorted()[0].fullshot
+            if child.pictures_ids:
+                child.fullshot = child.pictures_ids.sorted()[0].fullshot
 
     @api.model
     def _available_states(self):

--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -285,8 +285,8 @@ class CompassionChild(models.Model):
         readonly=False,
     )
     household_id = fields.Many2one("compassion.household", "Household", readonly=True)
-    portrait = fields.Image(related="pictures_ids.headshot")
-    fullshot = fields.Image(related="pictures_ids.fullshot")
+    portrait = fields.Image(compute="_compute_portrait")
+    fullshot = fields.Image(compute="_compute_fullshot")
     child_disaster_impact_ids = fields.One2many(
         "child.disaster.impact", "child_id", "Child Disaster Impact", readonly=True
     )
@@ -348,6 +348,16 @@ class CompassionChild(models.Model):
     def _compute_available(self):
         for child in self:
             child.is_available = child.state in self._available_states()
+
+    @api.depends("pictures_ids")
+    def _compute_portrait(self):
+        for child in self:
+            child.portrait = child.pictures_ids.sorted()[0].headshot
+
+    @api.depends("pictures_ids")
+    def _compute_fullshot(self):
+        for child in self:
+            child.fullshot = child.pictures_ids.sorted()[0].fullshot
 
     @api.model
     def _available_states(self):

--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -353,13 +353,13 @@ class CompassionChild(models.Model):
     def _compute_portrait(self):
         for child in self:
             if child.pictures_ids:
-                child.portrait = child.pictures_ids.sorted()[0].headshot
+                child.portrait = child.pictures_ids.sorted()[:1].headshot
 
     @api.depends("pictures_ids")
     def _compute_fullshot(self):
         for child in self:
             if child.pictures_ids:
-                child.fullshot = child.pictures_ids.sorted()[0].fullshot
+                child.fullshot = child.pictures_ids.sorted()[:1].fullshot
 
     @api.model
     def _available_states(self):

--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -1184,7 +1184,9 @@ class SponsorshipContract(models.Model):
 
                 # Check contract is active or terminated recently.
                 if contract.state == "cancelled" and not bypass_state:
-                    raise UserError(f"The contract {contract.display_name} is not active.")
+                    raise UserError(
+                        f"The contract {contract.display_name} is not active."
+                    )
                 if (
                     contract.state == "terminated"
                     and contract.end_date
@@ -1193,7 +1195,9 @@ class SponsorshipContract(models.Model):
                     limit = invoice.invoice_date - relativedelta(days=180)
                     ended_since = contract.end_date
                     if ended_since.date() < limit:
-                        raise UserError(f"The contract {contract.display_name} is not active.")
+                        raise UserError(
+                            f"The contract {contract.display_name} is not active."
+                        )
 
                 # Activate gift related contracts (if any)
                 if "S" in contract.type:


### PR DESCRIPTION
# Description
When we recieve a new picture of a child through the `BeneficiaryKit` GMC action, we update the picture of the child and then send a `NewBiennial` communication to the sponsor. However this communication doesn't contain the new picture but instead contains the previous picture.

# Technical Aspects
It seems that even after the child model is updated, the `fullshot` and `portrait` fields still pointed to the previous picture. These fields are `related` to `picture_ids` and for some readon the `picture_ids` list is not up to date when the fields are called to fetch the picture.

I changed these fields to be `computed` instead, when called we sort the `picture_ids` and fetch the latest picture.