### PR TITLE
T1789 - Sponsorship Gifts

### DIFF
--- a/sponsorship_compassion/views/sponsorship_contract_view.xml
+++ b/sponsorship_compassion/views/sponsorship_contract_view.xml
@@ -53,7 +53,7 @@
             <field name="medium_id" position="attributes">
                 <attribute
           name="attrs"
-        >{'required':[('type', 'in', ['S','SC','SWP'])]}</attribute>
+        >{'required':[('type', 'in', ['S','SC','SWP']), ('id', '=', False)]}</attribute>
             </field>
             <field name="medium_id" position="before">
                 <field


### PR DESCRIPTION
Some sponsorships (`1105`) are missing a `medium_id` and custom action buttons aren't working on those:
![image](https://github.com/user-attachments/assets/b6e5f088-64d7-4738-8dd3-51007cc36143)
This PR makes `medium_id` required only on new records so we can use the action buttons without adding a `medium_id`.
**Potential drawback:** allows to remove the `medium_id` after creation.