### PR TITLE
T1732 - Interaction resume

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -166,8 +166,8 @@ class CrmClaim(models.Model):
 
         if "partner_id" not in custom_values:
             match_obj = self.env["res.partner.match"]
-            partner = match_obj.match_values_to_partner(
-                {"email": email_normalize(defaults["email_from"])}, match_create=False
+            partner = match_obj._match_email(
+                {"email": email_normalize(defaults["email_from"])}
             )
             if partner:
                 defaults["partner_id"] = partner.id
@@ -216,7 +216,7 @@ class CrmClaim(models.Model):
         in_leave.write({"stage_id": stage_new, "user_id": False})
         return result
 
-    @api.returns('mail.message', lambda value: value.id)
+    @api.returns("mail.message", lambda value: value.id)
     def message_post(self, **kwargs):
         """Change the stage to "Resolve" when the employee answer
         to the supporter but not if it's an automatic answer.

--- a/crm_request/models/res_partner_match.py
+++ b/crm_request/models/res_partner_match.py
@@ -17,10 +17,13 @@ class ResPartnerMatch(models.AbstractModel):
     def _match_email(self, vals):
         # Redefine email rule to include aliases in search
         email = vals["email"].strip()
-        return self.env["res.partner"].search(
+        partner = self.env["res.partner"].search(
             [
+                "|",
                 "|",
                 ("email", "=ilike", email),
                 ("email_alias_ids.email", "=ilike", email),
+                ("other_contact_ids.email", "=ilike", email),
             ]
         )
+        return partner

--- a/interaction_resume/models/abstract_interaction_source.py
+++ b/interaction_resume/models/abstract_interaction_source.py
@@ -22,6 +22,8 @@ class InteractionSource(models.AbstractModel):
         @param until:
         """
         search_domain = self._get_interaction_partner_domain(partner)
+        if not search_domain:
+            return True
         records = self.search(
             [
                 *search_domain,
@@ -33,6 +35,12 @@ class InteractionSource(models.AbstractModel):
         return True
 
     def _get_interaction_partner_domain(self, partner):
+        if not partner.email:
+            return [
+                "|",
+                ("partner_id", "=", partner.id),
+                ("partner_id", "in", partner.other_contact_ids.ids),
+            ]
         return [
             "|",
             "|",

--- a/interaction_resume/models/crm_request.py
+++ b/interaction_resume/models/crm_request.py
@@ -35,6 +35,12 @@ class CrmRequest(models.Model):
         return res
 
     def _get_interaction_partner_domain(self, partner):
+        if not partner.email:
+            return [
+                "|",
+                ("partner_id", "=", partner.id),
+                ("partner_id", "in", partner.other_contact_ids.ids),
+            ]
         return [
             "|",
             "|",

--- a/interaction_resume/models/crm_request.py
+++ b/interaction_resume/models/crm_request.py
@@ -1,4 +1,4 @@
-from odoo import models, api
+from odoo import api, models
 from odoo.tools.mail import html2plaintext
 
 
@@ -45,7 +45,7 @@ class CrmRequest(models.Model):
             ("email_from", "=", partner.email),
         ]
 
-    @api.returns('mail.message', lambda value: value.id)
+    @api.returns("mail.message", lambda value: value.id)
     def message_post(self, **kwargs):
         res = super().message_post(**kwargs)
         self.partner_id.with_delay().fetch_interactions()

--- a/interaction_resume/models/mailing_trace.py
+++ b/interaction_resume/models/mailing_trace.py
@@ -43,6 +43,8 @@ class MailingTrace(models.Model):
         ]
 
     def _get_interaction_partner_domain(self, partner):
+        if not partner.email:
+            return []
         return [
             ("email", "=", partner.email),
         ]

--- a/interaction_resume/models/res_partner.py
+++ b/interaction_resume/models/res_partner.py
@@ -7,6 +7,8 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+from datetime import datetime as dt
+
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, fields, models
@@ -63,7 +65,11 @@ class Partner(models.Model):
         self.ensure_one()
         # Each page shows interactions for one year
         years_to_fetch = 1
-        until = fields.Datetime.now() - relativedelta(years=page * years_to_fetch)
+        years = page * years_to_fetch
+        # Do not fetch invalid negative years interactions
+        if years > dt.now().year:
+            return True
+        until = fields.Datetime.now() - relativedelta(years=years)
         since = until - relativedelta(years=years_to_fetch)
         models = [
             "partner.communication.job",


### PR DESCRIPTION
# Problem
When loading the interaction resume for a partner without a defined email address, the system mistakenly loads interactions for all partners who lack an email address. This behavior results in incorrect data being displayed.

# Solution
To address this issue, a check is introduced to verify if the partner has an email address before attempting to load their interactions. If the partner does not have an email address, the search scope is restricted to prevent loading interactions from other partners without email addresses.