### PR TITLE
T2257 FIX gifts problem: sometimes, the name & address of sponsor appears in "instructions"

### DIFF
--- a/gift_compassion/models/sponsorship_gift.py
+++ b/gift_compassion/models/sponsorship_gift.py
@@ -456,7 +456,6 @@ class SponsorshipGift(models.Model):
                 {
                     "sponsorship_id": sponsorship.id,
                     "invoice_line_ids": [(4, invoice_line.id)],
-                    "instructions": invoice_line.move_id.narration,
                 }
             )
 


### PR DESCRIPTION
In this PR, I remove the line `"instructions": invoice_line.move_id.narration` from `get_gift_values_from_product`
The field narration of `invoice_line.move_id` may contain the name and the address. There's few cases where it would contain relevant information.

(More details about what I've found on Odoo)