### PR TITLE
T1955 - Fix unit tests

### DIFF
--- a/account_reconcile_compassion/README.rst
+++ b/account_reconcile_compassion/README.rst
@@ -46,14 +46,14 @@ Configuration
 You can add the following system parameter to enable an analytic account
 to be set on exchange rate move lines:
 
--  account_reconcile_compassion.currency_exchange_analytic_account
+- account_reconcile_compassion.currency_exchange_analytic_account
 
 Usage
 =====
 
 To use this module, you need to:
 
--  Go to Accounting -> Bank Statement -> Reconcile
+- Go to Accounting -> Bank Statement -> Reconcile
 
 Bug Tracker
 ===========
@@ -76,7 +76,7 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
+- Emanuel Cino <ecino@compassion.ch>
 
 Maintainers
 -----------

--- a/advanced_translation/models/__init__.py
+++ b/advanced_translation/models/__init__.py
@@ -3,6 +3,6 @@ from . import (
     lang_compassion,
     langdetect,
     ocr,
-    res_partner_test,
     translatable_model,
+    res_partner_test,
 )

--- a/child_compassion/README.rst
+++ b/child_compassion/README.rst
@@ -43,18 +43,18 @@ Configuration
 Access rights
 -------------
 
--  Assign the rights to the users so that they can access the new
-   "Sponsorship" menu
+- Assign the rights to the users so that they can access the new
+  "Sponsorship" menu
 
 Configuration menu
 ------------------
 
--  Find the configuration menu in Sponsorship/Configuration (must be
-   given rights)
--  Configure the default hold durations in the menu Global
-   Childpool/Availability Management
--  Assign people to be notified when receiving National Office Disaster
-   Alerts using the menu Communication/Staff Notifications
+- Find the configuration menu in Sponsorship/Configuration (must be
+  given rights)
+- Configure the default hold durations in the menu Global
+  Childpool/Availability Management
+- Assign people to be notified when receiving National Office Disaster
+  Alerts using the menu Communication/Staff Notifications
 
 Odoo.conf file
 --------------
@@ -70,8 +70,8 @@ Demand planning
 You can add in the system settings default values for weekly demand and
 resupply quantities by setting the following keys:
 
--  child_compassion.default_demand
--  child_compassion.default_resupply
+- child_compassion.default_demand
+- child_compassion.default_resupply
 
 Usage
 =====
@@ -99,10 +99,10 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
--  Cyril Sester <cyril.sester@outlook.com>
--  Kevin Cristi <kcristi@compassion.ch>
--  David Coninckx <david@coninckx.com>
+- Emanuel Cino <ecino@compassion.ch>
+- Cyril Sester <cyril.sester@outlook.com>
+- Kevin Cristi <kcristi@compassion.ch>
+- David Coninckx <david@coninckx.com>
 
 Maintainers
 -----------

--- a/crm_compassion/README.rst
+++ b/crm_compassion/README.rst
@@ -25,13 +25,13 @@ Compassion - Events
 This module helps Compassion CH to manage its planned events, by
 creating a new model for tracking upcoming events.
 
-   -  Opportunities can generate new events
-   -  Each event is linked to an analytic account
-   -  Each event creates a sponsorship origin
-   -  Portal users have an analytic account to track sponsorships gained
-      by them
-   -  Can set ambassadors to sponsorships in order to track who brought
-      them
+   - Opportunities can generate new events
+   - Each event is linked to an analytic account
+   - Each event creates a sponsorship origin
+   - Portal users have an analytic account to track sponsorships gained
+     by them
+   - Can set ambassadors to sponsorships in order to track who brought
+     them
 
    | Warning: This module deactivates e-mail notification for calendar
      events !
@@ -67,39 +67,37 @@ Here is how the computations are done :
 Demand
 ~~~~~~
 
