### PR TITLE
T2332 FIX Payment Reminder 2 & 3 generated at the same time

### DIFF
--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -43,10 +43,7 @@ class RecurringContract(models.Model):
     def create_reminder_communication(self):
         """Creation of the reminder for active and waiting contracts"""
         _logger.info("Creating Sponsorship Reminders")
-        # Change today() for debugging purposes
-        # today = datetime.now()
-        # set today to 1st october 2023 for testing
-        today = datetime(2024, 11, 15)
+        today = datetime.now()
         first_day_of_month = today.replace(day=1)
         reminder_confs = self.env["partner.communication.config"]
         for i in range(1, 4):

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -103,7 +103,7 @@ class RecurringContract(models.Model):
                     # create a 3rd reminder.
                     eligible_reminders["third"] += sponsorship
                 else:
-                    # Create 2nd reminder iff not already send
+                    # Create 2nd reminder if not already send
                     has_second_reminder = partnerCommunicationJob.search_count(
                         reminder_search
                         + [

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -43,7 +43,10 @@ class RecurringContract(models.Model):
     def create_reminder_communication(self):
         """Creation of the reminder for active and waiting contracts"""
         _logger.info("Creating Sponsorship Reminders")
-        today = datetime.now()
+        # Change today() for debugging purposes
+        # today = datetime.now()
+        # set today to 1st october 2023 for testing
+        today = datetime(2024, 11, 15)
         first_day_of_month = today.replace(day=1)
         reminder_confs = self.env["partner.communication.config"]
         for i in range(1, 4):
@@ -93,6 +96,7 @@ class RecurringContract(models.Model):
 
             first_reminders = reminders_by_config[reminder_confs[0].id]
             second_reminders = reminders_by_config[reminder_confs[1].id]
+            third_reminders = reminders_by_config[reminder_confs[2].id]
 
             # Look if first reminder was sent previous month
             old_first = any(r.sent_date < twenty_days_ago for r in first_reminders)
@@ -102,14 +106,14 @@ class RecurringContract(models.Model):
 
                 if old_second:
                     # The 2nd reminder has been sent at least 20 days ago, then
-                    # we can send the 3rd.
-                    eligible_reminders["third"] += sponsorship
+                    # we can send the 3rd if it wasn't already sent.
+                    if not third_reminders:
+                        eligible_reminders["third"] += sponsorship
                 elif not recent_second:
                     eligible_reminders["second"] += sponsorship
                 # If recent 2nd reminder, do nothing
 
-            else:
-                if not first_reminders or all(r.sent_date < twenty_days_ago for r in first_reminders):
+            elif not first_reminders or all(r.sent_date < twenty_days_ago for r in first_reminders):
                     eligible_reminders["first"] += sponsorship
                 # If recent 1st reminder, do nothing
 

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -99,8 +99,20 @@ class RecurringContract(models.Model):
                     ]
                 )
                 if has_second_reminder:
+                    # If the 2nd reminder have been sent more than 20 days ago,
+                    # create a 3rd reminder.
                     eligible_reminders["third"] += sponsorship
-                eligible_reminders["second"] += sponsorship
+                else:
+                    # Create 2nd reminder iff not already send
+                    has_second_reminder = partnerCommunicationJob.search_count(
+                        reminder_search
+                        + [
+                            ("sent_date", ">=", twenty_days_ago),
+                            ("config_id", "=", reminder_confs[1].id),
+                        ]
+                    )
+                    if not has_second_reminder:
+                        eligible_reminders["second"] += sponsorship
             else:
                 # Create first reminder only if one was not already created less
                 # than twenty days ago

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -72,55 +72,50 @@ class RecurringContract(models.Model):
                 ("state", "=", "done"),
                 ("object_ids", "like", str(sponsorship.id)),
             ]
