### PR TITLE
[T2077] FIX: New Biennial wrongly generated

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -592,10 +592,14 @@ class CompassionChild(models.Model):
                 new_photo = pictures[0].date
                 diff_pic = relativedelta(new_photo, last_photo)
                 diff_today = relativedelta(today, new_photo)
+
                 if (
-                    len(pictures) == 2 or diff_pic.months >= 6 or diff_pic.years > 0
-                ) and (diff_today.months <= 6 and diff_today.years == 0):
+                    (diff_pic.months >= 6 or diff_pic.years > 0)
+                    and (diff_today.months <= 6 and diff_today.years == 0)
+                    and not pictures[0].funct_new_photo_called
+                ):
                     child.new_photo()
+                    pictures[0].funct_new_photo_called = True
 
     # Lifecycle methods
     ###################

--- a/child_compassion/models/child_pictures.py
+++ b/child_compassion/models/child_pictures.py
@@ -42,6 +42,7 @@ class ChildPictures(models.Model):
     fname = fields.Char(compute="_compute_filename")
     hname = fields.Char(compute="_compute_filename")
 
+    funct_new_photo_called = fields.Boolean(default=False)
     _sql_constraints = [
         (
             "unique_picture_per_child",


### PR DESCRIPTION
To migrate the DB, the following SQL queries should be run:

ALTER TABLE compassion_child_pictures 
ADD COLUMN funct_new_photo_called BOOLEAN;

UPDATE compassion_child_pictures ccp
set funct_new_photo_called = false; 