### PR TITLE
T2415-Fix bug automatic stage change to resolve when schedule activity is done

### DIFF
--- a/crm_request/models/request.py
+++ b/crm_request/models/request.py
@@ -223,7 +223,7 @@ class CrmClaim(models.Model):
         to the supporter but not if it's an automatic answer.
         """
         result = super().message_post(**kwargs)
-        if "mail_server_id" in kwargs and not self.env.context.get("keep_stage"):
+        if "mail_server_id" in kwargs and kwargs.get("message_type") == "comment":
             resolved_stage = self.env.ref("crm_claim.stage_claim2")
             self.write({"stage_id": resolved_stage.id})
         return result


### PR DESCRIPTION
I simply changed the condition in CrmClaim.message_post() to change the stage to Resolve if and only if the employee answer to the supporter and not anymore when clicking on Mark as Done button.