### PR TITLE
[T3244] FIX: open log-interaction wizard when interaction resume is empty

### DIFF
--- a/interaction_resume/static/src/js/tree_button.js
+++ b/interaction_resume/static/src/js/tree_button.js
@@ -61,7 +61,9 @@ odoo.define("interaction_resume.tree_button", function (require) {
 
     _onLogInteraction: function () {
       var self = this;
-      var context = this.model.get(this.handle).data[0].context;
+      var state = this.model.get(this.handle);
+      var context =
+        (state.data[0] && state.data[0].context) || state.getContext();
 
       if (!context) {
         console.log("No context to log interaction");

--- a/interaction_resume/static/src/js/tree_button.js
+++ b/interaction_resume/static/src/js/tree_button.js
@@ -62,8 +62,7 @@ odoo.define("interaction_resume.tree_button", function (require) {
     _onLogInteraction: function () {
       var self = this;
       var state = this.model.get(this.handle);
-      var context =
-        (state.data[0] && state.data[0].context) || state.getContext();
+      var context = (state.data[0] && state.data[0].context) || state.context;
 
       if (!context) {
         console.log("No context to log interaction");


### PR DESCRIPTION
Fall back to the list context when the resume has no rows, so data[0] is no longer read on an empty list.