### PR TITLE
T2624   make the letter creation progress bar show real checkpoints

### DIFF
--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -80,6 +80,22 @@ class CorrespondenceS2bGenerator(models.Model):
     preview_pdf = fields.Binary(readonly=True)
     filename = fields.Char(compute="_compute_filename")
     month = fields.Selection("_get_months")
+    generation_status = fields.Selection(
+        [
+            ("creating_task", "creating_task"),
+            ("apply_template", "apply_template"),
+            ("apply_text", "apply_text"),
+            ("apply_images", "apply_images"),
+            ("generate_pdf", "generate_pdf"),
+            ("done", "done"),
+            ("failed", "failed"),
+            ("finalizing", "finalizing"),
+        ],
+        default="creating_task",
+        string="Generation Status",
+    )
+    generation_error_message = fields.Text(string="Generation Message")
+    MAX_PAGE_COUNT = 15  # Maximum number of pages allowed in a letter
 
     def _compute_nb_letters(self):
         for generator in self:
@@ -128,9 +144,9 @@ class CorrespondenceS2bGenerator(models.Model):
                 domain.append(month_select)
             self.selection_domain = str(domain)
 
-    def preview(self):
+    def preview(self, **callbacks):
         """Generate a picture for preview."""
-        pdf = self._get_pdf(self.sponsorship_ids[:1])[0]
+        pdf = self._get_pdf(self.sponsorship_ids[:1], **callbacks)[0]
         if self.template_id.layout == "CH-A-3S01-1":
             # Read page 2
             in_pdf = PdfFileReader(BytesIO(pdf))
@@ -140,6 +156,14 @@ class CorrespondenceS2bGenerator(models.Model):
             output_pdf.write(out_data)
             out_data.seek(0)
             pdf = out_data.read()
+        # Check the number of pages
+        n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
+        if n_pages > self.MAX_PAGE_COUNT:
+            msg = _("Oops your letter has %d pages. The limit is %d") % (
+                n_pages,
+                self.MAX_PAGE_COUNT,
+            )
+            callbacks.get("failure_callback", lambda: None)(err_msg=msg)
 
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:
@@ -265,7 +289,7 @@ class CorrespondenceS2bGenerator(models.Model):
 
         return text
 
-    def _get_pdf(self, sponsorship):
+    def _get_pdf(self, sponsorship, **callbacks):
         """Generates a PDF given a sponsorship."""
         self.ensure_one()
         sponsor = sponsorship.correspondent_id
@@ -285,6 +309,7 @@ class CorrespondenceS2bGenerator(models.Model):
                 (header, ""),  # Headers (front/back)
                 {"Original": [text]},  # Text
                 self.mapped("image_ids").sorted(reverse=True).mapped("datas"),  # Images
+                **callbacks,
             ),
             text,
         )

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -337,4 +337,5 @@ class CorrespondenceS2bGenerator(models.Model):
             new_env = self.env(cr=new_cr)
             new_s2b_generator = new_env[self._name].browse(self.id)
             new_s2b_generator.generation_status = status
+            new_cr.commit()
         return True

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from wand.exceptions import PolicyError
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError,UserError
+from odoo.exceptions import UserError, ValidationError
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -160,7 +160,8 @@ class CorrespondenceS2bGenerator(models.Model):
         if n_pages > self.MAX_PAGE_COUNT:
             msg = _("Oops your letter has %d pages. The limit is %d.") % (
                 n_pages,
-                self.MAX_PAGE_COUNT)
+                self.MAX_PAGE_COUNT,
+            )
 
             raise UserError(msg)
 

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -165,6 +165,15 @@ class CorrespondenceS2bGenerator(models.Model):
             )
             callbacks.get("failure_callback", lambda: None)(err_msg=msg)
 
+        # Check the number of pages
+        n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
+        if n_pages > self.MAX_PAGE_COUNT:
+            msg = _("Oops your letter has %d pages. The limit is %d.") % (
+                n_pages,
+                self.MAX_PAGE_COUNT,
+            )
+            raise UserError(msg)
+
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from wand.exceptions import PolicyError
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -144,71 +144,59 @@ class CorrespondenceS2bGenerator(models.Model):
                 domain.append(month_select)
             self.selection_domain = str(domain)
 
