### PR TITLE
[T2169] FIX : invoice status after unreconcile

### DIFF
--- a/thankyou_letters/models/account_move.py
+++ b/thankyou_letters/models/account_move.py
@@ -56,8 +56,10 @@ class AccountInvoice(models.Model):
 
     def _compute_amount(self):
         """When invoice is open again, remove it from donation receipt."""
-        payment_states = self.mapped("payment_state")
+        # Computes values before treatments
         super()._compute_amount()
+        super()._compute_payment_state()
+        payment_states = self.mapped("payment_state")
         new_payment_states = self.mapped("payment_state")
         for i, state in enumerate(payment_states):
             invoice = self[i]


### PR DESCRIPTION
Fixed invoice status back to 'unpaid' after unreconciliation

The issue was caused by the thankyou_letter method, leading to a mismatch between the amount and state.

I fixed this by recomputing payment_state before processing in the overridden _compute_amount() method.