### PR TITLE
[T3241] FIX: keep departed sponsorship invoices until exit communication is sent

### DIFF
--- a/partner_communication_compassion/__manifest__.py
+++ b/partner_communication_compassion/__manifest__.py
@@ -39,6 +39,7 @@
         "partner_salutation",
         "sbc_compassion",
         "report_wkhtmltopdf_param",  # OCA/reporting-engine
+        "sponsorship_sub_management",
     ],
     "data": [
         "data/major_revision_emails.xml",

--- a/partner_communication_compassion/models/contracts.py
+++ b/partner_communication_compassion/models/contracts.py
@@ -60,10 +60,12 @@ class RecurringContract(models.Model):
             "sponsorship_compassion.end_reason_depart", raise_if_not_found=False
         )
         for contract in self:
-            contract.exit_communication_pending = (
+            contract.exit_communication_pending = bool(
                 contract.state == "terminated"
                 and contract.end_reason_id == depart
                 and not contract.exit_communication_sent
+                and contract.child_id
+                and contract.type.startswith("S")
             )
 
     ##########################################################################

--- a/partner_communication_compassion/models/contracts.py
+++ b/partner_communication_compassion/models/contracts.py
@@ -36,6 +36,12 @@ class RecurringContract(models.Model):
         "transmitted to the sponsor."
     )
     exit_communication_sent = fields.Datetime()
+    exit_communication_pending = fields.Boolean(
+        compute="_compute_exit_communication_pending",
+        help="A child departure was registered but the exit communication has "
+        "not been sent to the sponsor yet. Sponsor-facing changes (invoice "
+        "cleanup, donations page) are held back until it is sent.",
+    )
 
     @api.onchange("origin_id", "correspondent_id")
     def _do_not_send_letter_to_transfer(self):
@@ -48,9 +54,34 @@ class RecurringContract(models.Model):
         else:
             self.send_introduction_letter = True
 
+    @api.depends("state", "end_reason_id", "exit_communication_sent")
+    def _compute_exit_communication_pending(self):
+        depart = self.env.ref("sponsorship_compassion.end_reason_depart")
+        for contract in self:
+            contract.exit_communication_pending = (
+                contract.state == "terminated"
+                and contract.end_reason_id == depart
+                and not contract.exit_communication_sent
+            )
+
     ##########################################################################
     #                             PUBLIC METHODS                             #
     ##########################################################################
+    def cancel_contract_invoices(self):
+        """Defer invoice cleanup for child departures until the exit
+        communication has been sent.
+
+        The termination itself (state, end_date, SDS sub workflow, ...) still
+        happens immediately so that the staff sees the departure. Only the
+        invoice cleanup that would lower the sponsor's amount is held back; it
+        is triggered later from ``partner.communication.job.send`` once the
+        exit communication has been sent to the sponsor.
+        """
+        immediate = self.filtered(lambda c: not c.exit_communication_pending)
+        if immediate:
+            super(RecurringContract, immediate).cancel_contract_invoices()
+        return True
+
     def send_communication(self, communication, correspondent=True, both=False):
         """Sends a communication to selected sponsorships.
         :param communication: the communication config to use

--- a/partner_communication_compassion/models/contracts.py
+++ b/partner_communication_compassion/models/contracts.py
@@ -56,7 +56,9 @@ class RecurringContract(models.Model):
 
     @api.depends("state", "end_reason_id", "exit_communication_sent")
     def _compute_exit_communication_pending(self):
-        depart = self.env.ref("sponsorship_compassion.end_reason_depart")
+        depart = self.env.ref(
+            "sponsorship_compassion.end_reason_depart", raise_if_not_found=False
+        )
         for contract in self:
             contract.exit_communication_pending = (
                 contract.state == "terminated"
@@ -77,9 +79,10 @@ class RecurringContract(models.Model):
         is triggered later from ``partner.communication.job.send`` once the
         exit communication has been sent to the sponsor.
         """
-        immediate = self.filtered(lambda c: not c.exit_communication_pending)
-        if immediate:
-            super(RecurringContract, immediate).cancel_contract_invoices()
+        deferred = self.filtered("exit_communication_pending")
+        to_clean = self - deferred
+        if to_clean:
+            super(RecurringContract, to_clean).cancel_contract_invoices()
         return True
 
     def send_communication(self, communication, correspondent=True, both=False):

--- a/partner_communication_compassion/models/partner_communication.py
+++ b/partner_communication_compassion/models/partner_communication.py
@@ -164,15 +164,17 @@ class PartnerCommunication(models.Model):
             for child in biennials.get_objects():
                 child.sponsorship_ids[0].new_picture = False
         exit_confs = self.env.ref(
-            "partner_communication_compassion.lifecycle_child_planned_exit"
+            "partner_communication_compassion.planned_exit_notification"
         ) + self.env.ref(
             "partner_communication_compassion.lifecycle_child_unplanned_exit"
         )
         exits = self.filtered(lambda j: j.state == "done" and j.config_id in exit_confs)
         if exits:
-            exits.get_objects().write(
-                {"exit_communication_sent": fields.Datetime.now()}
-            )
+            contracts = exits.get_objects()
+            contracts.write({"exit_communication_sent": fields.Datetime.now()})
+            # The sponsor has now been informed: run the invoice cleanup that
+            # was deferred when the departure was registered.
+            contracts.cancel_contract_invoices()
         return res
 
     def cancel(self):

