### PR TITLE
T2234 onboarding emails

### DIFF
--- a/partner_communication/models/communication_config.py
+++ b/partner_communication/models/communication_config.py
@@ -135,6 +135,27 @@ class CommunicationConfig(models.Model):
         help="If selected, disable the automatic merging of communications",
     )
     active = fields.Boolean(default=True)
+    send_from = fields.Selection(
+        [
+            ("manual", "Manual"),
+            ("dynamic", "Dynamic"),
+        ],
+        string="Send from",
+        required=True,
+        default="manual",
+        help="If 'Manual', the sender is determined by the communication rule. "
+        "If 'Dynamic', the sender is dynamically retrieved from the related record "
+        "using the field specified below.",
+    )
+    sender_field_id = fields.Many2one(
+        "ir.model.fields",
+        string="Send from selection",
+        domain="[('model_id', '=', model_id),"
+        "('relation', '=', 'res.users'),"
+        "('ttype', '=', 'many2one')]",
+        help="If 'Send From' is 'Dynamic', pick which Many2one-to-res.users field "
+        "should be used as the sender.",
+    )
 
     ##########################################################################
     #                             FIELDS METHODS                             #

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -388,6 +388,48 @@ class CommunicationJob(models.Model):
         return super().copy(vals)
 
     @api.model
+    def _get_dynamic_user(self, config, object_ids_str):
+        """
+        Check if config is dynamic and has a sender field,
+        parse the first ID from object_ids,
+        load the record from config.model_id.model,
+        retrieve the user via sender_field_id.name
+        (use the first if multiple), and return None if none is found.
+        """
+        if config.send_from != "dynamic" or not config.sender_field_id:
+            return None  # Not dynamic, or no field chosen
+
+        if not object_ids_str:
+            return None
+
+        first_id_str = object_ids_str.split(",")[0].strip()
+        if not first_id_str.isdigit():
+            return None
+
+        object_id = int(first_id_str)
+        model_name = config.model_id.model
+        if not model_name:
+            return None
+
+        related_object = config.env[model_name].browse(object_id)
+        if not related_object:
+            return None
+
+        field_name = config.sender_field_id.name
+        if not hasattr(related_object, field_name):
+            return None
+
+        user_id = related_object[field_name]
+        if not user_id:
+            return None
+
+        # If multiple users returned, pick the first
+        if len(related_object) > 1:
+            user_id = user_id[0]
+
+        return user_id
+
+    @api.model
     def _get_default_vals(self, vals, default_vals=None):
         """
         Used at record creation to find default values given the config of the
@@ -424,14 +466,13 @@ class CommunicationJob(models.Model):
             user_id = self.env.uid
             if default_config.user_id:
                 user_id = default_config.user_id.id
+            elif config.send_from == "dynamic":
+                dynamic_user = self._get_dynamic_user(config, vals.get("object_ids"))
+                if dynamic_user:
+                    user_id = dynamic_user.id
             elif config.user_id:
                 user_id = config.user_id.id
             vals["user_id"] = user_id
-
-        # if not vals.get("printer_output_tray_id"):
-        #     if printer_config.printer_output_tray_id:
-        #         vals["printer_output_tray_id"] = \
-        #             printer_config.printer_output_tray_id.id
 
         # Check all default_vals fields
         for default_val in default_vals:

--- a/partner_communication/views/communication_config_view.xml
+++ b/partner_communication/views/communication_config_view.xml
@@ -24,8 +24,19 @@
                           <field name="forbid_merging" />
                         </group>
                         <group>
-                            <field name="user_id" />
                             <field name="model_id" />
+                            <field name="send_from" />
+                            <field
+                name="sender_field_id"
+                domain="[('model_id','=', model_id),
+                                             ('relation','=','res.users'),
+                                             ('ttype','=','many2one')]"
+                attrs="{'invisible' : [('send_from', '=', 'manual')]}"
+              />
+                            <field
+                name="user_id"
+                attrs="{'invisible': [('send_from', '=', 'dynamic')]}"
+              />
                             <field name="email_template_id" />
                             <field name="report_id" />
                             <field name="attachments_function" />

--- a/sponsorship_compassion/security/security.xml
+++ b/sponsorship_compassion/security/security.xml
@@ -11,7 +11,7 @@
         </record>
         <record id="forget_me_group" model="res.groups">
             <field name="name">Anonymize Partners</field>
-            <field name="category_id" ref="base.module_category_usability"/>
+            <field name="category_id" ref="base.module_category_usability" />
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
A new "Send From" option has been added to communication rules, allowing the sender to be selected either manually or dynamically. In dynamic mode, the sender is automatically retrieved from a user-related field (e.g., sds_uid) on the target model, making it possible to send communications on behalf of the user responsible for the related record—ideal for onboarding cases like sponsorship validation.

IMPORTANT!! 
Use only the commits of MarcoPontarolo and not AndiR27.
Changed files:
- partner_communication/models/communication_config.py
- partner_communication/models/communication_job.py
- partner_communication/views/communication_config_view.xml