### PR TITLE
T1706 - Support request partner assignation

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -166,8 +166,8 @@ class CrmClaim(models.Model):
 
         if "partner_id" not in custom_values:
             match_obj = self.env["res.partner.match"]
-            partner = match_obj.match_values_to_partner(
-                {"email": email_normalize(defaults["email_from"])}, match_create=False
+            partner = match_obj._match_email(
+                {"email": email_normalize(defaults["email_from"])}
             )
             if partner:
                 defaults["partner_id"] = partner.id
@@ -216,7 +216,7 @@ class CrmClaim(models.Model):
         in_leave.write({"stage_id": stage_new, "user_id": False})
         return result
 
-    @api.returns('mail.message', lambda value: value.id)
+    @api.returns("mail.message", lambda value: value.id)
     def message_post(self, **kwargs):
         """Change the stage to "Resolve" when the employee answer
         to the supporter but not if it's an automatic answer.

--- a/crm_request/models/res_partner_match.py
+++ b/crm_request/models/res_partner_match.py
@@ -17,10 +17,13 @@ class ResPartnerMatch(models.AbstractModel):
     def _match_email(self, vals):
         # Redefine email rule to include aliases in search
         email = vals["email"].strip()
-        return self.env["res.partner"].search(
+        partner = self.env["res.partner"].search(
             [
+                "|",
                 "|",
                 ("email", "=ilike", email),
                 ("email_alias_ids.email", "=ilike", email),
+                ("other_contact_ids.email", "=ilike", email),
             ]
         )
+        return partner

--- a/interaction_resume/models/crm_request.py
+++ b/interaction_resume/models/crm_request.py
@@ -1,4 +1,4 @@
-from odoo import models, api
+from odoo import api, models
 from odoo.tools.mail import html2plaintext
 
 
@@ -45,7 +45,7 @@ class CrmRequest(models.Model):
             ("email_from", "=", partner.email),
         ]
 
-    @api.returns('mail.message', lambda value: value.id)
+    @api.returns("mail.message", lambda value: value.id)
     def message_post(self, **kwargs):
         res = super().message_post(**kwargs)
         self.partner_id.with_delay().fetch_interactions()


### PR DESCRIPTION
In Odoo, there are main contacts and "Linked partners" that have a different email address but are associated with the main contact. These linked partners are usually archived, meaning they don't appear in the lists.

When a sponsor sends an email using a secondary email address, the partner is matched and the related partner is identified. If the found partner is a secondary contact, it's preferable to link the support request to the main partner instead (because all history is maintained there). However, the secondary email address should still be used when replying to the sponsor in the support.