--- a/partner_communication_compassion/models/partner_communication.py
+++ b/partner_communication_compassion/models/partner_communication.py
@@ -164,7 +164,7 @@ class PartnerCommunication(models.Model):
             for child in biennials.get_objects():
                 child.sponsorship_ids[0].new_picture = False
         exit_confs = self.env.ref(
-            "partner_communication_compassion.planned_exit_notification"
+            "partner_communication_compassion.lifecycle_child_planned_exit"
         ) + self.env.ref(
             "partner_communication_compassion.lifecycle_child_unplanned_exit"
         )

--- a/partner_communication_compassion/models/partner_communication.py
+++ b/partner_communication_compassion/models/partner_communication.py
@@ -171,10 +171,13 @@ class PartnerCommunication(models.Model):
         exits = self.filtered(lambda j: j.state == "done" and j.config_id in exit_confs)
         if exits:
             contracts = exits.get_objects()
+            # Capture the departures still pending cleanup BEFORE the stamp below
+            # flips exit_communication_pending to False; only those need the
+            # deferred invoice cleanup (avoids re-triggering it on re-sends or
+            # contracts already cleaned by the old flow).
+            to_clean = contracts.filtered("exit_communication_pending")
             contracts.write({"exit_communication_sent": fields.Datetime.now()})
-            # The sponsor has now been informed: run the invoice cleanup that
-            # was deferred when the departure was registered.
-            contracts.cancel_contract_invoices()
+            to_clean.cancel_contract_invoices()
         return res
 
     def cancel(self):

--- a/partner_communication_compassion/views/contract_view.xml
+++ b/partner_communication_compassion/views/contract_view.xml
@@ -32,4 +32,29 @@
             </filter>
         </field>
     </record>
+
+    <!-- Flag SDS sub-management cards whose exit communication is still pending. -->
+    <record id="view_follow_contract_kanban_exit_pending" model="ir.ui.view">
+        <field name="name">follow.contract.kanban.exit.pending</field>
+        <field name="model">recurring.contract</field>
+        <field
+      name="inherit_id"
+      ref="sponsorship_sub_management.view_follow_contract_kanban_compassion"
+    />
+        <field name="arch" type="xml">
+            <field name="state" position="after">
+                <field name="exit_communication_pending" />
+            </field>
+            <xpath expr="//div[hasclass('o_kanban_footer')]" position="before">
+                <div
+          t-if="record.exit_communication_pending.raw_value"
+          class="text-warning"
+        >
+                    <i
+            class="fa fa-exclamation-triangle"
+          /> Awaiting exit communication
+                </div>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/partner_communication_compassion/views/partner_compassion_view.xml
+++ b/partner_communication_compassion/views/partner_compassion_view.xml
@@ -17,4 +17,68 @@
             </field>
         </field>
     </record>
+
+    <!-- Highlight terminated sponsorships whose exit communication has not yet
+         been sent to the sponsor (departure pending communication). -->
+    <record id="view_res_partner_sponsorships_exit_pending" model="ir.ui.view">
+        <field name="name">res.partner.sponsorships.exit.pending</field>
+        <field name="model">res.partner</field>
+        <field
+      name="inherit_id"
+      ref="sponsorship_compassion.view_res_partner_invoice_line_button_form"
+    />
+        <field name="arch" type="xml">
+            <xpath
+        expr="//field[@name='contracts_paid']/tree"
+        position="attributes"
+      >
+                <attribute
+          name="decoration-muted"
+        >state in ('terminated','cancelled') and not exit_communication_pending</attribute>
+                <attribute
+          name="decoration-warning"
+        >exit_communication_pending</attribute>
+            </xpath>
+            <xpath
+        expr="//field[@name='contracts_paid']/tree/field[@name='state']"
+        position="after"
+      >
+                <field name="exit_communication_pending" invisible="1" />
+            </xpath>
+            <xpath
+        expr="//field[@name='contracts_correspondant']/tree"
+        position="attributes"
+      >
+                <attribute
+          name="decoration-muted"
+        >state in ('terminated','cancelled') and not exit_communication_pending</attribute>
+                <attribute
+          name="decoration-warning"
+        >exit_communication_pending</attribute>
+            </xpath>
+            <xpath
+        expr="//field[@name='contracts_correspondant']/tree/field[@name='state']"
+        position="after"
+      >
+                <field name="exit_communication_pending" invisible="1" />
+            </xpath>
+            <xpath
+        expr="//field[@name='contracts_fully_managed']/tree"
+        position="attributes"
+      >
+                <attribute
+          name="decoration-muted"
+        >state in ('terminated','cancelled') and not exit_communication_pending</attribute>
+                <attribute
+          name="decoration-warning"
+        >exit_communication_pending</attribute>
+            </xpath>
+            <xpath
+        expr="//field[@name='contracts_fully_managed']/tree/field[@name='state']"
+        position="after"
+      >
+                <field name="exit_communication_pending" invisible="1" />
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/partner_communication_compassion/views/partner_compassion_view.xml
+++ b/partner_communication_compassion/views/partner_compassion_view.xml
@@ -19,7 +19,7 @@
     </record>
 
     <!-- Highlight terminated sponsorships whose exit communication has not yet
-         been sent to the sponsor (departure pending communication). -->
+         been sent to the sponsor -->
     <record id="view_res_partner_sponsorships_exit_pending" model="ir.ui.view">
         <field name="name">res.partner.sponsorships.exit.pending</field>
         <field name="model">res.partner</field>


### PR DESCRIPTION


- FIX: keep invoices on a terminated departure until the exit communication is sent (exit_communication_pending flag + cancel_contract_invoices override; cleanup is triggered from communication send())
- FEAT: flag pending departures for SDS — orange rows in the partner Sponsorships tab and a tag in the sub-management kanban