### PR TITLE
[T3035] FIX: language detection now does not overwrite source/target language in some cases

### DIFF
--- a/sbc_compassion/models/correspondence.py
+++ b/sbc_compassion/models/correspondence.py
@@ -453,6 +453,8 @@ class Correspondence(models.Model):
         lang_detector = self.env["langdetect"]
 
         for letter in self.with_context(skip_lang_detect=True):
+            # Determine which text is analyzed
+            is_translation = bool(letter.translated_text or letter.english_text)
             letter_text = (
                 letter.translated_text or letter.english_text or letter.original_text
             )
@@ -475,8 +477,16 @@ class Correspondence(models.Model):
                 continue
 
             detected_lang = lang_detector.detect_language(clean_text)
-            if detected_lang and detected_lang != letter.translation_language_id:
-                letter.translation_language_id = detected_lang
+            if detected_lang:
+                # update the target langauge only if analyzing translated text
+                if is_translation and detected_lang != letter.translation_language_id:
+                    letter.translation_language_id = detected_lang
+
+                # update the source language if analyzing original text
+                elif (
+                    not is_translation and detected_lang != letter.original_language_id
+                ):
+                    letter.original_language_id = detected_lang
 
     @api.depends("uuid")
     def _compute_read_url(self):

--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -183,23 +183,23 @@ class Correspondence(models.Model):
         if vals.get("direction") == "Beneficiary To Supporter":
             correspondence = super().create(vals)
         else:
-            sponsorship = self.env["recurring.contract"].browse(vals["sponsorship_id"])
+            # create letter first and let super.create() run the language detection first
+            correspondence = super(
+                Correspondence, self.with_context(no_comm_kit=True)
+            ).create(vals)
 
-            original_lang = self.env["res.lang.compassion"].browse(
-                vals.get("original_language_id")
-            )
+            sponsorship = correspondence.sponsorship_id
+            original_lang = correspondence.original_language_id
 
             # Languages the office/region understand
             office = sponsorship.child_id.project_id.field_office_id
             language_ids = office.spoken_language_ids + office.translated_language_ids
 
             if original_lang.translatable and original_lang not in language_ids:
-                correspondence = super(
-                    Correspondence, self.with_context(no_comm_kit=True)
-                ).create(vals)
                 correspondence.send_local_translate()
             else:
-                correspondence = super().create(vals)
+                # if no translation is needed, resume GMC dispatch
+                correspondence.create_commkit()
 
         return correspondence
 

--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -463,6 +463,15 @@ class SponsorshipContract(models.Model):
 
     @api.depends_context("allow_during_suspension")
     def _compute_can_write_letter(self):
+        """
+        Computes whether a letter can be written for the current sponsorship.
+
+        A letter is permitted if:
+        1. The project has not suspended S2B letters
+            (or the context bypasses the suspension)
+        2. THe contract is in an active/pending state, OR it is 'terminated' but still
+        within the configured allowed time (default 90 days) since its end date.
+        """
         days_allowed = (
             self.env["ir.config_parameter"]
             .sudo()
@@ -470,14 +479,18 @@ class SponsorshipContract(models.Model):
         )
         now = fields.Datetime.now()
         for sponsorship in self:
+            # Project/center has suspended letters
             hold_letters = (
                 sponsorship.project_id.hold_s2b_letters
                 and not self.env.context.get("allow_during_suspension")
             )
+            # Letter not 'terminated', 'canceled', or a 'draft'. AND not on hold
             is_allowed = (
                 sponsorship.state not in ["terminated", "cancelled", "draft"]
                 and not hold_letters
             )
+            # If 'terminated' but not on hold, check if within allowed
+            # time since end date
             if sponsorship.state == "terminated" and not hold_letters:
                 is_allowed = (now - sponsorship.end_date).days <= int(days_allowed)
             sponsorship.can_write_letter = is_allowed


### PR DESCRIPTION
- FIX: language detector now overwrites correct translation (source/target)
- FIX: correspondence created first and then sent to translation pool if applicable
- STYLE: added docstrings comments to compute write letter