### PR TITLE
T3017 [FIX] replace isolated_write with write in correspondence handling

### DIFF
--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -607,14 +607,13 @@ class Correspondence(models.Model):
             datetime.date.today()
         )
         messages = self.env["gmc.message"]
+        action_id = self.env.ref("sbc_compassion.create_letter").id
         for letter in self:
-            action = self.env.ref("sbc_compassion.create_letter")
             message_vals = {
-                "action_id": action.id,
+                "action_id": action_id,
                 "object_id": letter.id,
                 "child_id": letter.child_id.id,
                 "partner_id": letter.partner_id.id,
-                "direction": action.direction,
             }
             if (
                 letter.sponsorship_id.state not in ("active", "terminated")
@@ -986,7 +985,8 @@ class Correspondence(models.Model):
                     .name
                     + " "
                 )
-            name += letter.child_id.local_id
+            if letter.child_id:
+                name += letter.child_id.local_id
             if letter.kit_identifier:
                 name += " " + letter.kit_identifier
             name += "." + (letter.letter_format or "pdf")

--- a/sbc_compassion/models/correspondence_s2b_generator.py
+++ b/sbc_compassion/models/correspondence_s2b_generator.py
@@ -248,6 +248,7 @@ class CorrespondenceS2bGenerator(models.Model):
                     "source": self.source,
                     "original_language_id": self.language_id.id,
                     "original_text": text,
+                    "generator_id": self.id,
                 }
                 if self.image_ids:
                     vals["original_attachment_ids"] = [
@@ -264,14 +265,10 @@ class CorrespondenceS2bGenerator(models.Model):
                     ]
                 letters += letters.create(vals)
 
-            letters.create_text_boxes()
-            self.letter_ids = letters
-
             # If the operation succeeds, notify the user
             message = "Letters have been successfully generated."
             self.env.user.notify_success(message=message)
-
-            return self.isolated_write(
+            return self.write(
                 {
                     "state": "done",
                     "date": fields.Datetime.now(),
@@ -358,4 +355,4 @@ class CorrespondenceS2bGenerator(models.Model):
             new_env = self.env(cr=new_cr)
             new_s2b_generator = new_env[self._name].browse(self.id)
             new_s2b_generator.write(vals)
-            new_cr.commit()
+        return True


### PR DESCRIPTION
- Happy path should use main cursor
- Only exceptions should use a new cursor in DB
- Remove redundant calls

@Danielgergely This reverts part of the changes you did for T2986 (GMC message direction), but I think I found the root cause of the problem. For a reason, the separate transactions with isolated_writes prevented the relational and compute fields to be set correctly. Can you please review those changes and let me know what you think?

This change also fixes T3017