### PR TITLE
Fix resolve concurrency issues with letters status being polled

### DIFF
--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -252,14 +252,14 @@ class CorrespondenceS2bGenerator(models.Model):
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
 
-            # Update state to done
-
-            self.state = "done"
-            self.date = fields.Datetime.now()
-            # Ensure atomicity
-            self.env.cr.commit()
-
-            return True
+            return self.write(
+                {
+                    "state": "done",
+                    "date": fields.Datetime.now(),
+                    "generation_status": "done",
+                    "generation_error_message": False,
+                }
+            )
 
         except Exception as error:
             # If the operation fails, notify the user with the error message

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -168,7 +168,6 @@ class CorrespondenceS2bGenerator(models.Model):
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
 
-                self.isolated_write({"generation_status": "done"})
                 return self.isolated_write(
                     {
                         "state": "preview",
@@ -176,7 +175,7 @@ class CorrespondenceS2bGenerator(models.Model):
                         "preview_pdf": base64.b64encode(pdf),
                     }
                 )
-                return
+
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
                 _(
@@ -261,7 +260,6 @@ class CorrespondenceS2bGenerator(models.Model):
                 {
                     "state": "done",
                     "date": fields.Datetime.now(),
-                    "generation_status": "done",
                     "generation_error_message": False,
                 }
             )

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -168,8 +168,6 @@ class CorrespondenceS2bGenerator(models.Model):
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
 
