### PR TITLE
T1737 - Constraint Error When Creating/Editing CRM Opportunities Without Customer Email

### DIFF
--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 
-from odoo import _, fields, models
+from odoo import api, fields, models
 
 from odoo.addons.partner_communication.models.communication_config import (
     CommunicationConfig,
@@ -26,6 +26,12 @@ class Partner(models.Model):
         compute="_compute_receive_ambassador_receipts",
         inverse="_inverse_receive_ambassador_receipts",
     )
+
+    @api.constrains("email")
+    def _check_email_mass_mailing_contacts(self):
+        for partner in self:
+            if not partner.email and partner.sudo().mass_mailing_contact_ids:
+                self.sudo().mass_mailing_contact_ids.unlink()
 
     def _compute_receive_ambassador_receipts(self):
         for partner in self:


### PR DESCRIPTION
# Context

When the church reps wants to create or edit an opportunity (crm.lead) and make it with a customer but without an email, there is a constraint error.

Sometimes, they are working with customers that has no emails, they should be able to pass against this email constraint.

# Analysis

The error occurs because the contact is part of an email distribution list. As a result, removing the contact’s email address leads to an error. This is a standard error designed to prevent cascading failures when sending emails through the distribution list.

# Proposed solutions

There are two possible solutions:

1. Keep this protection in place to ensure no errors occur when using distribution lists (current solution).
2. Remove the contact from the distribution list.

In my opinion, we should implement the second solution. If an email address is removed from a contact, it is because it is no longer in use or relevant. Therefore, not sending emails to this address for marketing campaigns should not cause any issues.