### PR TITLE
T1795 - Special characters are wrongly encoded

### DIFF
--- a/sbc_compassion/FPDF/src/pdfcreator.php
+++ b/sbc_compassion/FPDF/src/pdfcreator.php
@@ -204,7 +204,7 @@ class PDFCreator
         {
             $pagesWithoutText++;
             if($pagesWithoutText >= 4) {
-                if ($this->utils->overflowTemplate != false) {
+                if ($this->utils->overflowTemplate) {
                     // Try to push remaining text on overflow page
                     $this->InsertOverflowPages($pdf);
                 } else {

--- a/sbc_compassion/FPDF/src/pdfcreator.php
+++ b/sbc_compassion/FPDF/src/pdfcreator.php
@@ -37,6 +37,7 @@ class PDFCreator
                                     // through the available boxes.
 	protected $overflowPage;        // Will be set when overflow occurs. Holds the overflown texts from the current page.  => array[Text]
 
+    protected $overflowTemplate;
 
     /**
     *
@@ -62,9 +63,9 @@ class PDFCreator
         );
 
         $this->lang = $params['lang'];
-        $overflowTemplate = false;
+        $this->overflowTemplate = false;
         if (!empty($params['overflow_template'])) {
-            $overflowTemplate = new Template(...$params['overflow_template']);
+            $this->overflowTemplate = new Template(...$params['overflow_template']);
             $this->preventOverflow = $params['prevent_overflow'];
         }
         $this->originalSize = $params['original_size'];
@@ -75,7 +76,7 @@ class PDFCreator
         {
             throw new Exception("No templates provided, cannot generate PDF");
         }
-        $this->utils = new TemplateUtils($templates, $params['original_size'], $overflowTemplate);
+        $this->utils = new TemplateUtils($templates, $params['original_size'], $this->overflowTemplate);
         $headerOnLastPage = false;
         $this->overflowPage = [];
     }

--- a/sbc_compassion/FPDF/src/pdfcreator.php
+++ b/sbc_compassion/FPDF/src/pdfcreator.php
@@ -37,8 +37,6 @@ class PDFCreator
                                     // through the available boxes.
 	protected $overflowPage;        // Will be set when overflow occurs. Holds the overflown texts from the current page.  => array[Text]
 
-    protected $overflowTemplate;
-
     /**
     *
     */
@@ -63,9 +61,9 @@ class PDFCreator
         );
 
         $this->lang = $params['lang'];
-        $this->overflowTemplate = false;
+        $overflowTemplate = false;
         if (!empty($params['overflow_template'])) {
-            $this->overflowTemplate = new Template(...$params['overflow_template']);
+            $overflowTemplate = new Template(...$params['overflow_template']);
             $this->preventOverflow = $params['prevent_overflow'];
         }
         $this->originalSize = $params['original_size'];
@@ -76,7 +74,7 @@ class PDFCreator
         {
             throw new Exception("No templates provided, cannot generate PDF");
         }
-        $this->utils = new TemplateUtils($templates, $params['original_size'], $this->overflowTemplate);
+        $this->utils = new TemplateUtils($templates, $params['original_size'], $overflowTemplate);
         $headerOnLastPage = false;
         $this->overflowPage = [];
     }
@@ -206,7 +204,7 @@ class PDFCreator
         {
             $pagesWithoutText++;
             if($pagesWithoutText >= 4) {
-                if ($this->overflowTemplate != false) {
+                if ($this->utils->overflowTemplate != false) {
                     // Try to push remaining text on overflow page
                     $this->InsertOverflowPages($pdf);
                 } else {

--- a/sbc_compassion/FPDF/src/text.php
+++ b/sbc_compassion/FPDF/src/text.php
@@ -13,7 +13,7 @@ class Text
 
     function __construct($filename, $type)
     {
-        $this->text = utf8_decode(file_get_contents($filename));
+        $this->text = file_get_contents($filename);
         $this->type = $type;
     }
 

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -179,12 +179,13 @@ class CorrespondenceTemplate(models.Model):
         text_list = []
         for t_type, t_boxes in list(text.items()):
             for txt in t_boxes:
-                temp_img.append(
-                    tempfile.NamedTemporaryFile("w", prefix=t_type + "_", suffix=".txt")
+                txt_file = tempfile.NamedTemporaryFile(
+                    "w", prefix=t_type + "_", suffix=".txt"
                 )
-                temp_img[-1].write(txt)
-                temp_img[-1].flush()
-                text_list.append([temp_img[-1].name, t_type])
+                txt_file.write(txt)
+                txt_file.flush()
+                temp_img.append(txt_file)
+                text_list.append([txt_file.name, t_type])
 
         for image in image_data:
             ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
@@ -206,7 +207,8 @@ class CorrespondenceTemplate(models.Model):
 
         json_val = json.dumps(generated_json).replace(" ", "")
 
-        std_err_file = open(self.path_to("stderr.txt"), "w")
+        std_err_file_path = self.path_to("stderr.txt")
+        std_err_file = open(std_err_file_path, "w", encoding="utf-8")
 
         php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
         if config.get("php_debug"):
@@ -222,6 +224,14 @@ class CorrespondenceTemplate(models.Model):
             )
         proc = subprocess.Popen(php_command_args, stderr=std_err_file)
         proc.communicate()
+
+        if proc.returncode != 0:
+            with open(std_err_file_path, "r", encoding="utf-8") as stderr:
+                _logger.error(
+                    "FPDF returned nonzero exit code %d. stderr:\n%s",
+                    proc.returncode,
+                    stderr.read(),
+                )
 
         # Clean temp files
         for img in temp_img:

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -180,7 +180,7 @@ class CorrespondenceTemplate(models.Model):
         for t_type, t_boxes in list(text.items()):
             for txt in t_boxes:
                 txt_file = tempfile.NamedTemporaryFile(
-                    "w", prefix=t_type + "_", suffix=".txt"
+                    "w", prefix=t_type + "_", suffix=".txt", encoding="utf-8"
                 )
                 txt_file.write(txt)
                 txt_file.flush()


### PR DESCRIPTION
Fix an encoding issue when passing the translated texts from python to PHP through a file.

### Misc
- Fix invalid reference to `$this->overflowTemplate`.
- If the PHP PDF creation fails, log its output to Odoo logs. 