### PR TITLE
T2240   No money hold extension reminders

### DIFF
--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -487,9 +487,9 @@ class CompassionHold(models.Model):
                 hold.write(hold_vals)
 
             # ----------------------------------------------------
-            # NOTIFICATION (Only for SUB_CHILD_HOLD)
+            # NOTIFICATION (Only for NO_MONEY_HOLD)
             # ----------------------------------------------------
-            if hold.type == HoldType.SUB_CHILD_HOLD:
+            if hold.type == HoldType.NO_MONEY_HOLD:
                 if hold.child_id.sponsor_id:
                     body = (
                         "The no money hold for child {local_id} was expiring on "

--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -501,15 +501,13 @@ class CompassionHold(models.Model):
                         subject=_("No money hold extension"),
                         subtype_xmlid="mail.mt_comment",
                     )
-                else :
+                else:
                     body = _(
                         "The no money hold for child {local_id} is expiring on "
                         "{old_expiration} and will not be extended since "
                         "no sponsorship exists for this child."
                     )
                     hold.message_post(body=body.format(**values))
-
-
 
     ##########################################################################
     #                              Mapping METHOD                            #

--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -486,24 +486,30 @@ class CompassionHold(models.Model):
                 }
                 hold.write(hold_vals)
 
-                body = (
-                    "The no money hold for child {local_id} was expiring on "
-                    "{old_expiration} and was extended to {new_expiration} "
-                    "({extension_description} extension).{additional_text}"
-                )
-                hold.message_post(
-                    body=_(body.format(**values)),
-                    subject=_("No money hold extension"),
-                    subtype_xmlid="mail.mt_comment",
-                )
+            # ----------------------------------------------------
+            # NOTIFICATION (Only for SUB_CHILD_HOLD)
+            # ----------------------------------------------------
+            if hold.type == HoldType.SUB_CHILD_HOLD:
+                if hold.child_id.sponsor_id:
+                    body = (
+                        "The no money hold for child {local_id} was expiring on "
+                        "{old_expiration} and was extended to {new_expiration} "
+                        "({extension_description} extension).{additional_text}"
+                    )
+                    hold.message_post(
+                        body=_(body.format(**values)),
+                        subject=_("No money hold extension"),
+                        subtype_xmlid="mail.mt_comment",
+                    )
+                else :
+                    body = _(
+                        "The no money hold for child {local_id} is expiring on "
+                        "{old_expiration} and will not be extended since "
+                        "no sponsorship exists for this child."
+                    )
+                    hold.message_post(body=body.format(**values))
 
-            else:
-                body = _(
-                    "The no money hold for child {local_id} is expiring on "
-                    "{old_expiration} and will not be extended since "
-                    "no sponsorship exists for this child."
-                )
-                hold.message_post(body=body.format(**values))
+
 
     ##########################################################################
     #                              Mapping METHOD                            #

--- a/child_compassion/models/compassion_hold.py
+++ b/child_compassion/models/compassion_hold.py
@@ -489,7 +489,7 @@ class CompassionHold(models.Model):
             # ----------------------------------------------------
             # NOTIFICATION (Only for NO_MONEY_HOLD)
             # ----------------------------------------------------
-            if hold.type == HoldType.NO_MONEY_HOLD:
+            if hold.type == HoldType.NO_MONEY_HOLD.value:
                 if hold.child_id.sponsor_id:
                     body = (
                         "The no money hold for child {local_id} was expiring on "


### PR DESCRIPTION
## Background 
The system currently has a scheduled process (postpone_no_money_cron) that identifies expiring "No Money Holds" and "SUB Child Holds". The postpone_no_money_hold method is then called on these holds to extend their expiration date automatically. As part of this process, a notification is posted on the hold's chatter to inform the owner about the extension.

## Summary 
This PR adds a condition to ensure that the SDS is only notified when the hold type is **HoldType.NO_MONEY_HOLD.value**. 
The logic for extending the hold's expiration date is not  affected.

## Modified files
- `/setup/child_compassion/odoo/addons/child_compassion/models/compassion_hold.py` : Add the boolean logic.