### PR TITLE
T1217 : pre migration script

### DIFF
--- a/sbc_compassion/__manifest__.py
+++ b/sbc_compassion/__manifest__.py
@@ -28,7 +28,7 @@
 # pylint: disable=C8101
 {
     "name": "Sponsor to Participant communication",
-    "version": "14.0.1.0.2",
+    "version": "14.0.1.0.3",
     "category": "Compassion",
     "summary": "SBC - Supporter to Participant Communication",
     "sequence": 150,

--- a/sbc_compassion/migrations/14.0.1.0.3/pre-migration.py
+++ b/sbc_compassion/migrations/14.0.1.0.3/pre-migration.py
@@ -1,0 +1,67 @@
+import logging
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    cr = env.cr
+    cr.execute(
+        """
+        SELECT DISTINCT(id) FROM res_partner 
+        WHERE translation_user_id IS NULL 
+        AND id IN (
+            SELECT DISTINCT(translator_id) FROM correspondence c
+            WHERE c.translator_id IS NOT NULL
+            AND c.new_translator_id IS NOT NULL
+        );
+    """
+    )
+    # Fetch res_partners id with missing direct link to translation_user.
+    partner_ids = [r[0] for r in cr.fetchall()]
+    all_missing_links_resolved = True
+    for r in partner_ids:
+        # compute the direct link to translation_user by the correspondence table
+        cr.execute(
+            """
+            SELECT DISTINCT(new_translator_id) FROM correspondence
+            WHERE translator_id = %s;
+        """ % r
+        )
+        translation_user_ids = [r[0] for r in cr.fetchall()]
+        if len(translation_user_ids) == 0:
+            _logger.info("Partner link to translation_user not found for id = %s" % r)
+            all_missing_links_resolved = False
+        elif len(translation_user_ids) > 1:
+            _logger.info("Partner link to translation_user is not unique for id = %s"
+                         % r)
+            all_missing_links_resolved = False
+        else:
+            # set the direct link to res_partner -> translation_user
+            link = translation_user_ids[0]
+            openupgrade.logged_query(
+                env.cr,
+                """
+                UPDATE res_partner
+                SET translation_user_id = %s
+                WHERE id = %s;
+                """ % (link, r),
+            )
+    if all_missing_links_resolved:
+        # Remove the redundant column translator_id
+        cr.execute(
+            """
+            ALTER TABLE correspondence
+                DROP COLUMN IF EXISTS translator_id;
+            """
+        )
+
+    # Remove the column translator which is unused from 2016
+    cr.execute(
+        """
+        ALTER TABLE correspondence
+            DROP COLUMN IF EXISTS translator;
+        """
+    )
+

--- a/sbc_compassion/migrations/14.0.1.0.3/pre-migration.py
+++ b/sbc_compassion/migrations/14.0.1.0.3/pre-migration.py
@@ -8,61 +8,14 @@ _logger = logging.getLogger(__name__)
 @openupgrade.migrate()
 def migrate(env, version):
     cr = env.cr
+
+    # Remove the column translator_id which has been deleted from the code in 2022
     cr.execute(
         """
-        SELECT DISTINCT(id) FROM res_partner
-        WHERE translation_user_id IS NULL
-        AND id IN (
-            SELECT DISTINCT(translator_id) FROM correspondence c
-            WHERE c.translator_id IS NOT NULL
-            AND c.new_translator_id IS NOT NULL
-        );
-    """
+        ALTER TABLE correspondence
+            DROP COLUMN IF EXISTS translator_id;
+        """
     )
-    # Fetch res_partners id with missing direct link to translation_user.
-    partner_ids = [r[0] for r in cr.fetchall()]
-    all_missing_links_resolved = True
-    for r in partner_ids:
-        # compute the direct link to translation_user by the correspondence table
-        cr.execute(
-            """
-            SELECT DISTINCT(new_translator_id) FROM correspondence
-            WHERE translator_id = %s;
-            """,
-            (r,),
-        )
-        translation_user_ids = [r[0] for r in cr.fetchall()]
-        if len(translation_user_ids) == 0:
-            _logger.info("Partner link to translation_user not found for id = %s" % r)
-            all_missing_links_resolved = False
-        elif len(translation_user_ids) > 1:
-            _logger.info(
-                "Partner link to translation_user is not unique for id = %s" % r
-            )
-            all_missing_links_resolved = False
-        else:
-            # set the direct link to res_partner -> translation_user
-            link = translation_user_ids[0]
-            openupgrade.logged_query(
-                env.cr,
-                """
-                UPDATE res_partner
-                SET translation_user_id = %s
-                WHERE id = %s;
-                """,
-                (
-                    link,
-                    r,
-                ),
-            )
-    if all_missing_links_resolved:
-        # Remove the redundant column translator_id
-        cr.execute(
-            """
-            ALTER TABLE correspondence
-                DROP COLUMN IF EXISTS translator_id;
-            """
-        )
 
     # Remove the column translator which is unused from 2016
     cr.execute(

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -221,7 +221,6 @@ class Correspondence(models.Model):
     original_letter_url = fields.Char()
     final_letter_url = fields.Char()
     import_id = fields.Many2one("import.letters.history", readonly=False)
-    translator = fields.Char()
     email = fields.Char(related="partner_id.email")
     sponsorship_state = fields.Selection(
         related="sponsorship_id.state", string="Sponsorship state", readonly=True

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -166,10 +166,6 @@
                         </group>
                         <group>
                             <field
-                name="translator"
-                attrs="{'invisible': [('translator', '=', False)]}"
-              />
-                            <field
                 name="translation_language_id"
                 options="{'create':False}"
               />

--- a/sbc_translation/views/correspondence_view.xml
+++ b/sbc_translation/views/correspondence_view.xml
@@ -16,7 +16,7 @@
                         string="Put back into translation"
                         attrs="{'invisible': [('state', '!=', 'Translation check unsuccessful')]}"/>
             </button>
-            <field name="translator" position="after">
+            <field name="translation_language_id" position="before">
                 <field name="new_translator_id"/>
                 <field name="translate_date"/>
                 <field name="translate_done"/>


### PR DESCRIPTION
The translator field is deleted everywhere and in the database.
The migration script try to resolve all the missing links between res.partner and translation.user. If and only if all the missing links are resolved, the translator_id field is deleted from the database.