### PR TITLE
T2288---Force-the-maximum-pages-of-a-letter-to-be-15

### DIFF
--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -157,7 +157,6 @@ class CorrespondenceS2bGenerator(models.Model):
             out_data.seek(0)
             pdf = out_data.read()
 
-
         # Check the number of pages
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
         if n_pages > self.MAX_PAGE_COUNT:

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -160,11 +160,12 @@ class CorrespondenceS2bGenerator(models.Model):
         # Check the number of pages
         n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
         if n_pages > self.MAX_PAGE_COUNT:
-            msg = _("Oops your letter has %d pages. The limit is %d") % (
+            msg = _("Oops your letter has %d pages. The limit is %d.") % (
                 n_pages,
                 self.MAX_PAGE_COUNT,
             )
-            callbacks.get("failure_callback", lambda: None)(err_msg=msg)
+            callbacks.get("failure_callback", lambda **_: None)(err_msg=msg)
+            raise UserError(msg)
 
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -95,6 +95,7 @@ class CorrespondenceS2bGenerator(models.Model):
         string="Generation Status",
     )
     generation_error_message = fields.Text(string="Generation Message")
+    MAX_PAGE_COUNT = 15
 
     def _compute_nb_letters(self):
         for generator in self:
@@ -155,6 +156,16 @@ class CorrespondenceS2bGenerator(models.Model):
             output_pdf.write(out_data)
             out_data.seek(0)
             pdf = out_data.read()
+
+
+        # Check the number of pages
+        n_pages = PdfFileReader(BytesIO(pdf)).getNumPages()
+        if n_pages > self.MAX_PAGE_COUNT:
+            msg = _("Oops your letter has %d pages. The limit is %d") % (
+                n_pages,
+                self.MAX_PAGE_COUNT,
+            )
+            callbacks.get("failure_callback", lambda: None)(err_msg=msg)
 
         try:
             with Image(blob=pdf, resolution=96) as pdf_image:

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -164,7 +164,6 @@ class CorrespondenceS2bGenerator(models.Model):
                 n_pages,
                 self.MAX_PAGE_COUNT,
             )
-            callbacks.get("failure_callback", lambda **_: None)(err_msg=msg)
             raise UserError(msg)
 
         try:


### PR DESCRIPTION
## :warning: Important note: 
This PR code is based on two PRs: 
1)  https://github.com/CompassionCH/compassion-website/pull/163 -> For the polling response of the ongoing letter generation using callbacks. 
2) https://github.com/CompassionCH/compassion-modules/pull/2050 -> Updates the model correspondence_s2b_generator  to have a generation_status field and. 

## Summary 
This PR prevents the sponsors from creating (and previewing) letters that are more than 15 pages long. Which is a must follow from Compassion International.
Whenever this rule is broken, an error message pops-up showing **Oops your letter has XX pages. The limit is 15." **
## Technical information
The rendering is first done by the backend, if the compiled PDF is longer than 15 pages, the process aborts and an error message is returned to the sponsor. 

## Demonstration video
[Screencast from 02.10.2025 10:36:15.webm](https://github.com/user-attachments/assets/3983c852-e9fe-4d0d-a029-c22c767afb12)


## Modified file
- `sbc_compassion/models/correspondence_s2b_generator.py` : Add nb of page checking. 

