### PR TITLE
[T2987] REFACTOR: moved language detection to generator

### DIFF
--- a/sbc_compassion/__manifest__.py
+++ b/sbc_compassion/__manifest__.py
@@ -37,6 +37,7 @@
     "website": "https://github.com/CompassionCH/compassion-modules",
     "depends": [
         "sponsorship_compassion",
+        "advanced_translation",
     ],
     "external_dependencies": {
         "bin": ["php"],

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -119,6 +119,19 @@ class CorrespondenceS2bGenerator(models.Model):
                         _("Only JPG images are allowed as attached images.")
                     )
 
+    @api.model
+    def create(self, vals):
+        """
+        Overwrites the default create method
+        """
+        if vals.get("body") and not vals.get("language_id"):
+            detected_language = (
+                self.env["langdetect"].sudo().detect_language(vals["body"])
+            )
+            if detected_language:
+                vals["language_id"] = detected_language.id
+        return super().create(vals)
+
     ##########################################################################
     #                             VIEW CALLBACKS                             #
     ##########################################################################


### PR DESCRIPTION
- REFACTOR: Moved original language detection to generator and made sure everyone can access it -> sudo()

Based on the comments of @ecino in https://github.com/CompassionCH/compassion-website/pull/284. 