### PR TITLE
T1675 FIX bad implementation

### DIFF
--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -475,8 +475,8 @@ class Correspondence(models.Model):
             # Send to GMC
             self.sudo().create_commkit()
         else:
-            # Recompose the letter image and process letter
-            self.sudo().with_context(force_publish=True).process_letter()
+            # Recompose the letter image
+            self.compose_letter_button()
 
     def list_letters(self):
         """API call to fetch letters to translate"""


### PR DESCRIPTION
- move field `has_valid_language` because it is used in a submodule which didn't have access to it previously
- instead of calling `process_letter` function when a translation is made, call `compose_letter`. The previous method was replacing the PDF of the letter with the one from GMC, it couldn't work.
- Because we don't call `process_letter` when translation is done, move the hook to call `send_communication` to make sure the letter to the sponsor is generated after that.