-            # Look if first reminder was sent previous month (send second
-            # reminder in that case)
-            # avoid taking into account reminder that the partner already took care of
-            # we substract month due to the first of the month to get the older
-            # threshold
+
+
+            # To avoid taking into account reminder that the partner already took care of
+            # we subtract month due to the first of the month to get the older threshold
             # this also prevent reminder_1 to be sent after an already sent reminder_2
             older_threshold = first_day_of_month - relativedelta(
                 months=sponsorship.months_due
             )
 
-            has_first_reminder = partnerCommunicationJob.search_count(
-                reminder_search
-                + [
-                    ("sent_date", ">=", older_threshold),
-                    ("sent_date", "<", twenty_days_ago),
-                ]
+            # Search for every reminder more recent than older_threshold
+            reminders = partnerCommunicationJob.search(
+                reminder_search + [("sent_date", ">=", older_threshold)]
             )
-            if has_first_reminder:
-                has_second_reminder = partnerCommunicationJob.search_count(
-                    reminder_search
-                    + [
-                        ("sent_date", ">=", older_threshold),
-                        ("sent_date", "<", twenty_days_ago),
-                        ("config_id", "=", reminder_confs[1].id),
-                    ]
-                )
-                if has_second_reminder:
-                    # If the 2nd reminder have been sent more than 20 days ago,
-                    # create a 3rd reminder.
+
+            # Classify the reminders by id
+            reminders_by_config = {conf.id: [] for conf in reminder_confs}
+            for r in reminders:
+                if r.config_id.id in reminders_by_config:
+                    reminders_by_config[r.config_id.id].append(r)
+
+            first_reminders = reminders_by_config[reminder_confs[0].id]
+            second_reminders = reminders_by_config[reminder_confs[1].id]
+
+            old_first = any(r.sent_date < twenty_days_ago for r in first_reminders)
+
+            # Look if first reminder was sent previous month (send second
+            # reminder in that case).
+            if old_first:
+                old_second = any(r.sent_date < twenty_days_ago for r in second_reminders)
+                recent_second = any(r.sent_date >= twenty_days_ago for r in second_reminders)
+
+                if old_second:
+                    # The 2nd reminder has been sent at least 20 days ago, then
+                    # we can send the 3rd.
                     eligible_reminders["third"] += sponsorship
-                else:
-                    # Create 2nd reminder if not already send
-                    has_second_reminder = partnerCommunicationJob.search_count(
-                        reminder_search
-                        + [
-                            ("sent_date", ">=", twenty_days_ago),
-                            ("config_id", "=", reminder_confs[1].id),
-                        ]
-                    )
-                    if not has_second_reminder:
-                        eligible_reminders["second"] += sponsorship
+                elif not recent_second:
+                    eligible_reminders["second"] += sponsorship
+                # If recent 2nd reminder, do nothing
+
             else:
-                # Create first reminder only if one was not already created less
-                # than twenty days ago
-                has_first_reminder = partnerCommunicationJob.search_count(
-                    reminder_search + [("sent_date", ">=", twenty_days_ago)]
-                )
-                if not has_first_reminder:
+                if not first_reminders or all(r.sent_date < twenty_days_ago for r in first_reminders):
                     eligible_reminders["first"] += sponsorship
+                # If recent 1st reminder, do nothing
+
 
         for key, config in zip(["first", "second", "third"], reminder_confs):
             sponsorships = eligible_reminders[key]

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -86,19 +86,16 @@ class RecurringContract(models.Model):
                 reminder_search + [("sent_date", ">=", older_threshold)]
             )
 
-            # Classify the reminders by id
+            # Group reminders by configuration ID
             reminders_by_config = {conf.id: [] for conf in reminder_confs}
-            for r in reminders:
-                if r.config_id.id in reminders_by_config:
-                    reminders_by_config[r.config_id.id].append(r)
+            for reminder in reminders:
+                reminders_by_config.get(reminder.config_id.id, []).append(reminder)
 
             first_reminders = reminders_by_config[reminder_confs[0].id]
             second_reminders = reminders_by_config[reminder_confs[1].id]
 