-   -  Children for the website : each week a fixed number of children
-      are requested for the website. This number is taken from the
-      Settings (Settings -> Demand Planning)
-   -  Children for ambassadors : each week a fixed number of children
-      are requested for ambassadors. This number is taken from the
-      Settings
-   -  Children for SUB Sponsorships : This is a computed number based on
-      statistics since one year. It takes the average number of
-      registered SUB sponsorships per week and puts that number in all
-      weeks of previsions
-   -  Children for the Events : This number is directly extracted from
-      the planned events, with the "number_allocate_children" number and
-      "hold_start_date" set on each event. The number of requested
-      children is split evenly between the weeks separating the
-      "hold_start_date" and the "event_start_date".
+   - Children for the website : each week a fixed number of children are
+     requested for the website. This number is taken from the Settings
+     (Settings -> Demand Planning)
+   - Children for ambassadors : each week a fixed number of children are
+     requested for ambassadors. This number is taken from the Settings
+   - Children for SUB Sponsorships : This is a computed number based on
+     statistics since one year. It takes the average number of
+     registered SUB sponsorships per week and puts that number in all
+     weeks of previsions
+   - Children for the Events : This number is directly extracted from
+     the planned events, with the "number_allocate_children" number and
+     "hold_start_date" set on each event. The number of requested
+     children is split evenly between the weeks separating the
+     "hold_start_date" and the "event_start_date".
 
 Resupply
 ~~~~~~~~
 
-   -  Web resupply : Substracts the average of registered sponsorships
-      from the web since one year from the number requested (taken from
-      the Settings)
-   -  Ambassador resupply : Computed like the web, but with the
-      ambassador numbers
-   -  SUB Sponsorship resupply : Rejected SUB Sponsorships are those
-      that were ended in 90 days following the sponsorship creation.
-      Resupply is the average of sub rejections we had in the previous
-      year.
-   -  Events Resupply : The number is extracted from the events and is
-      equal to the "number_allocate_children" - "planned_sponsorships"
-   -  Sponsorships Cancellations : Cancellations are as well children
-      that will be released to the Global Childpool. This number is also
-      the average of cancellations from last year.
+   - Web resupply : Substracts the average of registered sponsorships
+     from the web since one year from the number requested (taken from
+     the Settings)
+   - Ambassador resupply : Computed like the web, but with the
+     ambassador numbers
+   - SUB Sponsorship resupply : Rejected SUB Sponsorships are those that
+     were ended in 90 days following the sponsorship creation. Resupply
+     is the average of sub rejections we had in the previous year.
+   - Events Resupply : The number is extracted from the events and is
+     equal to the "number_allocate_children" - "planned_sponsorships"
+   - Sponsorships Cancellations : Cancellations are as well children
+     that will be released to the Global Childpool. This number is also
+     the average of cancellations from last year.
 
 Weekly Revisions
 ~~~~~~~~~~~~~~~~
@@ -117,13 +115,13 @@ Usage
 
 To use this module, you need to:
 
--  go to CRM -> Events
+- go to CRM -> Events
 
 Known issues / Roadmap
 ======================
 
--  Maybe merge model crm.event.compassion with the odoo regular
-   event.event
+- Maybe merge model crm.event.compassion with the odoo regular
+  event.event
 
 Bug Tracker
 ===========
@@ -146,7 +144,7 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
+- Emanuel Cino <ecino@compassion.ch>
 
 Maintainers
 -----------

--- a/crm_compassion/static/description/index.html
+++ b/crm_compassion/static/description/index.html
@@ -414,12 +414,11 @@ predictions that were made.</p>
 <h2>Demand</h2>
 <blockquote>
 <ul class="simple">
-<li>Children for the website : each week a fixed number of children
-are requested for the website. This number is taken from the
-Settings (Settings -&gt; Demand Planning)</li>
-<li>Children for ambassadors : each week a fixed number of children
-are requested for ambassadors. This number is taken from the
-Settings</li>
+<li>Children for the website : each week a fixed number of children are
+requested for the website. This number is taken from the Settings
+(Settings -&gt; Demand Planning)</li>
+<li>Children for ambassadors : each week a fixed number of children are
+requested for ambassadors. This number is taken from the Settings</li>
 <li>Children for SUB Sponsorships : This is a computed number based on
 statistics since one year. It takes the average number of
 registered SUB sponsorships per week and puts that number in all
@@ -441,10 +440,9 @@ from the web since one year from the number requested (taken from
 the Settings)</li>
 <li>Ambassador resupply : Computed like the web, but with the
 ambassador numbers</li>
