### PR TITLE
[T2986] FIX: direction is now explicitly set through message values

### DIFF
--- a/message_center_compassion/models/gmc_message.py
+++ b/message_center_compassion/models/gmc_message.py
@@ -106,7 +106,7 @@ class GmcMessage(models.Model):
             )
 
         if not message:
-            message = super().create(vals)
+            message = super(GmcMessage, self).create(vals)
 
         if message.action_id.auto_process:
             message.process_messages()

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -609,12 +609,13 @@ class Correspondence(models.Model):
         )
         messages = self.env["gmc.message"]
         for letter in self:
-            action_id = self.env.ref("sbc_compassion.create_letter").id
+            action = self.env.ref("sbc_compassion.create_letter")
             message_vals = {
-                "action_id": action_id,
+                "action_id": action.id,
                 "object_id": letter.id,
                 "child_id": letter.child_id.id,
                 "partner_id": letter.partner_id.id,
+                "direction": action.direction
             }
             if (
                 letter.sponsorship_id.state not in ("active", "terminated")

--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -615,7 +615,7 @@ class Correspondence(models.Model):
                 "object_id": letter.id,
                 "child_id": letter.child_id.id,
                 "partner_id": letter.partner_id.id,
-                "direction": action.direction
+                "direction": action.direction,
             }
             if (
                 letter.sponsorship_id.state not in ("active", "terminated")


### PR DESCRIPTION
- FIX: fetch the whole action instead of only the id and set the id and direction for the message
- REFACTOR: added type to super().create() in gmc_message for clarity

Explanation: 
The direction field on `gmc.message `was not persisting to the database because of conflicts with Odoo's ORM logic:
- The related field approach failed because the source model (`gmc.action`) explicitly blocks writes to this field, which interrupted the ORM's synchronization process during creation. 
- The computed field also failed because even though the value was calculated in memory, the system failed to trigger a secondary SQL update to save it. 

The only approach which worked was to manually inject the value into the creation dictionary (vals) before calling `create()`, ensuring the data is included directly in the primary SQL INSERT statement.