### PR TITLE
T1740 - "Correct active text": Body_html cannot be edited.

### DIFF
--- a/partner_communication_revision/models/communication_revision.py
+++ b/partner_communication_revision/models/communication_revision.py
@@ -84,7 +84,6 @@ class CommunicationRevision(models.Model):
     body_html = fields.Html(
         compute="_compute_body_html", inverse="_inverse_body_html", sanitize=False
     )
-    raw_template_edit_mode = fields.Boolean()
     simplified_text = fields.Html(sanitize=False)
     user_id = fields.Many2one(
         "res.users",
@@ -573,7 +572,6 @@ class CommunicationRevision(models.Model):
 
     def reload_text(self):
         self.keyword_ids.unlink()
-        self.raw_template_edit_mode = False
         if self.body_html:
             self.with_context(no_update=True).simplified_text = self._simplify_text()
 

--- a/partner_communication_revision/views/communication_revision_view.xml
+++ b/partner_communication_revision/views/communication_revision_view.xml
@@ -26,20 +26,12 @@
                     <group>
                         <group>
                             <field
-                name="raw_template_edit_mode"
-                invisible="1"
-              />
-                            <field
                 name="proposition_text"
                 groups="base.group_erp_manager"
               />
                         </group>
                         <group>
-                            <field
-                name="body_html"
-                widget="ace"
-                attrs="{'readonly': [('raw_template_edit_mode','=',True)]}"
-              />
+                            <field name="body_html" widget="ace" />
                         </group>
                     </group>
                 </sheet>

--- a/partner_communication_revision/views/communication_revision_view.xml
+++ b/partner_communication_revision/views/communication_revision_view.xml
@@ -38,7 +38,7 @@
                             <field
                 name="body_html"
                 widget="ace"
-                attrs="{'readonly': [('raw_template_edit_mode','!=',True)]}"
+                attrs="{'readonly': [('raw_template_edit_mode','=',True)]}"
               />
                         </group>
                     </group>


### PR DESCRIPTION
`raw_template_edit_mode` is always `False` and this is the only place it is used. Couldn't it be removed altogether?