### PR TITLE
[T2855] - Impact trip procedure : upload criminal records

### DIFF
--- a/child_protection/models/partner_compassion.py
+++ b/child_protection/models/partner_compassion.py
@@ -38,6 +38,11 @@ class ResPartner(models.Model):
         compute="_compute_code_of_conduct_filename",
     )
 
+    passport = fields.Binary(
+        attachment=True
+    )
+    passport_name = fields.Char(compute="_compute_passport_name")
+
     ##########################################################################
     #                             FIELDS METHODS                             #
     ##########################################################################
@@ -54,6 +59,13 @@ class ResPartner(models.Model):
                 record.code_of_conduct_filename = f"Code_of_Conduct_{record.name}"
             else:
                 record.code_of_conduct_filename = False
+
+    def _compute_passport_name(self):
+        for partner in self:
+            if partner.passport:
+                partner.passport_name = f"Passport_{partner.name}"
+            else:
+                partner.passport_name = False
 
     ##########################################################################
     #                              ORM METHODS                               #

--- a/child_protection/models/partner_compassion.py
+++ b/child_protection/models/partner_compassion.py
@@ -38,9 +38,7 @@ class ResPartner(models.Model):
         compute="_compute_code_of_conduct_filename",
     )
 
-    passport = fields.Binary(
-        attachment=True
-    )
+    passport = fields.Binary(attachment=True)
     passport_name = fields.Char(compute="_compute_passport_name")
 
     ##########################################################################


### PR DESCRIPTION
# Criminal Record Save Failure Resolution

## Purpose and Context

The goal of this PR is to fix a critical issue preventing users from updating their **Criminal Record** via the MyCompassion portal.

Due to Odoo security constraints and inconsistent document handling, uploads were failing when registrations were in the **Attended** state. In some cases, this also caused unstable registration statuses and the disappearance of events from the **My Events** section.

This PR should be reviewed together with a related PR, as both contribute to stabilizing the document upload and event registration workflows.

---

## Applied Changes and Improvements

### 1. Portal Security and Save Reliability

- **Secure write with `sudo`**  
  Document saving in `event.registration.form` now uses  
  `form.registration_id.sudo().write(docs_to_save)`.

- **Result**  
  Documents are saved with sufficient privileges, preventing access errors, redirection crashes, and unintended status changes. The **Attended** status is preserved.

---

### 2. Document Management Standardization

- **Unified handling**  
  Passport and Criminal Record are now managed in an identical and consistent way.

- **Technical debt removal**  
  Complex `compute` / `inverse` logic for Passport has been removed.  
  Both documents are now standard `Binary` fields with `attachment=True` on `res.partner`.

- **Single source of truth**  
  Documents are physically attached to the partner (contact).  
  Event registrations access them through related fields.

- **XML cleanup**  
  Backend views were simplified by removing obsolete technical fields (e.g. `passport_filename`).

---

### 3. Validation and Testing

- **Portal upload testing**  
  Documents were uploaded using a real participant account for the Impact Trip in the Dominican Republic.

- **Technical verification**  
  Uploaded documents are visible under  
  `Settings → Technical → Attachments` as *Passport* and *Criminal Record*.

- **Data integrity**  
  Each attachment correctly references the related partner in the **Attached To** field.

---

## Outcome

- Criminal Record and Passport uploads are stable and reliable.
- Event registrations remain visible, with the **Attended** status preserved.
- The codebase is cleaner, standardized, and easier to maintain.

---

## Related PRs

This set of improvements is complemented by a related PR in the **Compassion-website** repository:

- PR: [[T2855] - Impact trip procedure : upload criminal records #242](https://github.com/CompassionCH/compassion-website/pull/242)