### PR TITLE
T1721 - Generate gift wizard uses the wrong partner

### DIFF
--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -66,7 +66,7 @@ class ContractGroup(models.Model):
 
     def _get_partner_for_contract(self, contract):
         return (
-            super()._get_partner_for_contract(contract)
+            super(ContractGroup, self)._get_partner_for_contract(contract)
             if not contract.send_gifts_to
             else contract[contract.send_gifts_to]
         )

--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -63,3 +63,10 @@ class ContractGroup(models.Model):
                 "analytic_account_id"
             ] = contract_line.contract_id.origin_id.analytic_id.id
         return res
+
+    def _get_partner_for_contract(self, contract):
+        return (
+            super()._get_partner_for_contract(contract)
+            if not contract.send_gifts_to
+            else contract[contract.send_gifts_to]
+        )


### PR DESCRIPTION
Create the invoice for the `send_gifts_to` target, defaults to `partner_id` if not set.

**Note**: The first contract is used to get `send_gifts_to`, as the current code does for other fields.

CompassionCH/compassion-accounting#240