### PR TITLE
T1793 + T1720 - Neuro as sender and birthday gift error for communications

### DIFF
--- a/partner_communication/wizards/mail_compose_message.py
+++ b/partner_communication/wizards/mail_compose_message.py
@@ -81,8 +81,11 @@ class EmailComposeMessage(models.TransientModel):
         # Body would be sanitized if we write it now, breaking any embedded code and
         # causing an error.
         # Only usage is create_emails above and it overrides it just after.
+        # We write it just after getting the mail values.
+        mail_body = write_data["body"]
         del write_data["body"]
-
         wizard.write(write_data)
+        values = wizard.get_mail_values(res_ids)
+        wizard.write({"body": mail_body})
 
-        return wizard.get_mail_values(res_ids)
+        return values

--- a/partner_communication/wizards/mail_compose_message.py
+++ b/partner_communication/wizards/mail_compose_message.py
@@ -77,8 +77,12 @@ class EmailComposeMessage(models.TransientModel):
         write_data = wizard.onchange_template_id(
             template.id, "mass_mail", False, False
         )["value"]
-        values = wizard.get_mail_values(res_ids)
+
+        # Body would be sanitized if we write it now, breaking any embedded code and
+        # causing an error.
+        # Only usage is create_emails above and it overrides it just after.
+        del write_data["body"]
 
         wizard.write(write_data)
 
-        return values
+        return wizard.get_mail_values(res_ids)

--- a/partner_communication/wizards/mail_compose_message.py
+++ b/partner_communication/wizards/mail_compose_message.py
@@ -82,8 +82,7 @@ class EmailComposeMessage(models.TransientModel):
         # causing an error.
         # Only usage is create_emails above and it overrides it just after.
         # We write it just after getting the mail values.
-        mail_body = write_data["body"]
-        del write_data["body"]
+        mail_body = write_data.pop("body")
         wizard.write(write_data)
         values = wizard.get_mail_values(res_ids)
         wizard.write({"body": mail_body})


### PR DESCRIPTION
Solves the same issue as CompassionCH/compassion-modules#1956 but doesn't create the neuro as sender problem.

### Issue root cause
`wizard.write(write_data)` is responsible for defining the correct sender, but it sanitizes the email content and causes error if the email's embedded code contains `>`. 

`wizard.get_mail_values(res_ids)` must be called after `wizard.write(write_data)` so the sender matches the expected one and doesn't use default (Neuro).

### Fix details
Don't write the body directly so it isn't sanitized when saved in cache. This portion of the code only affects communications sent through Odoo.
Another fix would be to override the `body` field so it isn't sanitized in `partner_communication/wizards/mail_compose_message.py`:
```py
body = fields.Html(sanitize=False)
```
but it might cause an issue if some mails need to be sanitized, to see if such mails exist as it might be a cleaner approach.