-    def preview(self, s2b_generator = None):
+    def preview(self):
         """Generate a picture for preview."""
-        pdf = self._get_pdf(self.sponsorship_ids[:1], s2b_generator = s2b_generator)[0]
+        pdf = self._get_pdf(self.sponsorship_ids[:1])[0]
+
         if self.template_id.layout == "CH-A-3S01-1":
-            # Read page 2
             in_pdf = PdfFileReader(BytesIO(pdf))
             output_pdf = PdfFileWriter()
-            out_data = BytesIO()
             output_pdf.addPage(in_pdf.getPage(1))
+            out_data = BytesIO()
             output_pdf.write(out_data)
-            out_data.seek(0)
-            pdf = out_data.read()
-        # Check the number of pages
+            pdf = out_data.getvalue()
+
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
         if n_pages > self.MAX_PAGE_COUNT:
-            error_message = _("Oops your letter has %d pages. The limit is %d") % (
-                n_pages,
-                self.MAX_PAGE_COUNT,
+            return self.write(
+                {
+                    "generation_status": "failed",
+                    "generation_error_message": _(
+                        "Oops your letter has %d pages. The limit is %d"
+                    )
+                    % (n_pages, self.MAX_PAGE_COUNT),
+                }
             )
-            if s2b_generator:
-                s2b_generator.generation_status = "failed"
-                s2b_generator.generation_status = error_message
-                s2b_generator.env.cr.commit()
-
-
-        # Check the number of pages
-        n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
-        if n_pages > self.MAX_PAGE_COUNT:
-            msg = _("Oops your letter has %d pages. The limit is %d.") % (
-                n_pages,
-                self.MAX_PAGE_COUNT,
-            )
-            raise UserError(msg)
 
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
-        except PolicyError as error:
-            _logger.error(
-                "ImageMagick policy error. Please add following line to "
-                "/etc/Image-Magick-<version>/policy.xml: "
-                '<policy domain="coder" rights="read|write" '
-                'pattern="PDF" />',
-            )
-            raise UserError(
+        except (PolicyError, TypeError) as error:
+            error_message = (
                 _(
-                    "Please allow ImageMagick to write PDF files."
-                    " Ask an IT admin for help."
+                    "Please allow ImageMagick to write PDF files. "
+                    "Ask an IT admin for help."
                 )
-            ) from error
-        except TypeError as error:
-            raise UserError(
-                _(
+                if isinstance(error, PolicyError)
+                else _(
                     "There was an error while generating the PDF of the letter. "
                     "Please check FPDF logs for more information."
                 )
-            ) from error
-
-        pdf_image = base64.b64encode(pdf)
+            )
+            return self.write(
+                {
+                    "generation_status": "failed",
+                    "generation_error_message": error_message,
+                }
+            )
 
         return self.write(
             {
                 "state": "preview",
+                "generation_status": "done",
+                "generation_error_message": False,
                 "preview_image": preview,
-                "preview_pdf": pdf_image,
+                "preview_pdf": base64.b64encode(pdf),
             }
         )
 
@@ -221,6 +209,7 @@ class CorrespondenceS2bGenerator(models.Model):
         Launch S2B Creation job
         :return: True
         """
+        self.generation_status = "finalizing"
         self.with_delay(
             identity_key="s2b_generator." + str(self.ids)
         ).generate_letters_job()
@@ -264,11 +253,24 @@ class CorrespondenceS2bGenerator(models.Model):
             # If the operation succeeds, notify the user
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
-            return self.write({"state": "done", "date": fields.Datetime.now()})
+            return self.write(
+                {
+                    "state": "done",
+                    "date": fields.Datetime.now(),
+                    "generation_status": "done",
+                    "generation_error_message": False,
+                }
+            )
 
         except Exception as error:
             # If the operation fails, notify the user with the error message
             error_message = str(error)
+            self.write(
+                {
+                    "generation_status": "failed",
+                    "generation_error_message": error_message,
+                }
+            )
             self.env.user.notify_danger(message=error_message)
 
         return True
@@ -302,7 +304,7 @@ class CorrespondenceS2bGenerator(models.Model):
 
         return text
 
-    def _get_pdf(self, sponsorship, s2b_generator = None):
+    def _get_pdf(self, sponsorship):
         """Generates a PDF given a sponsorship."""
         self.ensure_one()
         sponsor = sponsorship.correspondent_id
@@ -322,7 +324,17 @@ class CorrespondenceS2bGenerator(models.Model):
                 (header, ""),  # Headers (front/back)
                 {"Original": [text]},  # Text
                 self.mapped("image_ids").sorted(reverse=True).mapped("datas"),  # Images
-                s2b_generator = s2b_generator
+                s2b_generator=self,
             ),
             text,
         )
+
+    def update_generation_status(self, status):
+        """Use a separate transaction to update the status of the generation."""
+        if len(self) != 1:
+            return False
+        with self.env.registry.cursor() as new_cr:
+            new_env = self.env(cr=new_cr)
+            new_s2b_generator = new_env[self._name].browse(self.id)
+            new_s2b_generator.generation_status = status
+        return True

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -144,9 +144,9 @@ class CorrespondenceS2bGenerator(models.Model):
                 domain.append(month_select)
             self.selection_domain = str(domain)
 
-    def preview(self, **callbacks):
+    def preview(self, s2b_generator = None):
         """Generate a picture for preview."""
-        pdf = self._get_pdf(self.sponsorship_ids[:1], **callbacks)[0]
+        pdf = self._get_pdf(self.sponsorship_ids[:1], s2b_generator = s2b_generator)[0]
         if self.template_id.layout == "CH-A-3S01-1":
             # Read page 2
             in_pdf = PdfFileReader(BytesIO(pdf))
@@ -159,11 +159,15 @@ class CorrespondenceS2bGenerator(models.Model):
         # Check the number of pages
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
         if n_pages > self.MAX_PAGE_COUNT:
-            msg = _("Oops your letter has %d pages. The limit is %d") % (
+            error_message = _("Oops your letter has %d pages. The limit is %d") % (
                 n_pages,
                 self.MAX_PAGE_COUNT,
             )
-            callbacks.get("failure_callback", lambda: None)(err_msg=msg)
+            if s2b_generator:
+                s2b_generator.generation_status = "failed"
+                s2b_generator.generation_status = error_message
+                s2b_generator.env.cr.commit()
+
 
         # Check the number of pages
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
@@ -298,7 +302,7 @@ class CorrespondenceS2bGenerator(models.Model):
 
         return text
 
-    def _get_pdf(self, sponsorship, **callbacks):
+    def _get_pdf(self, sponsorship, s2b_generator = None):
         """Generates a PDF given a sponsorship."""
         self.ensure_one()
         sponsor = sponsorship.correspondent_id
@@ -318,7 +322,7 @@ class CorrespondenceS2bGenerator(models.Model):
                 (header, ""),  # Headers (front/back)
                 {"Original": [text]},  # Text
                 self.mapped("image_ids").sorted(reverse=True).mapped("datas"),  # Images
-                **callbacks,
+                s2b_generator = s2b_generator
             ),
             text,
         )

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -14,7 +14,7 @@ from io import BytesIO
 from wand.exceptions import PolicyError
 
 from odoo import _, api, fields, models
-from odoo.exceptions import ValidationError
+from odoo.exceptions import ValidationError,UserError
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -158,15 +158,11 @@ class CorrespondenceS2bGenerator(models.Model):
 
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
         if n_pages > self.MAX_PAGE_COUNT:
-            return self.write(
-                {
-                    "generation_status": "failed",
-                    "generation_error_message": _(
-                        "Oops your letter has %d pages. The limit is %d"
-                    )
-                    % (n_pages, self.MAX_PAGE_COUNT),
-                }
-            )
+            msg = _("Oops your letter has %d pages. The limit is %d.") % (
+                n_pages,
+                self.MAX_PAGE_COUNT)
+
+            raise UserError(msg)
 
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:
@@ -329,7 +325,7 @@ class CorrespondenceS2bGenerator(models.Model):
             text,
         )
 
-    def update_generation_status(self, status):
+    def update_generation_status(self, status, generation_error_message=None):
         """Use a separate transaction to update the status of the generation."""
         if len(self) != 1:
             return False
@@ -337,5 +333,7 @@ class CorrespondenceS2bGenerator(models.Model):
             new_env = self.env(cr=new_cr)
             new_s2b_generator = new_env[self._name].browse(self.id)
             new_s2b_generator.generation_status = status
+            if generation_error_message:
+                new_s2b_generator.generation_error_message = generation_error_message
             new_cr.commit()
         return True

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -112,7 +112,9 @@ class CorrespondenceTemplate(models.Model):
     ##########################################################################
     #                             PUBLIC METHODS                             #
     ##########################################################################
-    def generate_pdf(self, pdf_name, header, text, image_data, background_list=None):
+    def generate_pdf(
+        self, pdf_name, header, text, image_data, background_list=None, **callbacks
+    ):
         """
         Generate a pdf file
         This function is nearly as generic as it should be to be implemented
@@ -144,6 +146,8 @@ class CorrespondenceTemplate(models.Model):
             pages, header, background_list, temp_img
         )
         image_list = []
+
+        callbacks.get("apply_template_callback", lambda: None)()
 
         if background_list:
             # An original document is provided. We want
@@ -181,6 +185,7 @@ class CorrespondenceTemplate(models.Model):
                 text_list.append(text_box.get_json_repr())
             overflow_template = [add_background.name, header_data, text_list, []]
 
+        callbacks.get("apply_text_callback", lambda: None)()
         text_list = []
         for t_type, t_boxes in list(text.items()):
             for txt in t_boxes:
@@ -191,6 +196,8 @@ class CorrespondenceTemplate(models.Model):
                 txt_file.flush()
                 temp_img.append(txt_file)
                 text_list.append([txt_file.name, t_type])
+
+        callbacks.get("apply_img_callback", lambda: None)()
 
         for image in image_data:
             ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
@@ -214,6 +221,8 @@ class CorrespondenceTemplate(models.Model):
 
         std_err_file_path = self.path_to("stderr.txt")
         std_err_file = open(std_err_file_path, "w", encoding="utf-8")
+
+        callbacks.get("generating_pdf_callback", lambda: None)()
 
         php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
         if config.get("php_debug"):

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -113,7 +113,7 @@ class CorrespondenceTemplate(models.Model):
     #                             PUBLIC METHODS                             #
     ##########################################################################
     def generate_pdf(
-        self, pdf_name, header, text, image_data, background_list=None, **callbacks
+        self, pdf_name, header, text, image_data, background_list=None,s2b_generator = None
     ):
         """
         Generate a pdf file
@@ -147,7 +147,13 @@ class CorrespondenceTemplate(models.Model):
         )
         image_list = []
 
-        callbacks.get("apply_template_callback", lambda: None)()
+
+        if s2b_generator:
+            s2b_generator.generation_status = "apply_template"
+            s2b_generator.env.cr.commit()
+
+
+
 
         if background_list:
             # An original document is provided. We want
@@ -185,7 +191,11 @@ class CorrespondenceTemplate(models.Model):
                 text_list.append(text_box.get_json_repr())
             overflow_template = [add_background.name, header_data, text_list, []]
 
-        callbacks.get("apply_text_callback", lambda: None)()
+        if s2b_generator:
+            s2b_generator.generation_status = "apply_text"
+            s2b_generator.env.cr.commit()
+
+
         text_list = []
         for t_type, t_boxes in list(text.items()):
             for txt in t_boxes:
@@ -197,7 +207,10 @@ class CorrespondenceTemplate(models.Model):
                 temp_img.append(txt_file)
                 text_list.append([txt_file.name, t_type])
 
-        callbacks.get("apply_img_callback", lambda: None)()
+        if s2b_generator:
+            s2b_generator.generation_status = "apply_images"
+            s2b_generator.env.cr.commit()
+
 
         for image in image_data:
             ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
@@ -222,7 +235,10 @@ class CorrespondenceTemplate(models.Model):
         std_err_file_path = self.path_to("stderr.txt")
         std_err_file = open(std_err_file_path, "w", encoding="utf-8")
 
-        callbacks.get("generating_pdf_callback", lambda: None)()
+        if s2b_generator:
+            s2b_generator.generation_status = "generate_pdf"
+            s2b_generator.env.cr.commit()
+
 
         php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
         if config.get("php_debug"):

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -112,8 +112,15 @@ class CorrespondenceTemplate(models.Model):
     ##########################################################################
     #                             PUBLIC METHODS                             #
     ##########################################################################
+    # ruff: noqa: C901 (Yes this function is complex... it will be removed in v17)
     def generate_pdf(
-        self, pdf_name, header, text, image_data, background_list=None,s2b_generator = None
+        self,
+        pdf_name,
+        header,
+        text,
+        image_data,
+        background_list=None,
+        s2b_generator=None,
     ):
         """
         Generate a pdf file
@@ -121,6 +128,8 @@ class CorrespondenceTemplate(models.Model):
         directly to generate PDF for any template, text and image
         We save every text to a temp txt file to avoid having to escape all
         characters that could potentially be problematic
+        :param s2b_generator: <optional> a s2b.generator record to update
+                              the generation status
         :param pdf_name: path and name of the pdf file to write on
         :param header: tuple of text for the headers to display
                        (first value is for front pages, second for back pages)
@@ -132,152 +141,170 @@ class CorrespondenceTemplate(models.Model):
                                 the template.
         """
         self.ensure_one()
+        if s2b_generator is None:
+            s2b_generator = self.env["correspondence.s2b.generator"]
 
-        # Images stored on disk for FPDF processing. We keep them in these lists
-        # to make sure we properly remove the files at the end of the process.
-        temp_img = []
+        # Keep file objects alive to prevent auto-deletion
+        temp_files = []
+        std_err_file = None
+        pdf_file = None
 
-        if background_list is None:
-            background_list = []
-        overflow_template = False
-
-        pages = self.mapped("page_ids") - self.additional_page_id
-        template_list, header_data, image_boxes = self._generate_template_list(
-            pages, header, background_list, temp_img
-        )
-        image_list = []
-
-
-        if s2b_generator:
-            s2b_generator.generation_status = "apply_template"
-            s2b_generator.env.cr.commit()
-
-
-
-
-        if background_list:
-            # An original document is provided. We want
-            # to complete the PDF document with the remaining pages
-            # and provide an overflow template in case the text is longer
-            # and we should add pages for additional translation.
-            if len(background_list) > len(pages):
-                for i in range(len(pages), len(background_list)):
-                    bf = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
-                    bf.write(base64.b64decode(background_list[i]))
-                    bf.flush()
-                    temp_img.append(bf)
-                    template_list.append([bf.name, [], [], []])
-            additional_page = self.env.ref("sbc_compassion.b2s_additional_page")
-            bf_name = False
-            if additional_page.background:
-                bf = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
-                bf.write(base64.b64decode(additional_page.background))
-                bf.flush()
-                bf_name = bf.name
-                temp_img.append(bf)
-            text_list = []
-            for text_box in additional_page.text_box_ids:
-                text_list.append(text_box.get_json_repr())
-            overflow_template = [bf_name, [], text_list, image_boxes]
-        elif self.additional_page_id:
-            # We are generating a new PDF (S2B case). We provide
-            # an overflow template using the template
-            add_background = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
-            add_background.write(base64.b64decode(self.additional_page_id.background))
-            add_background.flush()
-            temp_img.append(add_background)
-            text_list = []
-            for text_box in self.additional_page_id.text_box_ids:
-                text_list.append(text_box.get_json_repr())
-            overflow_template = [add_background.name, header_data, text_list, []]
-
-        if s2b_generator:
-            s2b_generator.generation_status = "apply_text"
-            s2b_generator.env.cr.commit()
-
-
-        text_list = []
-        for t_type, t_boxes in list(text.items()):
-            for txt in t_boxes:
-                txt_file = tempfile.NamedTemporaryFile(
-                    "w", prefix=t_type + "_", suffix=".txt", encoding="utf-8"
-                )
-                txt_file.write(txt)
-                txt_file.flush()
-                temp_img.append(txt_file)
-                text_list.append([txt_file.name, t_type])
-
-        if s2b_generator:
-            s2b_generator.generation_status = "apply_images"
-            s2b_generator.env.cr.commit()
-
-
-        for image in image_data:
-            ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
-            ifile.write(base64.b64decode(image))
-            ifile.flush()
-            image_list.append(ifile.name)
-            temp_img.append(ifile)
-
-        generated_json = {
-            "images": image_list,
-            "templates": template_list,
-            "texts": text_list,
-            # The output should at least contain 2 pages
-            "original_size": max(2, len(background_list)),
-            "overflow_template": overflow_template,
-            "lang": self.env.lang,
-            "prevent_overflow": self.type == "b2s",
-        }
-
-        json_val = json.dumps(generated_json).replace(" ", "")
-
-        std_err_file_path = self.path_to("stderr.txt")
-        std_err_file = open(std_err_file_path, "w", encoding="utf-8")
-
-        if s2b_generator:
-            s2b_generator.generation_status = "generate_pdf"
-            s2b_generator.env.cr.commit()
-
-
-        php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
-        if config.get("php_debug"):
-            # Allow php debugging with Xend
-            os.environ["XDEBUG_CONFIG"] = "PHPSTORM"
-            php_command_args.extend(
-                [
-                    "-dxdebug.remote_enable=1",
-                    "-dxdebug.remote_mode=req",
-                    "-dxdebug.remote_port=9000",
-                    "-dxdebug.remote_host=127.0.0.1",
-                ]
-            )
-        proc = subprocess.Popen(php_command_args, stderr=std_err_file)
-        proc.communicate()
-
-        if proc.returncode != 0:
-            with open(std_err_file_path, "r", encoding="utf-8") as stderr:
-                _logger.error(
-                    "FPDF returned nonzero exit code %d. stderr:\n%s",
-                    proc.returncode,
-                    stderr.read(),
-                )
-
-        # Clean temp files
-        for img in temp_img:
-            img.close()
-        std_err_file.close()
-
-        # Read and return output
         try:
+            if background_list is None:
+                background_list = []
+            overflow_template = False
+
+            pages = self.mapped("page_ids") - self.additional_page_id
+            template_list, header_data, image_boxes = self._generate_template_list(
+                pages, header, background_list, temp_files
+            )
+            image_list = []
+
+            s2b_generator.update_generation_status("apply_template")
+
+            if background_list:
+                # An original document is provided. We want
+                # to complete the PDF document with the remaining pages
+                # and provide an overflow template in case the text is longer
+                # and we should add pages for additional translation.
+                if len(background_list) > len(pages):
+                    for i in range(len(pages), len(background_list)):
+                        bf = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
+                        bf.write(base64.b64decode(background_list[i]))
+                        bf.flush()
+                        temp_files.append(bf)
+                        template_list.append([bf.name, [], [], []])
+                additional_page = self.env.ref("sbc_compassion.b2s_additional_page")
+                bf_name = False
+                if additional_page.background:
+                    bf = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
+                    bf.write(base64.b64decode(additional_page.background))
+                    bf.flush()
+                    bf_name = bf.name
+                    temp_files.append(bf)
+                text_list = []
+                for text_box in additional_page.text_box_ids:
+                    text_list.append(text_box.get_json_repr())
+                overflow_template = [bf_name, [], text_list, image_boxes]
+            elif self.additional_page_id:
+                # We are generating a new PDF (S2B case). We provide
+                # an overflow template using the template
+                add_background = tempfile.NamedTemporaryFile(
+                    prefix="img_", suffix=".jpg"
+                )
+                add_background.write(
+                    base64.b64decode(self.additional_page_id.background)
+                )
+                add_background.flush()
+                temp_files.append(add_background)
+                text_list = []
+                for text_box in self.additional_page_id.text_box_ids:
+                    text_list.append(text_box.get_json_repr())
+                overflow_template = [add_background.name, header_data, text_list, []]
+
+            s2b_generator.update_generation_status("apply_text")
+
+            text_list = []
+            for t_type, t_boxes in list(text.items()):
+                for txt in t_boxes:
+                    txt_file = tempfile.NamedTemporaryFile(
+                        "w", prefix=t_type + "_", suffix=".txt", encoding="utf-8"
+                    )
+                    txt_file.write(txt)
+                    txt_file.flush()
+                    temp_files.append(txt_file)
+                    text_list.append([txt_file.name, t_type])
+
+            s2b_generator.update_generation_status("apply_images")
+
+            for image in image_data:
+                ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
+                ifile.write(base64.b64decode(image))
+                ifile.flush()
+                image_list.append(ifile.name)
+                temp_files.append(ifile)
+
+            generated_json = {
+                "images": image_list,
+                "templates": template_list,
+                "texts": text_list,
+                # The output should at least contain 2 pages
+                "original_size": max(2, len(background_list)),
+                "overflow_template": overflow_template,
+                "lang": self.env.lang,
+                "prevent_overflow": self.type == "b2s",
+            }
+
+            json_val = json.dumps(generated_json).replace(" ", "")
+
+            std_err_file_path = self.path_to("stderr.txt")
+            std_err_file = open(std_err_file_path, "w", encoding="utf-8")
+
+            s2b_generator.update_generation_status("generate_pdf")
+
+            php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
+            if config.get("php_debug"):
+                # Allow php debugging with Xend
+                os.environ["XDEBUG_CONFIG"] = "PHPSTORM"
+                php_command_args.extend(
+                    [
+                        "-dxdebug.remote_enable=1",
+                        "-dxdebug.remote_mode=req",
+                        "-dxdebug.remote_port=9000",
+                        "-dxdebug.remote_host=127.0.0.1",
+                    ]
+                )
+            proc = subprocess.Popen(php_command_args, stderr=std_err_file)
+            proc.communicate()
+
+            if proc.returncode != 0:
+                with open(std_err_file_path, "r", encoding="utf-8") as stderr:
+                    _logger.error(
+                        "FPDF returned nonzero exit code %d. stderr:\n%s",
+                        proc.returncode,
+                        stderr.read(),
+                    )
+
+            # Read and return output
             pdf_file = open(pdf_name, "rb")
             res = pdf_file.read()
             pdf_file.close()
-            os.remove(pdf_file.name)
-        except FileNotFoundError:
-            _logger.error("Cannot read PDF made by FPDF.")
-            res = False
-        return res
+            pdf_file = None
+            os.remove(pdf_name)
+
+            return res
+
+        except Exception:
+            _logger.error("Cannot read PDF made by FPDF.", exc_info=True)
+            return False
+
+        finally:
+            # Clean up all temporary files (they will be auto-deleted when closed)
+            for temp_file in temp_files:
+                try:
+                    temp_file.close()
+                except Exception as e:
+                    _logger.warning("Failed to close temp file: %s", str(e))
+
+            # Clean up stderr file
+            if std_err_file:
+                try:
+                    std_err_file.close()
+                except Exception:
+                    pass
+                try:
+                    std_err_file_path = self.path_to("stderr.txt")
+                    if os.path.exists(std_err_file_path):
+                        os.remove(std_err_file_path)
+                except Exception as e:
+                    _logger.warning("Failed to clean up stderr file: %s", str(e))
+
+            # Clean up PDF file if still open
+            if pdf_file:
+                try:
+                    pdf_file.close()
+                except Exception:
+                    pass
 
     # path of the FPDF folder
     _absolute_path = os.path.join(


### PR DESCRIPTION
## :warning: Important note:
This PR, being used as basis for the following PR, should be merged first: 
https://github.com/CompassionCH/compassion-modules/pull/2051

This PR is currently linked to PR : https://github.com/CompassionCH/compassion-website/pull/163


## Summary
This PR is related to the PR : https://github.com/CompassionCH/compassion-website/pull/163 , being on another reposirtory.
The current PR adds more fields to the model `correspondence_s2b_generator` to describe the generation status of the letter. It also adds callback kwargs on some methods. 

## Modified files
### In this PR:
- `sbc_compassion/models/correspondence_s2b_generator.py` : Add callbacks keyword-arguments to methods  and add generation status field to the model. 
- `sbc_compassion/models/correspondence_template.py`: Add the callbacks and call them at checkpoints.

### In the related PR https://github.com/CompassionCH/compassion-website/pull/163
- `my_compassion/controllers/my2_letters.py`: Add routes to the controller to handle polling requests, define the callbacks to be called during the letter creation.
- `my_compassion/static/src/js/my2_new_letter.js`: Allow the client to poll the status of the creation and update the progress bar in consequence.
- `theme_compassion_2025/static/src/js/_progress_bar.js`: Complete the progress bar logic to allow forward progresion.
