### PR TITLE
T1688 - Add Ambassador field in reconciliation

### DIFF
--- a/account_reconcile_compassion/models/account_reconcile_model.py
+++ b/account_reconcile_compassion/models/account_reconcile_model.py
@@ -13,6 +13,7 @@ class AccountReconcileModel(models.Model):
     sponsorship_id = fields.Many2one(
         "recurring.contract", "Sponsorship", readonly=False
     )
+    user_id = fields.Many2one("res.partner", "Ambassador", readonly=False)
     only_this_month = fields.Boolean(
         default=False, help="Check to search only from the start of the month"
     )
@@ -122,6 +123,8 @@ class AccountReconcileModelLine(models.Model):
         default="self.model_id.avoid_thankyou_letter",
         readonly=True,
     )
+
+    # ADD STUFF HERE ?????
 
     @api.onchange("product_id")
     def _onchange_product_id(self):

--- a/account_reconcile_compassion/models/account_reconcile_model.py
+++ b/account_reconcile_compassion/models/account_reconcile_model.py
@@ -124,8 +124,6 @@ class AccountReconcileModelLine(models.Model):
         readonly=True,
     )
 
-    # ADD STUFF HERE ?????
-
     @api.onchange("product_id")
     def _onchange_product_id(self):
         if self.product_id:

--- a/account_reconcile_compassion/models/bank_statement_line.py
+++ b/account_reconcile_compassion/models/bank_statement_line.py
@@ -217,7 +217,7 @@ class BankStatementLine(models.Model):
             "account_id": account_id,
             "price_unit": amount,
             "price_subtotal": amount,
-            # "user_id": mv_line_dict.get("user_id"),
+            "user_id": mv_line_dict.get("user_id"),
             "quantity": 1,
             "product_id": mv_line_dict["product_id"],
             "analytic_account_id": mv_line_dict["analytic_account_id"],

--- a/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
+++ b/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
@@ -327,6 +327,17 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
             }
           );
 
+          /**
+          self.fields.user_id = new relational_fields.FieldMany2One(
+            self,
+            "user_id",
+            record,
+            {
+              mode: "edit",
+            }
+          );
+          **/
+
           self.fields.comment = new basic_fields.FieldChar(
             self,
             "comment",
@@ -391,6 +402,11 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
           self.fields.sponsorship_id.appendTo(
             $create.find(".create_sponsorship_id .o_td_field")
           );
+          /**
+          self.fields.user_id.appendTo(
+            $create.find(".create_user_id .o_td_field")
+          );
+          **/
           self.fields.comment.appendTo(
             $create.find(".create_comment .o_td_field")
           );

--- a/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
+++ b/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
@@ -178,6 +178,11 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
               ],
             },
             {
+              relation: "res.partner",
+              type: "many2one",
+              name: "user_id",
+            },
+            {
               type: "char",
               name: "comment",
             },
@@ -203,6 +208,9 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
             },
             sponsorship_id: {
               string: _t("Sponsorship"),
+            },
+            user_id: {
+              string: "Ambassador",
             },
             comment: {
               string: _t("Gift instructions"),
@@ -327,7 +335,6 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
             }
           );
 