-<li>SUB Sponsorship resupply : Rejected SUB Sponsorships are those
-that were ended in 90 days following the sponsorship creation.
-Resupply is the average of sub rejections we had in the previous
-year.</li>
+<li>SUB Sponsorship resupply : Rejected SUB Sponsorships are those that
+were ended in 90 days following the sponsorship creation. Resupply
+is the average of sub rejections we had in the previous year.</li>
 <li>Events Resupply : The number is extracted from the events and is
 equal to the “number_allocate_children” - “planned_sponsorships”</li>
 <li>Sponsorships Cancellations : Cancellations are as well children

--- a/firebase_connector/README.rst
+++ b/firebase_connector/README.rst
@@ -35,7 +35,7 @@ Configuration
 
 Make sure the following variables are defined in your odoo.conf file:
 
--  \`firebase_api_key\`: Your Firebase API key
+- \`firebase_api_key\`: Your Firebase API key
 
 Usage
 =====
@@ -46,7 +46,7 @@ mobile devices.
 Known issues / Roadmap
 ======================
 
--  Provide mass messaging
+- Provide mass messaging
 
 Changelog
 =========
@@ -54,7 +54,7 @@ Changelog
 10.0.0.0.0 (2019-05-15)
 -----------------------
 
--  [ADD] Add the module
+- [ADD] Add the module
 
 Bug Tracker
 ===========
@@ -77,7 +77,7 @@ Authors
 Contributors
 ------------
 
--  Nicolas Badoux <n.badoux@hotmail.com>
+- Nicolas Badoux <n.badoux@hotmail.com>
 
 Maintainers
 -----------

--- a/message_center_compassion/README.rst
+++ b/message_center_compassion/README.rst
@@ -39,14 +39,14 @@ Configuration
 
 To configure this module, you need to:
 
--  add settings in .conf file of Odoo
--  connect_url = <url to entry point of GMC Onramp>
--  connect_api_key = <api key for using GMC messages services>
--  connect_client = <username for token requests>
--  connect_secret = <password for token requests>
--  connect_token_server = <base URL of token server>
--  connect_token_cert = <comma-separated list of full URLs of the public
-   keys of the token server>
+- add settings in .conf file of Odoo
+- connect_url = <url to entry point of GMC Onramp>
+- connect_api_key = <api key for using GMC messages services>
+- connect_client = <username for token requests>
+- connect_secret = <password for token requests>
+- connect_token_server = <base URL of token server>
+- connect_token_cert = <comma-separated list of full URLs of the public
+  keys of the token server>
 
 To allow incoming messages you must setup a user with required access
 rights and with login = <username sent by GMC in tokens> and password =
@@ -60,7 +60,7 @@ Usage
 
 To use this module, you need to:
 
--  Go to Message Center
+- Go to Message Center
 
 Bug Tracker
 ===========
@@ -83,10 +83,10 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
--  Cyril Sester <cyril.sester@outlook.com>
--  David Coninckx <david@coninckx.com>
--  Nathan Flückiger <nathan.fluckiger@hotmail.ch>
+- Emanuel Cino <ecino@compassion.ch>
+- Cyril Sester <cyril.sester@outlook.com>
+- David Coninckx <david@coninckx.com>
+- Nathan Flückiger <nathan.fluckiger@hotmail.ch>
 
 Maintainers
 -----------

--- a/mobile_app_connector/README.rst
+++ b/mobile_app_connector/README.rst
@@ -47,15 +47,15 @@ This module adds REST controllers that will work with the mobile App
 developed by Compassion UK. It adds the following routes that can be
 accessed by the mobile app:
 
--  /mobile-app-api/login
--  /mobile-app-api/<odoo_model>/<odoo_method>
--  /mobile-app-api/hero/
--  /mobile-app-api/correspondence/letter_pdf
+- /mobile-app-api/login
+- /mobile-app-api/<odoo_model>/<odoo_method>
+- /mobile-app-api/hero/
+- /mobile-app-api/correspondence/letter_pdf
 
 Known issues / Roadmap
 ======================
 
--  Implement all messages needed
+- Implement all messages needed
 
 Changelog
 =========
@@ -63,7 +63,7 @@ Changelog
 10.0.1.0.0 (2018-07-09)
 -----------------------
 
--  [ADD] Add the module with first set of messages.
+- [ADD] Add the module with first set of messages.
 
 Bug Tracker
 ===========
@@ -86,9 +86,9 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
--  Second Person <second.person@example.org> (optional company website
-   url)
+- Emanuel Cino <ecino@compassion.ch>
+- Second Person <second.person@example.org> (optional company website
+  url)
 
 Maintainers
 -----------

--- a/mobile_app_connector/tests/test_mobile_app_http.py
+++ b/mobile_app_connector/tests/test_mobile_app_http.py
@@ -8,7 +8,7 @@
 #
 ##############################################################################
 import simplejson
-from mock import patch
+from unittest.mock import patch
 
 from odoo.tests.common import HttpCase
 

--- a/mobile_app_connector/tests/test_mobile_app_http.py
+++ b/mobile_app_connector/tests/test_mobile_app_http.py
@@ -7,8 +7,9 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import simplejson
 from unittest.mock import patch
+
+import simplejson
 
 from odoo.tests.common import HttpCase
 

--- a/partner_communication_revision/README.rst
+++ b/partner_communication_revision/README.rst
@@ -35,7 +35,7 @@ Installation
 
 You need to add regex library
 
--  sudo pip install regex
+- sudo pip install regex
 
 Usage
 =====
@@ -45,9 +45,9 @@ Go into communication rules (config) in order to edit translations.
 Known issues / Roadmap
 ======================
 
--  Make javascript widgets to ease the editing process
--  Make possible to use global keywords across the templates
--  Improve usability
+- Make javascript widgets to ease the editing process
+- Make possible to use global keywords across the templates
+- Improve usability
 
 Bug Tracker
 ===========
@@ -70,7 +70,7 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
+- Emanuel Cino <ecino@compassion.ch>
 
 Maintainers
 -----------

--- a/sbc_compassion/README.rst
+++ b/sbc_compassion/README.rst
@@ -35,15 +35,15 @@ Installation
 
 To install this module, you need to install dependencies:
 
--  requires the following libraries (names from apt-get):
+- requires the following libraries (names from apt-get):
 
-   -  libzbar-dev
+  - libzbar-dev
 
--  requires tesseract for extracting text from PDF files (for S2B
-   letters scan):
+- requires tesseract for extracting text from PDF files (for S2B letters
+  scan):
 
-   -  tesseract-ocr
-   -  tesseract-ocr-language_code (for any desired language)
+  - tesseract-ocr
+  - tesseract-ocr-language_code (for any desired language)
 
 Usage
 =====
@@ -56,9 +56,9 @@ Changelog
 10.0.1.2.1 (2018-11-02)
 -----------------------
 
--  Change how we send Original Language to GMC. From now on, we map it
-   to the translated language in Odoo, in order to avoid unnecessary
-   translation at the National Office.
+- Change how we send Original Language to GMC. From now on, we map it to
+  the translated language in Odoo, in order to avoid unnecessary
+  translation at the National Office.
 
 Bug Tracker
 ===========
@@ -81,10 +81,10 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
--  Emmanuel Mathier <emmanuel.mathier@gmail.com>
--  Loic Hausammann <loic_hausammann@hotmail.com>
--  Emmanuel Girardin <emmanuel.girardin@outlook.com>
+- Emanuel Cino <ecino@compassion.ch>
+- Emmanuel Mathier <emmanuel.mathier@gmail.com>
+- Loic Hausammann <loic_hausammann@hotmail.com>
+- Emmanuel Girardin <emmanuel.girardin@outlook.com>
 
 Maintainers
 -----------

--- a/sbc_compassion/static/description/index.html
+++ b/sbc_compassion/static/description/index.html
@@ -398,8 +398,8 @@ correspondence between sponsors and their children sponsorships</p>
 <li>libzbar-dev</li>
 </ul>
 </li>
-<li>requires tesseract for extracting text from PDF files (for S2B
-letters scan):<ul>
+<li>requires tesseract for extracting text from PDF files (for S2B letters
+scan):<ul>
 <li>tesseract-ocr</li>
 <li>tesseract-ocr-language_code (for any desired language)</li>
 </ul>
@@ -414,8 +414,8 @@ letters scan):<ul>
 <div class="section" id="section-1">
 <h2><a class="toc-backref" href="#toc-entry-4">10.0.1.2.1 (2018-11-02)</a></h2>
 <ul class="simple">
-<li>Change how we send Original Language to GMC. From now on, we map it
-to the translated language in Odoo, in order to avoid unnecessary
+<li>Change how we send Original Language to GMC. From now on, we map it to
+the translated language in Odoo, in order to avoid unnecessary
 translation at the National Office.</li>
 </ul>
 </div>

--- a/sbc_translation/README.rst
+++ b/sbc_translation/README.rst
@@ -56,8 +56,8 @@ To configure this module, you need to:
 
 1. Give access rights to users
 
-   -  Front end translators need the User rights.
-   -  Managers need the Manager rights for accessing the backend.
+   - Front end translators need the User rights.
+   - Managers need the Manager rights for accessing the backend.
 
 |image1|
 
@@ -70,11 +70,11 @@ To use this module, you need to:
 
 1. Go to /Sponsorship/Correspondence/Translation Platform/ menu
 
-   -  Translation Pool is the list of all letters currently in
-      translation
-   -  Translators is the list of translators
-   -  Competences is the available skills of translations. It is also an
-      entry point to the translation pool, filtered by language.
+   - Translation Pool is the list of all letters currently in
+     translation
+   - Translators is the list of translators
+   - Competences is the available skills of translations. It is also an
+     entry point to the translation pool, filtered by language.
 
 Changelog
 =========
@@ -82,7 +82,7 @@ Changelog
 12.0.1.0.0 (2023-02-28)
 -----------------------
 
--  First version
+- First version
 
 Bug Tracker
 ===========
@@ -105,7 +105,7 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
+- Emanuel Cino <ecino@compassion.ch>
 
 Maintainers
 -----------

--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -67,7 +67,7 @@ class ContractGroup(models.Model):
     def _get_partner_for_contract(self, contract, gift_wizard=False):
         if gift_wizard and contract.send_gifts_to:
             return contract[contract.send_gifts_to]
-        return super()._get_partner_for_contract(contract)
+        return super()._get_partner_for_contract(contract, gift_wizard)
 
     def _should_skip_invoice_generation(self, invoicing_date, contract=None):
         self.ensure_one()

--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -67,7 +67,7 @@ class ContractGroup(models.Model):
     def _get_partner_for_contract(self, contract, gift_wizard=False):
         if gift_wizard and contract.send_gifts_to:
             return contract[contract.send_gifts_to]
-        return super()._get_partner_for_contract(contract, gift_wizard)
+        return super()._get_partner_for_contract(contract)
 
     def _should_skip_invoice_generation(self, invoicing_date, contract=None):
         self.ensure_one()

--- a/sponsorship_compassion/tests/test_sponsorship_compassion.py
+++ b/sponsorship_compassion/tests/test_sponsorship_compassion.py
@@ -90,14 +90,16 @@ class BaseSponsorshipTest(BaseContractCompassionTest):
         )
 
         # Create account used in unreconciled_transaction_items
-        self.env["account.account"].create(
-            {
-                "name": "Some test account",
-                "user_type_id": 1,
-                "reconcile": True,
-                "code": "1050",
-            }
-        )
+        account = self.env["account.account"]
+        if account.search_count([("code", "=", "1050")]) == 0:
+            self.env["account.account"].create(
+                {
+                    "name": "Some test account",
+                    "user_type_id": 1,
+                    "reconcile": True,
+                    "code": "1050",
+                }
+            )
 
         # Create a child and get the project associated
         self.child = self.create_child("PE012304567")

--- a/sponsorship_compassion/tests/test_sponsorship_compassion.py
+++ b/sponsorship_compassion/tests/test_sponsorship_compassion.py
@@ -88,6 +88,17 @@ class BaseSponsorshipTest(BaseContractCompassionTest):
                 "payment_method_id": dd_pay_method.id,
             }
         )
+
+        # Create account used in unreconciled_transaction_items
+        self.env["account.account"].create(
+            {
+                "name": "Some test account",
+                "user_type_id": 1,
+                "reconcile": True,
+                "code": "1050"
+            }
+        )
+
         # Create a child and get the project associated
         self.child = self.create_child("PE012304567")
         # Creation of the sponsorship contract

--- a/sponsorship_compassion/tests/test_sponsorship_compassion.py
+++ b/sponsorship_compassion/tests/test_sponsorship_compassion.py
@@ -95,7 +95,7 @@ class BaseSponsorshipTest(BaseContractCompassionTest):
                 "name": "Some test account",
                 "user_type_id": 1,
                 "reconcile": True,
-                "code": "1050"
+                "code": "1050",
             }
         )
 

--- a/sponsorship_reporting/README.rst
+++ b/sponsorship_reporting/README.rst
@@ -52,8 +52,8 @@ Authors
 Contributors
 ------------
 
--  Emanuel Cino <ecino@compassion.ch>
--  Simon Gonzalez <simon.gonzalez@bluewin.ch>
+- Emanuel Cino <ecino@compassion.ch>
+- Simon Gonzalez <simon.gonzalez@bluewin.ch>
 
 Maintainers
 -----------

--- a/survival_sponsorship_compassion/README.rst
+++ b/survival_sponsorship_compassion/README.rst
@@ -24,28 +24,27 @@ Compassion Survival Sponsorships
 
 This module add :
 
--  New type *CSP* for sponsorships
+- New type *CSP* for sponsorships
 
-   -  Filter the product available
+  - Filter the product available
 
--  Survival Sponsorship Sale on the product.template
+- Survival Sponsorship Sale on the product.template
 
-   -  Define if the product is actually used for the survival
-      sponsorships
+  - Define if the product is actually used for the survival sponsorships
 
--  Specific monitoring fields for product.product
+- Specific monitoring fields for product.product
 
-   -  Survival Field Office : Which field office this product applies to
-   -  Slot used : Number of intervention slot already taken
-   -  Survival Slots : Number of slots available for this field office
-   -  Survival Sponsorship : Number of sponsorships active
-   -  Alltime Survival Sponsorship : Number of sponsorships on this
-      specific product (active and inactive)
+  - Survival Field Office : Which field office this product applies to
+  - Slot used : Number of intervention slot already taken
+  - Survival Slots : Number of slots available for this field office
+  - Survival Sponsorship : Number of sponsorships active
+  - Alltime Survival Sponsorship : Number of sponsorships on this
+    specific product (active and inactive)
 
--  Base automation that will trigger schedule activities
+- Base automation that will trigger schedule activities
 
-   -  Put a schedule activity on the products that has too much slot
-      used (by default defined at 80%+)
+  - Put a schedule activity on the products that has too much slot used
+    (by default defined at 80%+)
 
 **Table of contents**
 
@@ -65,8 +64,8 @@ slots.
 Known issues / Roadmap
 ======================
 
--  Q3-4 2023 : API connected to the website to actually show the current
-   list of available country for this product
+- Q3-4 2023 : API connected to the website to actually show the current
+  list of available country for this product
 
 Bug Tracker
 ===========
@@ -89,7 +88,7 @@ Authors
 Contributors
 ------------
 
--  Simon Gonzalez <sgonzalez@ikmail.com>
+- Simon Gonzalez <sgonzalez@ikmail.com>
 
 Maintainers
 -----------

--- a/survival_sponsorship_compassion/static/description/index.html
+++ b/survival_sponsorship_compassion/static/description/index.html
@@ -377,8 +377,7 @@ ul.auto-toc {
 </ul>
 </li>
 <li>Survival Sponsorship Sale on the product.template<ul>
-<li>Define if the product is actually used for the survival
-sponsorships</li>
+<li>Define if the product is actually used for the survival sponsorships</li>
 </ul>
 </li>
 <li>Specific monitoring fields for product.product<ul>
@@ -391,8 +390,8 @@ specific product (active and inactive)</li>
 </ul>
 </li>
 <li>Base automation that will trigger schedule activities<ul>
-<li>Put a schedule activity on the products that has too much slot
-used (by default defined at 80%+)</li>
+<li>Put a schedule activity on the products that has too much slot used
+(by default defined at 80%+)</li>
 </ul>
 </li>
 </ul>


### PR DESCRIPTION
Fixed:
- The order of imports prevented the PartnerTest class from bein initialised properly (in test mode).
- mock moved to unittest.mock : https://docs.python.org/3.3/library/unittest.mock.html
- unreconciled_transaction_items error because of non-existing account (in empty db)

Only `--test-tags=sponsorship_compassion` is now error-free (all tests pass, on an empty db). Other tests should be fixed in separate PRs.

See also: https://github.com/CompassionCH/compassion-switzerland/pull/1673
