### PR TITLE
T1720 - Sponsorship - 1 Day Birthday Reminder

### DIFF
--- a/partner_communication/wizards/mail_compose_message.py
+++ b/partner_communication/wizards/mail_compose_message.py
@@ -72,8 +72,13 @@ class EmailComposeMessage(models.TransientModel):
                 }
             )
         )
+
         # Fetch template values.
-        wizard.write(
-            wizard.onchange_template_id(template.id, "mass_mail", False, False)["value"]
-        )
-        return wizard.get_mail_values(res_ids)
+        write_data = wizard.onchange_template_id(
+            template.id, "mass_mail", False, False
+        )["value"]
+        values = wizard.get_mail_values(res_ids)
+
+        wizard.write(write_data)
+
+        return values


### PR DESCRIPTION
If `write` is called before `wizard.get_mail_values` it escapes the `>` character used in the search inside `1 Day Birthday Reminder` and crashes while trying to send the communication.
## Repro
In the communication job view, click `Retry` then `Send Now` on a `Sponsorship - 1 Day Birthday Reminder`.
