### PR TITLE
T1728 - Events: The expenses and income buttons are not working

### DIFF
--- a/crm_compassion/models/event_compassion.py
+++ b/crm_compassion/models/event_compassion.py
@@ -389,6 +389,7 @@ class EventCompassion(models.Model):
                 "default_company_id": self.company_id.id,
                 "search_default_account_id": self.analytic_id.id,
             },
+            "domain": [("id", "in", self.expense_line_ids.ids)],
         }
 
     def show_income(self):

--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -63,3 +63,10 @@ class ContractGroup(models.Model):
                 "analytic_account_id"
             ] = contract_line.contract_id.origin_id.analytic_id.id
         return res
+
+    def _get_partner_for_contract(self, contract):
+        return (
+            super()._get_partner_for_contract(contract)
+            if not contract.send_gifts_to
+            else contract[contract.send_gifts_to]
+        )


### PR DESCRIPTION
- Filter the expenses so it only shows the one related to the event.

Concerning the incomes, the negative ones are filtered out from the count. That is why the -1 000 CHF is not counted in the example.