### PR TITLE
T1732 - Fix incorrect loading of interactions for partners without email addresses

### DIFF
--- a/interaction_resume/models/abstract_interaction_source.py
+++ b/interaction_resume/models/abstract_interaction_source.py
@@ -22,6 +22,8 @@ class InteractionSource(models.AbstractModel):
         @param until:
         """
         search_domain = self._get_interaction_partner_domain(partner)
+        if not search_domain:
+            return True
         records = self.search(
             [
                 *search_domain,

--- a/interaction_resume/models/crm_request.py
+++ b/interaction_resume/models/crm_request.py
@@ -35,6 +35,12 @@ class CrmRequest(models.Model):
         return res
 
     def _get_interaction_partner_domain(self, partner):
+        if not partner.email:
+            return [
+                "|",
+                ("partner_id", "=", partner.id),
+                ("partner_id", "in", partner.other_contact_ids.ids),
+            ]
         return [
             "|",
             "|",

--- a/interaction_resume/models/mailing_trace.py
+++ b/interaction_resume/models/mailing_trace.py
@@ -45,4 +45,5 @@ class MailingTrace(models.Model):
     def _get_interaction_partner_domain(self, partner):
         return [
             ("email", "=", partner.email),
+            ("email", "!=", False),
         ]

--- a/interaction_resume/models/res_partner.py
+++ b/interaction_resume/models/res_partner.py
@@ -7,6 +7,8 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+from datetime import datetime as dt
+
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, fields, models
@@ -63,7 +65,11 @@ class Partner(models.Model):
         self.ensure_one()
         # Each page shows interactions for one year
         years_to_fetch = 1
-        until = fields.Datetime.now() - relativedelta(years=page * years_to_fetch)
+        years = page * years_to_fetch
+        # Do not fetch invalid negative years interactions
+        if years > dt.now().year:
+            return True
+        until = fields.Datetime.now() - relativedelta(years=years)
         since = until - relativedelta(years=years_to_fetch)
         models = [
             "partner.communication.job",


### PR DESCRIPTION
# Problem
When loading the interaction resume for a partner without a defined email address, the system mistakenly loads interactions for all partners who lack an email address. This behavior results in incorrect data being displayed.

# Solution
To address this issue, a check is introduced to verify if the partner has an email address before attempting to load their interactions. If the partner does not have an email address, the search scope is restricted to prevent loading interactions from other partners without email addresses.