### PR TITLE
T1799 - Fix zoom invite Part 2 (2/2)

### DIFF
--- a/partner_auto_match/models/abstract_partner_form.py
+++ b/partner_auto_match/models/abstract_partner_form.py
@@ -72,8 +72,9 @@ class PartnerForm(models.AbstractModel):
             match_update = vals.get("match_update", False)
             match_create = vals.get("match_create", True)
             if vals.get("partner_id") and match_update:
-                partner = self.env["res.partner"].browse(vals["partner_id"])
-                self.env["res.partner.match"].update_partner(partner, vals)
+                partner_vals = self._convert_vals_for_res_partner(vals)
+                partner = self.env["res.partner"].browse(partner_vals["id"])
+                self.env["res.partner.match"].update_partner(partner, partner_vals)
             if not vals.get("partner_id") and (match_update or match_create):
                 partner_vals = self._convert_vals_for_res_partner(vals)
                 vals["partner_id"] = (


### PR DESCRIPTION
# Description 
Follow-up of https://github.com/CompassionCH/compassion-switzerland/pull/1664

# Technical Aspects
In the case when the `partner_id` is passed as we need to ensure that all the values are formatted correctly, so we use `_convert_vals_for_res_partner`. 