### PR TITLE
T3059 fcp lifecycle events

### DIFF
--- a/child_compassion/__manifest__.py
+++ b/child_compassion/__manifest__.py
@@ -29,7 +29,7 @@
 # pylint: disable=C8101
 {
     "name": "Compassion Children",
-    "version": "14.0.1.5.0",
+    "version": "14.0.1.6.0",
     "category": "Compassion",
     "author": "Compassion CH",
     "license": "AGPL-3",

--- a/child_compassion/migrations/14.0.1.6.0/post-migration.py
+++ b/child_compassion/migrations/14.0.1.6.0/post-migration.py
@@ -1,0 +1,24 @@
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """
+    Recompute the lifecycle state & date of an FCP project
+    """
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+
+    # Fetch all projects:
+    projects = env["compassion.project"].search([])
+
+    # Invalidate cache
+    projects.invalidate_cache(["last_lifecycle_id", "suspension", "suspension"])
+
+    projects._compute_last_lifecycle()
+    projects._compute_suspension()
+
+    _logger.info("Successfully recomputed lifecycle states for %s FCPs.", len(projects))

--- a/child_compassion/migrations/14.0.1.6.0/post-migration.py
+++ b/child_compassion/migrations/14.0.1.6.0/post-migration.py
@@ -16,7 +16,7 @@ def migrate(cr, version):
     projects = env["compassion.project"].search([])
 
     # Invalidate cache
-    projects.invalidate_cache(["last_lifecycle_id", "suspension", "suspension"])
+    projects.invalidate_cache(["last_lifecycle_id", "status", "suspension"])
 
     projects._compute_last_lifecycle()
     projects._compute_suspension()

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -489,7 +489,8 @@ class CompassionProject(models.Model):
             last_info = sorted_events[0]
 
             reactivation_lifecycle = sorted_events.filtered(
-                lambda r: r.date == last_info.date and r.type == "Reactivation"
+                lambda r, _last=last_info: r.date == _last.date
+                and r.type == "Reactivation"
             )
 
             # If it exists, lifecycle with type 'Reactivation' is determinant

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -483,8 +483,7 @@ class CompassionProject(models.Model):
 
             # Sort lifecycle events by date descending
             sorted_events = project.lifecycle_ids.sorted(
-                key=lambda r: (str(r.date or ''), r.id),
-                reverse=True
+                key=lambda r: (str(r.date or ""), r.id), reverse=True
             )
             # Take first (newest) event
             last_info = sorted_events[0]
@@ -494,8 +493,9 @@ class CompassionProject(models.Model):
             )
 
             # If it exists, lifecycle with type 'Reactivation' is determinant
-            project.last_lifecycle_id = reactivation_lifecycle[0] if reactivation_lifecycle else last_info
-
+            project.last_lifecycle_id = (
+                reactivation_lifecycle[0] if reactivation_lifecycle else last_info
+            )
 
     @api.depends("lifecycle_ids", "lifecycle_ids.write_date")
     def _compute_suspension(self):

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -477,13 +477,25 @@ class CompassionProject(models.Model):
     @api.depends("lifecycle_ids", "lifecycle_ids.date")
     def _compute_last_lifecycle(self):
         for project in self:
-            last_info = project.lifecycle_ids[:1]
-            reactivation_lifecycle = project.lifecycle_ids.filtered(
-                lambda r, _last=last_info: r.date == _last.date
-                and r.type == "Reactivation"
-            )[:1]
+            if not project.lifecycle_ids:
+                project.last_lifecycle_id = False
+                continue
+
+            # Sort lifecycle events by date descending
+            sorted_events = project.lifecycle_ids.sorted(
+                key=lambda r: (str(r.date or ''), r.id),
+                reverse=True
+            )
+            # Take first (newest) event
+            last_info = sorted_events[0]
+
+            reactivation_lifecycle = sorted_events.filtered(
+                lambda r: r.date == last_info.date and r.type == "Reactivation"
+            )
+
             # If it exists, lifecycle with type 'Reactivation' is determinant
-            project.last_lifecycle_id = reactivation_lifecycle or last_info
+            project.last_lifecycle_id = reactivation_lifecycle[0] if reactivation_lifecycle else last_info
+
 
     @api.depends("lifecycle_ids", "lifecycle_ids.write_date")
     def _compute_suspension(self):

--- a/child_compassion/views/project_compassion_view.xml
+++ b/child_compassion/views/project_compassion_view.xml
@@ -87,7 +87,9 @@
                                 </group>
                                 <group string="Lifecycle">
                                     <field name="lifecycle_ids">
-                                        <tree>
+                                        <tree
+                      default_order="date desc, id desc"
+                    >
                                             <field name="create_date" />
                                             <field name="date" />
                                             <field name="type" />


### PR DESCRIPTION
- FIX: take all events, sort by date descending, take first date and calculate state according to this event
- FIX: post-migration script should now update the last event date on all projects
- FIX: changed the sorting of the lifecycle events in the projects view
- FIX: updated module version