### PR TITLE
T1364 - Fix Letter Translation Logic: Hide English Transcription for Sponsors Speaking Source Language

### DIFF
--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -736,7 +736,7 @@ class Correspondence(models.Model):
 
     def process_letter(self):
         """Method called when new B2S letter is Published."""
-        # If the letter's source language is known by the sponsor, we can send the original letter without any translation
+        # If the letter's source language is known by the sponsor, send the original letter without any translation
         letter_type = "final_letter_url"
         if self.original_language_id in self.supporter_languages_ids:
             letter_type = "original_letter_url"

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -736,7 +736,7 @@ class Correspondence(models.Model):
 
     def process_letter(self):
         """Method called when new B2S letter is Published."""
-        # If the letter's source language is known by the sponsor, we can send the original letter with the English translation
+        # If the letter's source language is known by the sponsor, we can send the original letter without any translation
         letter_type = "final_letter_url"
         if self.original_language_id in self.supporter_languages_ids:
             letter_type = "original_letter_url"

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -736,7 +736,8 @@ class Correspondence(models.Model):
 
     def process_letter(self):
         """Method called when new B2S letter is Published."""
-        # If the letter's source language is known by the sponsor, send the original letter without any translation
+        # If the letter's source language is known by the sponsor,
+        # send the original letter without any translation
         letter_type = "final_letter_url"
         if self.original_language_id in self.supporter_languages_ids:
             letter_type = "original_letter_url"

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -736,7 +736,11 @@ class Correspondence(models.Model):
 
     def process_letter(self):
         """Method called when new B2S letter is Published."""
-        self.download_attach_letter_image(letter_type="final_letter_url")
+        # If the letter's source language is known by the sponsor, we can send the original letter with the English translation
+        letter_type = "final_letter_url"
+        if self.original_language_id in self.supporter_languages_ids:
+            letter_type = "original_letter_url"
+        self.download_attach_letter_image(letter_type=letter_type)
         return True
 
     def download_attach_letter_image(self, letter_type="final_letter_url"):

--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -215,7 +215,7 @@ class Correspondence(models.Model):
         needed and upload to translation platform."""
         for letter in self:
             if (
-                (letter.beneficiary_language_ids & letter.supporter_languages_ids)
+                (letter.original_language_id in letter.supporter_languages_ids)
                 or letter.has_valid_language
                 or self.env.context.get("force_publish")
             ):

--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -215,7 +215,7 @@ class Correspondence(models.Model):
         needed and upload to translation platform."""
         for letter in self:
             if (
-                (letter.original_language_id in letter.supporter_languages_ids)
+                (letter.beneficiary_language_ids & letter.supporter_languages_ids)
                 or letter.has_valid_language
                 or self.env.context.get("force_publish")
             ):


### PR DESCRIPTION
When a B2S letter is received via a GMC message, it sometimes happens that no transcription in the original language is provided, but an English translation is available. Currently, when sending the letter to the sponsor, the system includes the English translation if the sponsor speaks either the original language or English.

However, if the sponsor speaks the original language of the letter, there is no need to display the English translation. If the sponsor speaks neither the original language nor English, then the standard translation process for the letter should be maintained.

This update ensures that English translations are only included when necessary, improving the clarity and relevance of the communication sent to sponsors.