### PR TITLE
T1687 - Cannot log calls in interaction resume

### DIFF
--- a/interaction_resume/models/crm_phonecall.py
+++ b/interaction_resume/models/crm_phonecall.py
@@ -1,4 +1,4 @@
-from odoo import fields, models
+from odoo import models
 
 TRACKING_STATUS_MAPPING = {
     "open": "sent",
@@ -11,10 +11,6 @@ TRACKING_STATUS_MAPPING = {
 class CrmPhonecall(models.Model):
     _inherit = ["crm.phonecall", "interaction.source"]
     _name = "crm.phonecall"
-
-    communication_id = fields.Many2one(
-        "partner.communication.job", "Communication", readonly=False
-    )
 
     def _get_interaction_data(self, partner_id):
         direction_mapping = {"inbound": "in", "outbound": "out"}

--- a/interaction_resume/models/crm_phonecall.py
+++ b/interaction_resume/models/crm_phonecall.py
@@ -1,4 +1,4 @@
-from odoo import models, fields
+from odoo import fields, models
 
 TRACKING_STATUS_MAPPING = {
     "open": "sent",

--- a/interaction_resume/models/crm_phonecall.py
+++ b/interaction_resume/models/crm_phonecall.py
@@ -1,4 +1,4 @@
-from odoo import models
+from odoo import models, fields
 
 TRACKING_STATUS_MAPPING = {
     "open": "sent",
@@ -11,6 +11,10 @@ TRACKING_STATUS_MAPPING = {
 class CrmPhonecall(models.Model):
     _inherit = ["crm.phonecall", "interaction.source"]
     _name = "crm.phonecall"
+
+    communication_id = fields.Many2one(
+        "partner.communication.job", "Communication", readonly=False
+    )
 
     def _get_interaction_data(self, partner_id):
         direction_mapping = {"inbound": "in", "outbound": "out"}

--- a/partner_communication_crm_phone/wizards/call_wizard.py
+++ b/partner_communication_crm_phone/wizards/call_wizard.py
@@ -47,7 +47,6 @@ class CallWizard(models.TransientModel):
             "state": state,
             "description": self.comments,
             "name": communication.config_id.name,
-            "communication_id": communication_id,
             "partner_id": communication.partner_id.id,
         }
         if state == "done":


### PR DESCRIPTION
## Details
Fix an exception when logging a call from the wizard shown by pressing `Log Call` and submitting a log. 
![image](https://github.com/user-attachments/assets/e9fee596-412a-4561-ba8d-8013e4437710)
## Solution
- Added back the `communication_id` field on the model `crm_phonecall` as it is the most conservative approach. Field removed in commit fcf0b20.
- If we don't want this field anymore, `call_log` should be edited to not pass a `communication_id` in file `compassion-modules/partner_communication_crm_phone/wizards/call_wizard.py`.

https://github.com/CompassionCH/compassion-modules/blob/8bdb323865ae6e917882d7541a76f675ed1c8d42/partner_communication_crm_phone/wizards/call_wizard.py#L46-L52