### PR TITLE
[T2370] fixed church name editing error

### DIFF
--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -67,7 +67,8 @@ class Partner(models.Model):
         super()._compute_opportunity_count()
         for partner in self:
             operator = "child_of" if partner.is_company else "="
-            # we use partner.ids[0] because when editing a church's name the id becomes temporarily a NewId and so an error is produced as the method uses child_of with a NewId and not the original id
+            # Using partner.ids[0] is a trick to avoid error with child_of
+            # when partner has a temporary NewId
             partner.opportunity_count += self.env["crm.lead"].search_count(
                 [
                     ("partner_id", operator, partner.ids[0]),

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -66,14 +66,14 @@ class Partner(models.Model):
     def _compute_opportunity_count(self):
         super()._compute_opportunity_count()
         for partner in self:
-                operator = "child_of" if partner.is_company else "="
-                partner.opportunity_count += self.env["crm.lead"].search_count(
-                    [
-                        ("partner_id", operator, partner.ids[0]),
-                        ("type", "=", "opportunity"),
-                        ("active", "=", False),
-                    ]
-                )
+            operator = "child_of" if partner.is_company else "="
+            partner.opportunity_count += self.env["crm.lead"].search_count(
+                [
+                    ("partner_id", operator, partner.ids[0]),
+                    ("type", "=", "opportunity"),
+                    ("active", "=", False),
+                ]
+            )
 
     def log_call(self):
         """Prepare crm.phonecall creation."""

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -66,16 +66,14 @@ class Partner(models.Model):
     def _compute_opportunity_count(self):
         super()._compute_opportunity_count()
         for partner in self:
-            if not isinstance(partner.id, int):
-                continue
-            operator = "child_of" if partner.is_company else "="
-            partner.opportunity_count += self.env["crm.lead"].search_count(
-                [
-                    ("partner_id", operator, partner.id),
-                    ("type", "=", "opportunity"),
-                    ("active", "=", False),
-                ]
-            )
+                operator = "child_of" if partner.is_company else "="
+                partner.opportunity_count += self.env["crm.lead"].search_count(
+                    [
+                        ("partner_id", operator, partner.ids[0]),
+                        ("type", "=", "opportunity"),
+                        ("active", "=", False),
+                    ]
+                )
 
     def log_call(self):
         """Prepare crm.phonecall creation."""

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -67,6 +67,7 @@ class Partner(models.Model):
         super()._compute_opportunity_count()
         for partner in self:
             operator = "child_of" if partner.is_company else "="
+            # we use partner.ids[0] because when editing a church's name the id becomes temporarily a NewId and so an error is produced as the method uses child_of with a NewId and not the original id
             partner.opportunity_count += self.env["crm.lead"].search_count(
                 [
                     ("partner_id", operator, partner.ids[0]),

--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -66,6 +66,8 @@ class Partner(models.Model):
     def _compute_opportunity_count(self):
         super()._compute_opportunity_count()
         for partner in self:
+            if not isinstance(partner.id, int):
+                continue
             operator = "child_of" if partner.is_company else "="
             partner.opportunity_count += self.env["crm.lead"].search_count(
                 [


### PR DESCRIPTION
The issue occurred when editing the name of certain Church records the def _compute_opportunity_count would run while some of the associated partner records still had temporary Odoo IDs (-> NewId_xxxx), which are strings rather than integers. This caused a type mismatch during the domain search, resulting in an error. The root cause is timing-related the compute method was being triggered before the record was fully saved.

To fix this, I added a condition to skip any partner with a non-integer ID. This ensures only fully saved records are processed, avoiding the error.