-          /**
           self.fields.user_id = new relational_fields.FieldMany2One(
             self,
             "user_id",
@@ -336,7 +343,6 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
               mode: "edit",
             }
           );
-          **/
 
           self.fields.comment = new basic_fields.FieldChar(
             self,
@@ -402,11 +408,9 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
           self.fields.sponsorship_id.appendTo(
             $create.find(".create_sponsorship_id .o_td_field")
           );
-          /**
           self.fields.user_id.appendTo(
             $create.find(".create_user_id .o_td_field")
           );
-          **/
           self.fields.comment.appendTo(
             $create.find(".create_comment .o_td_field")
           );
@@ -436,6 +440,7 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
     quickCreateFields: [
       "product_id",
       "sponsorship_id",
+      "user_id",
       "comment",
       "account_id",
       "amount",
@@ -642,6 +647,7 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
       result.sponsorship_id = prop.sponsorship_id
         ? prop.sponsorship_id.id
         : null;
+      result.user_id = prop.user_id ? prop.user_id.id : null;
       result.comment = prop.comment;
       result.avoid_thankyou_letter = prop.avoid_thankyou_letter
         ? prop.avoid_thankyou_letter

--- a/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
+++ b/account_reconcile_compassion/static/src/js/account_move_reconciliation.js
@@ -210,7 +210,7 @@ odoo.define("account_reconcile_compassion.reconciliation", function (require) {
               string: _t("Sponsorship"),
             },
             user_id: {
-              string: "Ambassador",
+              string: _t("Ambassador"),
             },
             comment: {
               string: _t("Gift instructions"),

--- a/account_reconcile_compassion/static/src/xml/account_move_reconciliation.xml
+++ b/account_reconcile_compassion/static/src/xml/account_move_reconciliation.xml
@@ -115,18 +115,6 @@
                </td>
                 <td class="o_td_field" />
             </tr>
-            <tr class="create_campaign_id">
-               <td class="o_td_label">
-                   <label class="o_form_label">Campaign</label>
-               </td>
-                <td class="o_td_field" />
-            </tr>
-            <tr class="create_medium_id">
-               <td class="o_td_label">
-                   <label class="o_form_label">Medium</label>
-               </td>
-                <td class="o_td_field" />
-            </tr>
         </t>
 
         <t t-jquery="tr.create_tax_id" t-operation="replace">

--- a/account_reconcile_compassion/static/src/xml/account_move_reconciliation.xml
+++ b/account_reconcile_compassion/static/src/xml/account_move_reconciliation.xml
@@ -109,6 +109,24 @@
                </td>
                 <td class="o_td_field" />
             </tr>
+            <tr class="create_user_id">
+               <td class="o_td_label">
+                   <label class="o_form_label">Ambassador</label>
+               </td>
+                <td class="o_td_field" />
+            </tr>
+            <tr class="create_campaign_id">
+               <td class="o_td_label">
+                   <label class="o_form_label">Campaign</label>
+               </td>
+                <td class="o_td_field" />
+            </tr>
+            <tr class="create_medium_id">
+               <td class="o_td_label">
+                   <label class="o_form_label">Medium</label>
+               </td>
+                <td class="o_td_field" />
+            </tr>
         </t>
 
         <t t-jquery="tr.create_tax_id" t-operation="replace">

--- a/sponsorship_compassion/models/account_move.py
+++ b/sponsorship_compassion/models/account_move.py
@@ -31,15 +31,8 @@ class AccountInvoice(models.Model):
 
     def _compute_children(self):
         """View children contained in invoice."""
-        def get_contract_child(contract):
-            if contract.type == "G" and False:
-                children = contract.mapped("contract_line_ids.sponsorship_id.child_id")
-                return children
-            else:
-                return contract.mapped("child_id")
-
         for invoice in self:
-            children = invoice.mapped("line_ids.contract_id").mapped(lambda c: get_contract_child(c))
+            children = invoice.mapped("line_ids.contract_id.child_id")
 
             if len(children) > 1:
                 num_children = len(children)

--- a/sponsorship_compassion/models/account_move.py
+++ b/sponsorship_compassion/models/account_move.py
@@ -31,8 +31,16 @@ class AccountInvoice(models.Model):
 
     def _compute_children(self):
         """View children contained in invoice."""
+        def get_contract_child(contract):
+            if contract.type == "G" and False:
+                children = contract.mapped("contract_line_ids.sponsorship_id.child_id")
+                return children
+            else:
+                return contract.mapped("child_id")
+
         for invoice in self:
-            children = invoice.mapped("line_ids.contract_id.child_id")
+            children = invoice.mapped("line_ids.contract_id").mapped(lambda c: get_contract_child(c))
+
             if len(children) > 1:
                 num_children = len(children)
                 invoice.children = f"{num_children} children"

--- a/sponsorship_compassion/models/account_move.py
+++ b/sponsorship_compassion/models/account_move.py
@@ -33,7 +33,6 @@ class AccountInvoice(models.Model):
         """View children contained in invoice."""
         for invoice in self:
             children = invoice.mapped("line_ids.contract_id.child_id")
-
             if len(children) > 1:
                 num_children = len(children)
                 invoice.children = f"{num_children} children"


### PR DESCRIPTION
# Description
During the reconciliation process, the accounting team used to be able to define the Ambassador of an `account.move` in odoo 12, but as of now this is not possible anymore.

# Technical Aspects
 Most of the changes is reverting what was done in [this commit](https://github.com/CompassionCH/compassion-modules/commit/f47c0080e98a6db85dc49d4492e5bbbcc61fda40), I did not figure out why it was removed but it seems to work. 