-
-
                 return self.write(
                     {
                         "state": "preview",
@@ -258,7 +256,7 @@ class CorrespondenceS2bGenerator(models.Model):
 
             self.state = "done"
             self.date = fields.Datetime.now()
-                # Ensure atomicity
+            # Ensure atomicity
             self.env.cr.commit()
 
             return True
@@ -329,9 +327,8 @@ class CorrespondenceS2bGenerator(models.Model):
         if len(self) != 1:
             return False
 
-
         self.generation_status = status
         if generation_error_message:
-            new_s2b_generator.generation_error_message = generation_error_message
+            self.generation_error_message = generation_error_message
         self.env.cr.commit()
         return True

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -165,18 +165,20 @@ class CorrespondenceS2bGenerator(models.Model):
                 )
 
                 raise UserError(msg)
-
+            self.update_generation_status("done", False)
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
-                return self.write(
-                    {
-                        "state": "preview",
-                        "generation_status": "done",
-                        "generation_error_message": False,
-                        "preview_image": preview,
-                        "preview_pdf": base64.b64encode(pdf),
-                    }
-                )
+
+                with self.env.registry.cursor() as new_cr:
+                    new_env = self.env(cr=new_cr)
+                    new_s2b_generator = new_env[self._name].browse(self.id)
+                    new_s2b_generator.state = "preview"
+                    new_s2b_generator.preview_image = preview
+                    new_s2b_generator.preview_pdf = base64.b64encode(pdf)
+
+                    new_cr.commit()
+
+                self.update_generation_status("done", False)
 
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
@@ -252,14 +254,16 @@ class CorrespondenceS2bGenerator(models.Model):
             # If the operation succeeds, notify the user
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
-            return self.write(
-                {
-                    "state": "done",
-                    "date": fields.Datetime.now(),
-                    "generation_status": "done",
-                    "generation_error_message": False,
-                }
-            )
+
+            with self.env.registry.cursor() as new_cr:
+                new_env = self.env(cr=new_cr)
+                new_s2b_generator = new_env[self._name].browse(self.id)
+                new_s2b_generator.state = "done"
+                new_s2b_generator.date = fields.Datetime.now()
+                new_s2b_generator.generation_status = "done"
+                new_cr.commit()
+
+                return
 
         except Exception as error:
             # If the operation fails, notify the user with the error message

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -168,15 +168,15 @@ class CorrespondenceS2bGenerator(models.Model):
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
 
-                return self.write(
+                self.isolated_write({"generation_status": "done"})
+                return self.isolated_write(
                     {
                         "state": "preview",
-                        "generation_status": "done",
-                        "generation_error_message": False,
                         "preview_image": preview,
                         "preview_pdf": base64.b64encode(pdf),
                     }
                 )
+                return
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
                 _(
@@ -196,7 +196,12 @@ class CorrespondenceS2bGenerator(models.Model):
             if self.env.context.get("raise_error"):
                 raise UserError(error_message) from error
             self.env.cr.rollback()
-            self.update_generation_status("failed", error_message)
+            self.isolated_write(
+                {
+                    "generation_status": "failed",
+                    "generation_error_message": error_message,
+                }
+            )
 
     def edit(self):
         """Generate a picture for preview."""
@@ -252,7 +257,7 @@ class CorrespondenceS2bGenerator(models.Model):
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
 
-            return self.write(
+            return self.isolated_write(
                 {
                     "state": "done",
                     "date": fields.Datetime.now(),
@@ -265,7 +270,12 @@ class CorrespondenceS2bGenerator(models.Model):
             # If the operation fails, notify the user with the error message
             self.env.cr.rollback()
             error_message = str(error)
-            self.update_generation_status("failed", error_message)
+            self.isolated_write(
+                {
+                    "generation_status": "failed",
+                    "generation_error_message": error_message,
+                }
+            )
         return True
 
     def open_letters(self):
@@ -322,13 +332,13 @@ class CorrespondenceS2bGenerator(models.Model):
             text,
         )
 
-    def update_generation_status(self, status, generation_error_message=None):
-        """Use a separate transaction to update the status of the generation."""
+    def isolated_write(self, vals):
+        """Use a separate transaction to update the letter_generator."""
         if len(self) != 1:
             return False
 
-        self.generation_status = status
-        if generation_error_message:
-            self.generation_error_message = generation_error_message
-        self.env.cr.commit()
-        return True
+        with self.env.registry.cursor() as new_cr:
+            new_env = self.env(cr=new_cr)
+            new_s2b_generator = new_env[self._name].browse(self.id)
+            new_s2b_generator.write(vals)
+            new_cr.commit()

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -174,7 +174,6 @@ class CorrespondenceS2bGenerator(models.Model):
                     new_s2b_generator.state = "preview"
                     new_s2b_generator.preview_image = preview
                     new_s2b_generator.preview_pdf = base64.b64encode(pdf)
-                    new_s2b_generator.preview_pdf = base64.b64encode(pdf)
                     # Ensure atomicity
                     new_cr.commit()
 

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -165,18 +165,17 @@ class CorrespondenceS2bGenerator(models.Model):
                 )
 
                 raise UserError(msg)
-
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
-                return self.write(
-                    {
-                        "state": "preview",
-                        "generation_status": "done",
-                        "generation_error_message": False,
-                        "preview_image": preview,
-                        "preview_pdf": base64.b64encode(pdf),
-                    }
-                )
+
+                with self.env.registry.cursor() as new_cr:
+                    new_env = self.env(cr=new_cr)
+                    new_s2b_generator = new_env[self._name].browse(self.id)
+                    new_s2b_generator.state = "preview"
+                    new_s2b_generator.preview_image = preview
+                    new_s2b_generator.preview_pdf = base64.b64encode(pdf)
+                    # Ensure atomicity
+                    new_cr.commit()
 
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
@@ -186,7 +185,7 @@ class CorrespondenceS2bGenerator(models.Model):
                     "as soon as possible."
                 )
                 if isinstance(error, PolicyError)
-                else error.message
+                else str(error)
                 if isinstance(error, UserError)
                 else _(
                     "There was an error while generating the PDF of the letter. "
@@ -252,14 +251,17 @@ class CorrespondenceS2bGenerator(models.Model):
             # If the operation succeeds, notify the user
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
-            return self.write(
-                {
-                    "state": "done",
-                    "date": fields.Datetime.now(),
-                    "generation_status": "done",
-                    "generation_error_message": False,
-                }
-            )
+
+            # Update state to done
+            with self.env.registry.cursor() as new_cr:
+                new_env = self.env(cr=new_cr)
+                new_s2b_generator = new_env[self._name].browse(self.id)
+                new_s2b_generator.state = "done"
+                new_s2b_generator.date = fields.Datetime.now()
+                # Ensure atomicity
+                new_cr.commit()
+
+                return True
 
         except Exception as error:
             # If the operation fails, notify the user with the error message

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -174,10 +174,9 @@ class CorrespondenceS2bGenerator(models.Model):
                     new_s2b_generator.state = "preview"
                     new_s2b_generator.preview_image = preview
                     new_s2b_generator.preview_pdf = base64.b64encode(pdf)
-                    new_s2b_generator.generation_status = "done"
-
+                    new_s2b_generator.preview_pdf = base64.b64encode(pdf)
+                    # Ensure atomicity
                     new_cr.commit()
-
 
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
@@ -254,12 +253,13 @@ class CorrespondenceS2bGenerator(models.Model):
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
 
+            # Update state to done
             with self.env.registry.cursor() as new_cr:
                 new_env = self.env(cr=new_cr)
                 new_s2b_generator = new_env[self._name].browse(self.id)
                 new_s2b_generator.state = "done"
                 new_s2b_generator.date = fields.Datetime.now()
-                new_s2b_generator.generation_status = "done"
+                # Ensure atomicity
                 new_cr.commit()
 
                 return

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -186,7 +186,7 @@ class CorrespondenceS2bGenerator(models.Model):
                     "as soon as possible."
                 )
                 if isinstance(error, PolicyError)
-                else error.message
+                else str(error)
                 if isinstance(error, UserError)
                 else _(
                     "There was an error while generating the PDF of the letter. "

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -171,6 +171,8 @@ class CorrespondenceS2bGenerator(models.Model):
                 return self.isolated_write(
                     {
                         "state": "preview",
+                        "generation_status": "done",
+                        "generation_error_message": False,
                         "preview_image": preview,
                         "preview_pdf": base64.b64encode(pdf),
                     }
@@ -260,6 +262,7 @@ class CorrespondenceS2bGenerator(models.Model):
                 {
                     "state": "done",
                     "date": fields.Datetime.now(),
+                    "generation_status": "done",
                     "generation_error_message": False,
                 }
             )

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -168,15 +168,17 @@ class CorrespondenceS2bGenerator(models.Model):
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
 
-                with self.env.registry.cursor() as new_cr:
-                    new_env = self.env(cr=new_cr)
-                    new_s2b_generator = new_env[self._name].browse(self.id)
-                    new_s2b_generator.state = "preview"
-                    new_s2b_generator.preview_image = preview
-                    new_s2b_generator.preview_pdf = base64.b64encode(pdf)
-                    # Ensure atomicity
-                    new_cr.commit()
 
+
+                return self.write(
+                    {
+                        "state": "preview",
+                        "generation_status": "done",
+                        "generation_error_message": False,
+                        "preview_image": preview,
+                        "preview_pdf": base64.b64encode(pdf),
+                    }
+                )
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (
                 _(
@@ -253,15 +255,13 @@ class CorrespondenceS2bGenerator(models.Model):
             self.env.user.notify_success(message=message)
 
             # Update state to done
-            with self.env.registry.cursor() as new_cr:
-                new_env = self.env(cr=new_cr)
-                new_s2b_generator = new_env[self._name].browse(self.id)
-                new_s2b_generator.state = "done"
-                new_s2b_generator.date = fields.Datetime.now()
-                # Ensure atomicity
-                new_cr.commit()
 
-                return True
+            self.state = "done"
+            self.date = fields.Datetime.now()
+                # Ensure atomicity
+            self.env.cr.commit()
+
+            return True
 
         except Exception as error:
             # If the operation fails, notify the user with the error message
@@ -328,11 +328,10 @@ class CorrespondenceS2bGenerator(models.Model):
         """Use a separate transaction to update the status of the generation."""
         if len(self) != 1:
             return False
-        with self.env.registry.cursor() as new_cr:
-            new_env = self.env(cr=new_cr)
-            new_s2b_generator = new_env[self._name].browse(self.id)
-            new_s2b_generator.generation_status = status
-            if generation_error_message:
-                new_s2b_generator.generation_error_message = generation_error_message
-            new_cr.commit()
+
+
+        self.generation_status = status
+        if generation_error_message:
+            new_s2b_generator.generation_error_message = generation_error_message
+        self.env.cr.commit()
         return True

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -261,7 +261,7 @@ class CorrespondenceS2bGenerator(models.Model):
                 # Ensure atomicity
                 new_cr.commit()
 
-                return
+                return True
 
         except Exception as error:
             # If the operation fails, notify the user with the error message

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -165,7 +165,6 @@ class CorrespondenceS2bGenerator(models.Model):
                 )
 
                 raise UserError(msg)
-            self.update_generation_status("done", False)
             with Image(blob=pdf, resolution=96) as pdf_image:
                 preview = base64.b64encode(pdf_image.make_blob(format="jpeg"))
 
@@ -175,10 +174,10 @@ class CorrespondenceS2bGenerator(models.Model):
                     new_s2b_generator.state = "preview"
                     new_s2b_generator.preview_image = preview
                     new_s2b_generator.preview_pdf = base64.b64encode(pdf)
+                    new_s2b_generator.generation_status = "done"
 
                     new_cr.commit()
 
-                self.update_generation_status("done", False)
 
         except (PolicyError, TypeError, UserError, Exception) as error:
             error_message = (

--- a/sbc_compassion/models/correspondence_template.py
+++ b/sbc_compassion/models/correspondence_template.py
@@ -160,7 +160,7 @@ class CorrespondenceTemplate(models.Model):
             )
             image_list = []
 
-            s2b_generator.update_generation_status("apply_template")
+            s2b_generator.isolated_write({"generation_status": "apply_template"})
 
             if background_list:
                 # An original document is provided. We want
@@ -202,7 +202,7 @@ class CorrespondenceTemplate(models.Model):
                     text_list.append(text_box.get_json_repr())
                 overflow_template = [add_background.name, header_data, text_list, []]
 
-            s2b_generator.update_generation_status("apply_text")
+            s2b_generator.isolated_write({"generation_status": "apply_text"})
 
             text_list = []
             for t_type, t_boxes in list(text.items()):
@@ -215,7 +215,7 @@ class CorrespondenceTemplate(models.Model):
                     temp_files.append(txt_file)
                     text_list.append([txt_file.name, t_type])
 
-            s2b_generator.update_generation_status("apply_images")
+            s2b_generator.isolated_write({"generation_status": "apply_images"})
 
             for image in image_data:
                 ifile = tempfile.NamedTemporaryFile(prefix="img_", suffix=".jpg")
@@ -240,7 +240,7 @@ class CorrespondenceTemplate(models.Model):
             std_err_file_path = self.path_to("stderr.txt")
             std_err_file = open(std_err_file_path, "w", encoding="utf-8")
 
-            s2b_generator.update_generation_status("generate_pdf")
+            s2b_generator.isolated_write({"generation_status": "generate_pdf"})
 
             php_command_args = ["php", self.path_to("pdf.php"), pdf_name, json_val]
             if config.get("php_debug"):


### PR DESCRIPTION
## :warning: Important note
This PR is linked to this PR : https://github.com/CompassionCH/compassion-website/pull/181

## Summary

This PR fixes some issues resulting from the merging of the three following tasks : 
- T2379 Implement letter draft functionality : https://github.com/CompassionCH/compassion-website/pull/141
- T2624Make the letter creation progress bar show "real" checkpoints : https://github.com/CompassionCH/compassion-website/pull/163
- T2288 Force the maximum pages of a letter to be 15 : https://github.com/CompassionCH/compassion-modules/pull/2051

## 🐛 Problem Description

After the recent merges, several regressions were identified:

1.  **Page Limit Bypass**: The validation check to enforce the 15-page limit on letters was no longer being triggered, allowing oversized letters to be submitted.
2.  **UI Deadlock**: A **race condition** between the backend process updating the `generation_status` and the frontend polling for that status was causing a deadlock. The UI would get stuck in a loading state because it was reading an inconsistent status from the database before the transaction committed.
3.  **No Retry on Failure**: If a letter failed generation (e.g., for being over the page limit), its status was permanently set to 'failed'. Even after the user corrected the letter, the system would not allow a new generation attempt.

---

## ✅ Proposed Solutions

To resolve these issues, the following changes have been implemented:

1.  **Reinstate Page Limit Check**: The `preview()` method, which contains the page count validation, is now called during the final "send" action. This ensures the page limit is checked just before submission.
2.  **Eliminate Race Condition**: To guarantee the polling mechanism sees fresh data, the database update for the `generation_status` is now forced to **commit immediately** in its own transaction. This ensures atomicity and prevents the frontend from reading a stale state.
3.  **Enable Resubmission After Failure**: The letter generator's state is now correctly reset when a user attempts to resubmit a letter that previously failed. The `status` and `generation_status` fields are reverted to their initial values, allowing the corrected letter to be processed as a new attempt.

---