### PR TITLE
T1705 - Regular partners should not be transmitted to GMC

### DIFF
--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -240,7 +240,8 @@ class ResPartner(models.Model):
         notify = functools.reduce(
             lambda prev, val: prev or val in vals, notify_vals, False
         )
-        if notify and not self.env.context.get("no_upsert"):
+
+        if notify and self.global_id and not self.env.context.get("no_upsert"):
             self.upsert_constituent()
 
         self._updt_invoices_rp(vals)


### PR DESCRIPTION
## Change
Only upsert to GMC if the partner has a `global_id`.

## Findings
Partners are upserted to GMC if they are edited. Keep this behavior only if it was upserted before.

## Note
Partners with a `global_id` will continue to send updates to GMC.
