### PR TITLE
T0024 - Allow passing arbitrary data to email template through context

### DIFF
--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -637,7 +637,9 @@ class CommunicationJob(models.Model):
             if template_id and job.object_ids:
                 try:
                     fields = template_id.with_context(
-                        template_preview_lang=lang
+                        template_preview_lang=lang,
+                        # Allow arbitrary data to be passed to the email template from the context
+                        extra_email_data=self.env.context.get("extra_email_data")
                     ).generate_email(job.ids, ["body_html", "subject"])
                     job.write(
                         {

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -638,7 +638,8 @@ class CommunicationJob(models.Model):
                 try:
                     fields = template_id.with_context(
                         template_preview_lang=lang,
-                        # Allow arbitrary data to be passed to the email template from the context
+                        # Allow arbitrary data to be passed to the email
+                        # template from the context
                         extra_email_data=self.env.context.get("extra_email_data"),
                     ).generate_email(job.ids, ["body_html", "subject"])
                     job.write(

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -639,7 +639,7 @@ class CommunicationJob(models.Model):
                     fields = template_id.with_context(
                         template_preview_lang=lang,
                         # Allow arbitrary data to be passed to the email template from the context
-                        extra_email_data=self.env.context.get("extra_email_data")
+                        extra_email_data=self.env.context.get("extra_email_data"),
                     ).generate_email(job.ids, ["body_html", "subject"])
                     job.write(
                         {

--- a/partner_communication_revision/README.rst
+++ b/partner_communication_revision/README.rst
@@ -35,7 +35,7 @@ Installation
 
 You need to add regex library
 
--  sudo pip install regex
+- sudo pip install regex
 
 Usage
 =====
@@ -45,9 +45,9 @@ Go into communication rules (config) in order to edit translations.
 Known issues / Roadmap
 ======================
 
--  Make javascript widgets to ease the editing process
--  Make possible to use global keywords across the templates
--  Improve usability
+- Make javascript widgets to ease the editing process
+- Make possible to use global keywords across the templates
+- Improve usability
 
 Bug Tracker
 ===========
@@ -70,7 +70,7 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
+- Emanuel Cino <ecino@compassion.ch>
 
 Maintainers
 -----------


### PR DESCRIPTION
This PR adds functionality to `partner_communication/models/communication_job.py`:`CommunicationJob.refresh_text` to pass arbitrary data to email templates from the context.
This is required to implement https://github.com/CompassionCH/compassion-switzerland/pull/1663 without computing the list of partners to archive twice (once in the cron job to determine if an email should be sent, and once in the email template to display the list of partners).

As I am new to odoo, maybe there is a simpler/cleaner way to do what I want to do. If so, this PR is maybe redundant.

If accepted, this PR must be merged **BEFORE** https://github.com/CompassionCH/compassion-switzerland/pull/1663