### PR TITLE
fix(T1794): Remove unwanted template from the SDS

### DIFF
--- a/sbc_translation/data/mail_template.xml
+++ b/sbc_translation/data/mail_template.xml
@@ -18,9 +18,6 @@
     </record>
 
     <template id="comments_reply">
-        <p>Dear <span t-field="object.new_translator_id.partner_id.name" />,</p>
-        <p
-    >You have just received a reply to your comments on the translation:</p>
         <p t-raw="reply" />
         <hr />
         <table>


### PR DESCRIPTION
This commit remove the salutation part and the first sentence of the template. "Dear..., You have just received a reply to your comments on the translation:"

