### PR TITLE
FIX: allow non-officer users to open their profile

### DIFF
--- a/crm_request/models/res_users.py
+++ b/crm_request/models/res_users.py
@@ -27,9 +27,11 @@ class ResUsers(models.Model):
         AccessError for non-officer employees.
         """
         super().__init__(pool, cr)
-        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + [
-            "do_reminder_support_req"
-        ]
-        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + [
-            "do_reminder_support_req"
-        ]
+        if "do_reminder_support_req" not in type(self).SELF_READABLE_FIELDS:
+            type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + [
+                "do_reminder_support_req"
+            ]
+        if "do_reminder_support_req" not in type(self).SELF_WRITEABLE_FIELDS:
+            type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + [
+                "do_reminder_support_req"
+            ]

--- a/crm_request/models/res_users.py
+++ b/crm_request/models/res_users.py
@@ -19,3 +19,17 @@ class ResUsers(models.Model):
         "you're assigned to",
         default=True,
     )
+
+    def __init__(self, pool, cr):
+        """Allow users to read/write this preference on their own profile,
+        even without HR Officer rights. Without this, the field breaks the
+        res.users self-read bypass and the whole profile page fails with an
+        AccessError for non-officer employees.
+        """
+        super().__init__(pool, cr)
+        type(self).SELF_READABLE_FIELDS = type(self).SELF_READABLE_FIELDS + [
+            "do_reminder_support_req"
+        ]
+        type(self).SELF_WRITEABLE_FIELDS = type(self).SELF_WRITEABLE_FIELDS + [
+            "do_reminder_support_req"
+        ]


### PR DESCRIPTION
Register do_reminder_support_req as self-readable/writeable so the res.users self-read bypass works for employees without HR Officer rights.