### PR TITLE
T3271 - FIX Wrong message at sponsorship creation

### DIFF
--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -504,7 +504,7 @@ class SponsorshipContract(models.Model):
         for contract in self:
             contract.is_direct_debit = contract.payment_mode_id in dd_modes
 
-    @api.depends("payment_mode_id")
+    @api.depends("payment_mode_id", "child_id", "birthday_invoice", "christmas_invoice")
     def _compute_is_gift_auth(self):
         for contract in self:
             contract.is_gift_authorized = contract.child_id


### PR DESCRIPTION
The bug was in the @api.depends decorator (line 507) — it only lists payment_mode_id but the compute body also reads child_id, birthday_invoice, and christmas_invoice. So when you add a child on a new form, the compute doesn't re-run, is_gift_authorized stays False from the previous run, and the view shows the warning even though no annual gift is set.