### PR TITLE
T1669 - attaching a background check and child protection agreement to "personal information"

### DIFF
--- a/child_protection/models/partner_compassion.py
+++ b/child_protection/models/partner_compassion.py
@@ -23,11 +23,11 @@ class ResPartner(models.Model):
         "protection charter.",
         tracking=True,
     )
-    signed_child_protection_agreement = fields.Binary(
+    child_protection_agreement = fields.Binary(
         attachment=True,
     )
-    signed_child_protection_agreement_name = fields.Char(
-        compute="_compute_signed_child_protection_agreement_name"
+    child_protection_agreement_name = fields.Char(
+        compute="_compute_child_protection_agreement_name"
     )
     criminal_record = fields.Binary(
         attachment=True,
@@ -42,11 +42,11 @@ class ResPartner(models.Model):
     ##########################################################################
     #                             FIELDS METHODS                             #
     ##########################################################################
-    def _compute_signed_child_protection_agreement_name(self):
+    def _compute_child_protection_agreement_name(self):
         for partner in self:
-            partner.signed_child_protection_agreement_name = partner._get_file_name(
-                partner.with_context(bin_size=False).signed_child_protection_agreement,
-                "Child agreement",
+            partner.child_protection_agreement_name = partner._get_file_name(
+                partner.with_context(bin_size=False).child_protection_agreement,
+                "Child protection agreement",
             )
 
     def _compute_criminal_record_name(self):

--- a/child_protection/views/partner_compassion_view.xml
+++ b/child_protection/views/partner_compassion_view.xml
@@ -19,6 +19,11 @@
             name="date_agreed_child_protection_charter"
             readonly="1"
           />
+                    <field name="signed_child_protection_agreement_name" invisible="1" />
+                    <field
+            name="signed_child_protection_agreement"
+            filename="signed_child_protection_agreement_name"
+          />
                     <field name="criminal_record_name" invisible="1" />
                     <field
             name="criminal_record"
@@ -26,6 +31,11 @@
             groups="child_protection.group_criminal_record"
           />
                     <field name="criminal_record_date" />
+                    <field name="background_check_name" invisible="1" />
+                    <field
+            name="background_check"
+            filename="background_check_name"
+          />
                 </group>
             </group>
         </field>

--- a/child_protection/views/partner_compassion_view.xml
+++ b/child_protection/views/partner_compassion_view.xml
@@ -19,10 +19,13 @@
             name="date_agreed_child_protection_charter"
             readonly="1"
           />
-                    <field name="signed_child_protection_agreement_name" invisible="1" />
                     <field
-            name="signed_child_protection_agreement"
-            filename="signed_child_protection_agreement_name"
+            name="child_protection_agreement_name"
+            invisible="1"
+          />
+                    <field
+            name="child_protection_agreement"
+            filename="child_protection_agreement_name"
           />
                     <field name="criminal_record_name" invisible="1" />
                     <field


### PR DESCRIPTION
Adds two new binary fields in `ResPartner` displayed in `Personal Information` under `Child Protection` named `child_protection_agreement`, and `background_check`:
![image](https://github.com/user-attachments/assets/47e59f8b-d1a2-4c81-84b0-76bde3b6a73b)
## Note
The request hints that existing fields were present in `12.0` for that. I checked all `ResPartners` models in `12.0` and didn't find any.