+            # Look if first reminder was sent previous month
             old_first = any(r.sent_date < twenty_days_ago for r in first_reminders)
-
-            # Look if first reminder was sent previous month (send second
-            # reminder in that case).
             if old_first:
                 old_second = any(r.sent_date < twenty_days_ago for r in second_reminders)
                 recent_second = any(r.sent_date >= twenty_days_ago for r in second_reminders)
@@ -115,7 +112,6 @@ class RecurringContract(models.Model):
                 if not first_reminders or all(r.sent_date < twenty_days_ago for r in first_reminders):
                     eligible_reminders["first"] += sponsorship
                 # If recent 1st reminder, do nothing
-
 
         for key, config in zip(["first", "second", "third"], reminder_confs):
             sponsorships = eligible_reminders[key]

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -76,10 +76,10 @@ class RecurringContract(models.Model):
                 ("object_ids", "like", str(sponsorship.id)),
             ]
 
-
-            # To avoid taking into account reminder that the partner already took care of
-            # we subtract month due to the first of the month to get the older threshold
-            # this also prevent reminder_1 to be sent after an already sent reminder_2
+            # To avoid taking into account reminder that the partner already took care
+            # of we subtract month due to the first of the month to get the older
+            # threshold. This also prevent reminder_1 to be sent after an already sent
+            # reminder_2
             older_threshold = first_day_of_month - relativedelta(
                 months=sponsorship.months_due
             )
@@ -101,8 +101,12 @@ class RecurringContract(models.Model):
             # Look if first reminder was sent previous month
             old_first = any(r.sent_date < twenty_days_ago for r in first_reminders)
             if old_first:
-                old_second = any(r.sent_date < twenty_days_ago for r in second_reminders)
-                recent_second = any(r.sent_date >= twenty_days_ago for r in second_reminders)
+                old_second = any(
+                    r.sent_date < twenty_days_ago for r in second_reminders
+                )
+                recent_second = any(
+                    r.sent_date >= twenty_days_ago for r in second_reminders
+                )
 
                 if old_second:
                     # The 2nd reminder has been sent at least 20 days ago, then
@@ -113,9 +117,11 @@ class RecurringContract(models.Model):
                     eligible_reminders["second"] += sponsorship
                 # If recent 2nd reminder, do nothing
 
-            elif not first_reminders or all(r.sent_date < twenty_days_ago for r in first_reminders):
-                    eligible_reminders["first"] += sponsorship
-                # If recent 1st reminder, do nothing
+            elif not first_reminders or all(
+                r.sent_date < twenty_days_ago for r in first_reminders
+            ):
+                eligible_reminders["first"] += sponsorship
+            # If recent 1st reminder, do nothing
 
         for key, config in zip(["first", "second", "third"], reminder_confs):
             sponsorships = eligible_reminders[key]


### PR DESCRIPTION
To fix the issue, I extended the logic used to handle the 1st reminder for the 2nd and 3rd reminder.
In more details:

In the original code, we had this :
```python
if has_first_reminder:
                has_second_reminder = partnerCommunicationJob.search_count(
                    reminder_search
                    + [
                        ("sent_date", ">=", older_threshold),
                        ("sent_date", "<", twenty_days_ago),
                        ("config_id", "=", reminder_confs[1].id),
                    ]
                )
                if has_second_reminder:
                    eligible_reminders["third"] += sponsorship
                eligible_reminders["second"] += sponsorship
 ```

This seems incorrect to me. The `if has_second_reminder:` clause is true iff a 2nd reminder have been sent more than 20 days ago. So if it  has been sent 10 days ago, we would simply send it again. Moreover, when creating the 3rd reminder, we also create a 2nd reminder every time due to the lack of `else` clause.

I have not find a way to test the create_reminder_communication method properly. What I have done is only based on code observation. 