### PR TITLE
T1779 - Remove dupplicate child pictures

### DIFF
--- a/child_compassion/__manifest__.py
+++ b/child_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion Children",
-    "version": "14.0.1.2.0",
+    "version": "14.0.1.3.0",
     "category": "Compassion",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
+++ b/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
@@ -9,5 +9,5 @@ def migrate(env, version):
         DELETE FROM compassion_child_pictures ccp_a
         USING compassion_child_pictures cpp_b
         WHERE ccp_a.image_url == ccp_b.image_url AND ccp_a.child_id == ccp_b.child_id AND ccp_a.date >= cpp_b.date;
-        """
+        """,
     )

--- a/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
+++ b/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
@@ -1,0 +1,13 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        DELETE FROM compassion_child_pictures ccp_a
+        USING compassion_child_pictures cpp_b
+        WHERE ccp_a.image_url == ccp_b.image_url AND ccp_a.child_id == ccp_b.child_id AND ccp_a.date >= cpp_b.date;
+        """
+    )

--- a/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
+++ b/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
@@ -8,6 +8,7 @@ def migrate(env, version):
         """
         DELETE FROM compassion_child_pictures ccp_a
         USING compassion_child_pictures cpp_b
-        WHERE ccp_a.image_url == ccp_b.image_url AND ccp_a.child_id == ccp_b.child_id AND ccp_a.date >= cpp_b.date;
+        WHERE ccp_a.image_url == ccp_b.image_url 
+            AND ccp_a.child_id == ccp_b.child_id AND ccp_a.date >= cpp_b.date;
         """,
     )

--- a/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
+++ b/child_compassion/migrations/14.0.1.3.0/pre-migrate.py
@@ -8,7 +8,7 @@ def migrate(env, version):
         """
         DELETE FROM compassion_child_pictures ccp_a
         USING compassion_child_pictures cpp_b
-        WHERE ccp_a.image_url == ccp_b.image_url 
+        WHERE ccp_a.image_url == ccp_b.image_url
             AND ccp_a.child_id == ccp_b.child_id AND ccp_a.date >= cpp_b.date;
         """,
     )

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -84,8 +84,9 @@ class ChildPictures(models.Model):
         a new Pictures object. Check if picture is the same as the previous
         and attach the pictures to the last case study.
         """
-        if self._child_picture_already_exists(vals):
-            return False
+        existing_picture = self._child_picture_already_exists(vals)
+        if existing_picture:
+            return existing_picture
 
         pictures = super().create(vals)
         # Retrieve Headshot
@@ -132,14 +133,14 @@ class ChildPictures(models.Model):
         return same_pics
 
     def _child_picture_already_exists(self, vals):
-        already_exists = self.search_count(
+        existing_picture = self.search(
             [
                 ("child_id", "=", vals.get("child_id")),
                 ("image_url", "=", vals.get("image_url")),
-            ]
+            ], limit=1
         )
 
-        return bool(already_exists)
+        return existing_picture
 
     def _get_picture(self, pic_type="Headshot", width=300, height=400):
         """Gets a picture from Compassion webservice"""

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -129,8 +129,10 @@ class ChildPictures(models.Model):
         )
 
         # The last picture is most probably one that could be the same.
-        same_pics = (pics[0].fullshot == reference.fullshot
-                     and pics[0].headshot == reference.headshot)
+        same_pics = (
+            pics[0].fullshot == reference.fullshot
+            and pics[0].headshot == reference.headshot
+        )
 
         return same_urls or same_pics
 

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -132,8 +132,12 @@ class ChildPictures(models.Model):
         return same_pics
 
     def _child_picture_already_exists(self, vals):
-        already_exists = self.search_count([("child_id", "=", vals.get('child_id')),
-                                            ("image_url", "=", vals.get('image_url'))])
+        already_exists = self.search_count(
+            [
+                ("child_id", "=", vals.get("child_id")),
+                ("image_url", "=", vals.get("image_url")),
+            ]
+        )
 
         return bool(already_exists)
 

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -84,7 +84,6 @@ class ChildPictures(models.Model):
         a new Pictures object. Check if picture is the same as the previous
         and attach the pictures to the last case study.
         """
-
         if self._child_picture_already_exists(vals):
             return False
 
@@ -106,8 +105,8 @@ class ChildPictures(models.Model):
         # Find if same pictures already exist
         same_pictures = pictures._find_same_picture()
         if same_pictures:
-            # Either the url is unchanged, or the url has
-            # changed but the picture is the same as the last.
+            # That case is not likely to happens, it means that the url has
+            #  changed, while the picture stay unchanged.
             pictures.child_id.message_post(
                 body=_("The picture was the same"), subject=_("Picture update")
             )

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -137,7 +137,8 @@ class ChildPictures(models.Model):
             [
                 ("child_id", "=", vals.get("child_id")),
                 ("image_url", "=", vals.get("image_url")),
-            ], limit=1
+            ],
+            limit=1,
         )
 
         return existing_picture


### PR DESCRIPTION
# Description
In the `Sponsorship - Certificate` correspondence, we attach the first and last picture of the sponsored child, however there were a couple of case where the pictures were the same.

# Technical Aspects
It seems that in the database there are multiple children that have the same `image_url`, resulting in them having dupplicate images.

A couple of fixed have been made : 
* added `_sql_contraint` and a check when creating a new image to ensure that there is no other image for that child with the same `image_url`
* added check before create that we aren't adding an already existing image (this can be caused for example when a sponsorship is terminated, we update the child information with the current information from GMC, causing dupplicate images)
* added a migration that will clear the dupplicates from the `compassion_child_pictures` table, keeping only the oldest ones.