### PR TITLE
T2039 project tags

### DIFF
--- a/crm_compassion/static/src/scss/kanban_colors.scss
+++ b/crm_compassion/static/src/scss/kanban_colors.scss
@@ -1,7 +1,6 @@
-$o-colors: lighten(#000, 46.7%), #f06050, #f4a460, #f7cd1f, #6cc1ed, #814968,
-  #eb7e7f, #2c8397, #475577, #d6145f, #30c381, #9365b8, #b30000, #0000cc,
-  #ff0000, #993300, #006600, #ffff80, #ffd1b3, #99ff99, #003366, #333333,
-  #330033, #4d0000, #476b6b;
+$o-colors: lighten(#000, 46.7%), #ff0000, #f4a460, #f7cd1f, #6cc1ed, #814968,
+  #eb7e7f, #2c8397, #191970, #d6145f, #30c381, #9365b8, #b30000, #0000ff,
+  #993300, #ffff80, #ffd1b3, #99ff99, #003366, #333333, #330033, #581845, #476b6b;
 
 @mixin o-kanban-record-color {
   @for $size from 2 through length($o-colors) {
@@ -59,3 +58,33 @@ $o-colors: lighten(#000, 46.7%), #f06050, #f4a460, #f7cd1f, #6cc1ed, #814968,
     }
   }
 }
+
+.o_field_color_picker {
+  ul {
+    @for $size from 1 through length($o-colors) {
+      .oe_kanban_color_#{$size - 1} {
+        @if $size == 1 {
+          background-color: white;
+          color: nth($o-colors, $size);
+          box-shadow: inset 0 0 0 2px nth($o-colors, $size);
+        } @else {
+          background-color: nth($o-colors, $size);
+          color: white;
+        }
+      }
+    }
+  }
+}
+
+.o_field_color_picker_preview {
+  a {
+    @for $size from 1 through length($o-colors) {
+      &[data-color="#{$size - 1}"] {
+        background-color: nth($o-colors, $size);
+        color: if($size == 1, nth($o-colors, $size), white);
+        box-shadow: if($size == 1, inset 0 0 0 2px nth($o-colors, $size), none);
+      }
+    }
+  }
+}
+

--- a/crm_compassion/static/src/scss/kanban_colors.scss
+++ b/crm_compassion/static/src/scss/kanban_colors.scss
@@ -1,6 +1,7 @@
 $o-colors: lighten(#000, 46.7%), #ff0000, #f4a460, #f7cd1f, #6cc1ed, #814968,
   #eb7e7f, #2c8397, #191970, #d6145f, #30c381, #9365b8, #b30000, #0000ff,
-  #993300, #ffff80, #ffd1b3, #99ff99, #003366, #333333, #330033, #581845, #476b6b;
+  #993300, #ffff80, #ffd1b3, #99ff99, #003366, #333333, #330033, #581845,
+  #476b6b;
 
 @mixin o-kanban-record-color {
   @for $size from 2 through length($o-colors) {
@@ -87,4 +88,3 @@ $o-colors: lighten(#000, 46.7%), #ff0000, #f4a460, #f7cd1f, #6cc1ed, #814968,
     }
   }
 }
-

--- a/crm_compassion/static/src/xml/kanban_colors.xml
+++ b/crm_compassion/static/src/xml/kanban_colors.xml
@@ -3,7 +3,7 @@
         <t t-jquery="t[t-set='colornames']" t-operation="attributes">
             <attribute
         name="value"
-      >['No color', 'Red', 'Orange', 'Yellow', 'Light blue', 'Dark purple', 'Salmon pink', 'Medium blue', 'Dark blue', 'Fushia', 'Green', 'Purple', 'Dark red', 'Blue', 'Red', 'Brown', 'Green', 'Light yellow', 'Beige', 'Pastel green', 'Tommy blue', 'Dark grey', 'Dark violet', 'Dark brown', 'Greyish blue']</attribute>
+      >['Dark red', 'Blue', 'Brown', 'Light yellow', 'Beige', 'Pastel green', 'Tommy blue', 'Dark grey', 'Dark violet', 'Dark brown', 'Greyish blue']</attribute>
         </t>
     </t>
     <t t-extend="FieldMany2ManyTag.colorpicker">
@@ -32,15 +32,6 @@
           t-att-data-id="tag_id"
           class="o_tag_color_14"
           data-color="14"
-          title="Red"
-          aria-label="Red"
-        /></li>
-            <li><a
-          role="menuitem"
-          href="#"
-          t-att-data-id="tag_id"
-          class="o_tag_color_15"
-          data-color="15"
           title="Brown"
           aria-label="Brown"
         /></li>
@@ -48,17 +39,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_16"
-          data-color="16"
-          title="Green"
-          aria-label="Green"
-        /></li>
-            <li><a
-          role="menuitem"
-          href="#"
-          t-att-data-id="tag_id"
-          class="o_tag_color_17"
-          data-color="17"
+          class="o_tag_color_15"
+          data-color="15"
           title="Light yellow"
           aria-label="Light yellow"
         /></li>
@@ -66,8 +48,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_18"
-          data-color="18"
+          class="o_tag_color_16"
+          data-color="16"
           title="Beige"
           aria-label="Beige"
         /></li>
@@ -75,8 +57,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_19"
-          data-color="19"
+          class="o_tag_color_17"
+          data-color="17"
           title="Pastel green"
           aria-label="Pastel green"
         /></li>
@@ -84,8 +66,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_20"
-          data-color="20"
+          class="o_tag_color_18"
+          data-color="18"
           title="Tommy blue"
           aria-label="Tommy blue"
         /></li>
@@ -93,8 +75,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_21"
-          data-color="21"
+          class="o_tag_color_19"
+          data-color="19"
           title="Dark grey"
           aria-label="Dark grey"
         /></li>
@@ -102,8 +84,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_22"
-          data-color="22"
+          class="o_tag_color_20"
+          data-color="20"
           title="Dark violet"
           aria-label="Dark violet"
         /></li>
@@ -111,8 +93,8 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_23"
-          data-color="23"
+          class="o_tag_color_21"
+          data-color="21"
           title="Dark brown"
           aria-label="Dark brown"
         /></li>
@@ -120,15 +102,15 @@
           role="menuitem"
           href="#"
           t-att-data-id="tag_id"
-          class="o_tag_color_24"
-          data-color="24"
+          class="o_tag_color_22"
+          data-color="22"
           title="Greyish blue"
           aria-label="Greyish blue"
         /></li>
         </t>
     </t>
     <t t-extend="KanbanColorPicker">
-        <t t-jquery="li:last" t-operation="after">
+        <t t-jquery="t[t-foreach='colors']:first" t-operation="after">
             <li><a
           role="menuitem"
           href="#"
@@ -150,89 +132,73 @@
           href="#"
           data-color="14"
           class="oe_kanban_color_14"
-          title="Red"
-          aria-label="Red"
-        /></li>
-            <li><a
-          role="menuitem"
-          href="#"
-          data-color="15"
-          class="oe_kanban_color_15"
           title="Brown"
           aria-label="Brown"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="16"
-          class="oe_kanban_color_16"
-          title="Green"
-          aria-label="Green"
-        /></li>
-            <li><a
-          role="menuitem"
-          href="#"
-          data-color="17"
-          class="oe_kanban_color_17"
+          data-color="15"
+          class="oe_kanban_color_15"
           title="Light yellow"
           aria-label="Light yellow"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="18"
-          class="oe_kanban_color_18"
+          data-color="16"
+          class="oe_kanban_color_16"
           title="Beige"
           aria-label="Beige"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="19"
-          class="oe_kanban_color_19"
+          data-color="17"
+          class="oe_kanban_color_17"
           title="Pastel green"
           aria-label="Pastel green"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="20"
-          class="oe_kanban_color_20"
+          data-color="18"
+          class="oe_kanban_color_18"
           title="Tommy blue"
           aria-label="Tommy blue"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="21"
-          class="oe_kanban_color_21"
+          data-color="19"
+          class="oe_kanban_color_19"
           title="Dark grey"
           aria-label="Dark grey"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="22"
-          class="oe_kanban_color_22"
+          data-color="20"
+          class="oe_kanban_color_20"
           title="Dark violet"
           aria-label="Dark violet"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="23"
-          class="oe_kanban_color_23"
+          data-color="21"
+          class="oe_kanban_color_21"
           title="Dark brown"
           aria-label="Dark brown"
         /></li>
             <li><a
           role="menuitem"
           href="#"
-          data-color="24"
-          class="oe_kanban_color_24"
+          data-color="22"
+          class="oe_kanban_color_22"
           title="Greyish blue"
           aria-label="Greyish blue"
         /></li>
+            </t>
         </t>
-    </t>
 </template>


### PR DESCRIPTION
AFTER PUTTING THIS SNIPPET IN PRODUCTION IT WILL CHANGE SOME COLOURS THAT ARE ALREADY IN EFFECT FOR TAGS/TASKS -> BECAUSE THERE WERE SOME COLOURS THAT HAD 2 DIFFERENT IDS, I REMOVED THEM AVOID REDUNDANCY. The extension of colours (not present in the odoo default addons) was being duplicated as it was extended in a for loop that was used to fetch the default odoo colours. The extension of colours was white (blank) because the logic to add the preview of the extended colours was only added for the colorpicker when you edit a colour (tag_color_x) and not for when you create a tag (oe_kanban_color_x). Now everything should work, there are no more duplicates and you can see all the previews of the colours.