### PR TITLE
T2678 on dashboard vignette sponsorship count is 0 when it should be one is an isolated case

### DIFF
--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -623,10 +623,6 @@ class SponsorshipContract(models.Model):
         if "reading_language" in vals:
             (self - updated_correspondents)._on_language_changed()
 
-        if old_partners:
-            self.mapped("partner_id").update_number_sponsorships()
-            old_partners.update_number_sponsorships()
-
         # Set the sub_sponsorship_id in the current parent_id
         if "parent_id" in vals:
             for sponsorship in self.filtered("parent_id"):
@@ -675,7 +671,6 @@ class SponsorshipContract(models.Model):
             sponsorship.hold_id.state = "expired"
             sponsorship.child_id.hold_id = False
         # Force refresh some fields in case they are not in sync
-        self.mapped("partner_id").update_number_sponsorships()
         self._compute_active()
         return True
 
@@ -684,7 +679,6 @@ class SponsorshipContract(models.Model):
         self.write(
             {"gmc_correspondent_commitment_id": vals["gmc_correspondent_commitment_id"]}
         )
-        self.correspondent_id.update_number_sponsorships()
         return True
 
     def cancel_sent(self, vals):
@@ -827,7 +821,6 @@ class SponsorshipContract(models.Model):
                 gift_contracts.contract_active()
 
         partners = self.mapped("partner_id") | self.mapped("correspondent_id")
-        partners.update_number_sponsorships()
         # Creating the messages to send to GMC when a sponsorship is activated
         for contract in self.filtered(lambda c: c.type in SPONSORSHIP_TYPE_LIST):
             # Define the payer that will be sync to gmc
@@ -1001,7 +994,6 @@ class SponsorshipContract(models.Model):
                 + error_message,
             )
 
-        self.correspondent_id.update_number_sponsorships()
         return True, ""
 
     def _on_sponsorship_finished(self):
@@ -1044,8 +1036,6 @@ class SponsorshipContract(models.Model):
                     ]
                 ).unlink()
                 sponsorship.state = "cancelled"
-        partners = self.mapped("partner_id") | self.mapped("correspondent_id")
-        partners.update_number_sponsorships()
 
     def _link_unlink_child_to_sponsor(self, vals):
         """Link/unlink child to sponsor"""

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -67,7 +67,12 @@ class ResPartner(models.Model):
     unrec_items = fields.Integer(compute="_compute_count_items")
     receivable_items = fields.Integer(compute="_compute_count_items")
     has_sponsorships = fields.Boolean()
-    number_sponsorships = fields.Integer(string="Number of sponsorships", copy=False)
+    number_sponsorships = fields.Integer(
+        string="Number of sponsorships",
+        compute="_compute_number_sponsorships",
+        search="_search_number_sponsorships",
+        copy=False,
+    )
     preferred_name = fields.Char()
     sponsored_child_ids = fields.One2many(
         "compassion.child",
@@ -160,13 +165,58 @@ class ResPartner(models.Model):
                 [("partner_id", "=", partner.id), ("account_id.code", "=", "1050")]
             )
 
-    def update_number_sponsorships(self):
+    def _compute_number_sponsorships(self):
         for partner in self:
+            active_sponsorship_domain = [
+                "|",
+                ("partner_id", "=", partner.id),
+                ("correspondent_id", "=", partner.id),
+                ("activation_date", "!=", False),
+                ("state", "not in", ["cancelled", "terminated"]),
+                ("child_id", "!=", False),
+            ]
             partner.number_sponsorships = self.env["recurring.contract"].search_count(
-                partner._get_active_sponsorships_domain()
+                active_sponsorship_domain
             )
             partner.has_sponsorships = partner.number_sponsorships
         return True
+
+    def _search_number_sponsorships(self, operator, value):
+        """
+        This method translates a search on the non-stored 'number_sponsorships'
+        field into a valid database query using a LEFT JOIN.
+
+        NOTE: This method counts unique contracts, not total involvements.
+        """
+        # 1. Securely validate the operator to prevent SQL injection.
+        if operator not in ("=", "!=", "<", ">", "<=", ">="):
+            raise ValueError("Invalid operator: %s" % operator)
+
+        # 2. Build the query using LEFT JOIN.
+        #    - Conditions on 'c' are in the ON clause.
+        #    - COUNT(c.id) correctly handles partners with 0 contracts.
+        #    - %%s is used to escape the '%' for the value placeholder.
+        query = """
+            SELECT
+                p.id
+            FROM
+                res_partner p
+            LEFT JOIN recurring_contract c
+                ON p.id IN (c.partner_id, c.correspondent_id)
+                AND c.state NOT IN ('cancelled', 'terminated')
+                AND c.activation_date IS NOT NULL
+                AND c.child_id IS NOT NULL
+            GROUP BY
+                p.id
+            HAVING
+                COUNT(c.id) {} %s
+        """.format(operator)
+        # 3. Execute the query with the value as a safe parameter.
+        self._cr.execute(query, (value,))
+        partner_ids = [res[0] for res in self._cr.fetchall()]
+
+        # 4. Return a valid Odoo domain.
+        return [("id", "in", partner_ids)]
 
     @api.depends("category_id", "member_ids")
     def _compute_is_church(self):
@@ -229,9 +279,6 @@ class ResPartner(models.Model):
         if "firstname" in vals and "preferred_name" not in vals:
             vals["preferred_name"] = vals["firstname"]
         res = super().write(vals)
-
-        if "church_id" in vals:
-            self.mapped("church_id").update_number_sponsorships()
 
         notify_vals = [
             "firstname",


### PR DESCRIPTION
## Summary

The number_sponsorships field on the res_partner model was frequently incorrect, showing a lower value than the actual number of active sponsorships. This was caused by the manual trigger-based method (_update_number_sponsorships) failing to cover all state transitions, such as a sponsorship moving from 'Draft' to 'Active'.

Here are some __res_partner.id__ with incoherent number of sponsorship (0 is stored instead of 1), to convince yourself: 

- 44070 

- 44109

- 22461

## Solution

To guarantee data accuracy, the number_sponsorships field has been converted to a non-stored computed field. This change ensures the value is always calculated in real-time and remains accurate without complex maintenance.

The computation is lightweight and avoids performance issues.

## Drawbacks

As the field is no longer stored, sorting and grouping by the 'Number of Sponsorships' column directly in the Odoo UI is not possible. However, filtering on this field (equality and inequalities) remains fully functional.

## Important note :warning: 

![f19a9475f492e7e5b794dc516c24445e](https://github.com/user-attachments/assets/c6127912-74ff-4d82-9a9c-174ee9619db1)

This task is linked the following PR : https://github.com/CompassionCH/compassion-switzerland/pull/1699
