### PR TITLE
T3067 my compassion 18.0 migration

### DIFF
--- a/partner_salutation/__manifest__.py
+++ b/partner_salutation/__manifest__.py
@@ -30,7 +30,7 @@
 {
     "name": "Compassion Partner Communications",
     "summary": "Adds a salutation field on partners",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "development_status": "Production/Stable",
     "category": "Partner Management",
     "website": "https://github.com/CompassionCH/compassion-modules",

--- a/partner_salutation/migrations/18.0.1.1.0/post-migration.py
+++ b/partner_salutation/migrations/18.0.1.1.0/post-migration.py
@@ -1,0 +1,41 @@
+##############################################################################
+#
+#    Copyright (C) 2026 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#    @author: Noé Berdoz <nberdoz@compassion.ch>
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+# Salutations offered on the public-facing forms by default. Curators adjust
+# the set afterwards from the title list; this only sets the initial value.
+DEFAULT_PUBLIC_TITLE_XMLIDS = [
+    "base.res_partner_title_mister",
+    "base.res_partner_title_madam",
+]
+
+
+def migrate(cr, version):
+    """Set the initial value of res.partner.title.is_shown_on_public_forms.
+
+    Runs once on the upgrade that introduces the field. Curators own the set
+    from then on, and later upgrades leave their choices untouched.
+    """
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    titles = env["res.partner.title"]
+    for xmlid in DEFAULT_PUBLIC_TITLE_XMLIDS:
+        title = env.ref(xmlid, raise_if_not_found=False)
+        if title:
+            titles |= title
+    if titles:
+        titles.is_shown_on_public_forms = True
+        _logger.info(
+            "Seeded is_shown_on_public_forms on default public titles: %s",
+            titles.mapped("name"),
+        )

--- a/partner_salutation/models/res_partner_title.py
+++ b/partner_salutation/models/res_partner_title.py
@@ -22,3 +22,8 @@ class ResPartnerTitle(models.Model):
 
     plural = fields.Boolean()
     order_index = fields.Integer()
+    is_shown_on_public_forms = fields.Boolean(
+        help="If set, this salutation is offered in the public-facing forms "
+        "(sponsorship wizard, donation, project creation). When unset, the "
+        "salutation stays usable in the backend but is hidden from those forms.",
+    )

--- a/partner_salutation/views/res_partner_title_view.xml
+++ b/partner_salutation/views/res_partner_title_view.xml
@@ -8,6 +8,7 @@
                 <field name="gender" />
                 <field name="plural" />
                 <field name="order_index" widget="handle" />
+                <field name="is_shown_on_public_forms" />
             </field>
         </field>
     </record>

--- a/sponsorship_compassion/models/res_partner.py
+++ b/sponsorship_compassion/models/res_partner.py
@@ -40,6 +40,7 @@ class ResPartner(models.Model):
         required=True,
     )
     global_id = fields.Char("Global ID", copy=False)
+    legal_agreement_date = fields.Datetime("Date of legal agreement", tracking=True)
     contracts_fully_managed = fields.One2many(
         "recurring.contract",
         compute="_compute_related_contracts",
@@ -464,6 +465,7 @@ class ResPartner(models.Model):
                 "title": False,
                 "country_id": False,
                 "uuid": False,
+                "legal_agreement_date": False,
             }
         )
         partner.env["mail.mail"].search([("recipient_ids", "=", partner.id)]).unlink()

--- a/sponsorship_compassion/tests/test_project_compassion.py
+++ b/sponsorship_compassion/tests/test_project_compassion.py
@@ -6,9 +6,10 @@ child_compassion
 import random
 from unittest.mock import patch
 
+from dateutil.relativedelta import relativedelta
+
 from odoo import fields
 from odoo.tests import TransactionCase
-from odoo.tools import relativedelta
 
 PROJECT_COMPASSION_ADDON = (
     "odoo.addons.child_compassion.models.project_compassion.CompassionProject"

--- a/sponsorship_compassion/views/res_partner_view.xml
+++ b/sponsorship_compassion/views/res_partner_view.xml
@@ -14,6 +14,7 @@
             <field name="uuid" position="after">
                 <field name="is_church" invisible="1" />
                 <field name="church_id" invisible="is_company or is_church" />
+                <field name="legal_agreement_date" />
             </field>
 
             <!-- Replace parent position of reference and global numbers -->

--- a/thankyou_letters/tests/test_thankyou_config.py
+++ b/thankyou_letters/tests/test_thankyou_config.py
@@ -7,10 +7,10 @@
 #
 ##############################################################################
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 
-class TestThankYouLetters(SavepointCase):
+class TestThankYouLetters(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()

--- a/thankyou_letters/tests/test_thankyou_letters.py
+++ b/thankyou_letters/tests/test_thankyou_letters.py
@@ -9,12 +9,12 @@
 import logging
 import time
 
-from odoo.tests import SavepointCase
+from odoo.tests import TransactionCase
 
 logger = logging.getLogger(__name__)
 
 
-class TestThankYouLetters(SavepointCase):
+class TestThankYouLetters(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()


### PR DESCRIPTION
# [MIG] T3067: shared fields for the MyCompassion portal (Odoo 18)

This PR adds two shared fields that the MyCompassion portal needs after the old
`website_sponsorship` module was removed. The fields used to live in that module,
so they had to move to a base module that stays.

**Please merge this PR first.** The other two PRs below depend on these fields.

## Key changes

- **partner_salutation**: add `is_shown_on_public_forms` on `res.partner.title`.
  This flag decides which titles (Mister, Madam, ...) are shown in public forms.
  A post-migration script seeds Mister and Madam so they keep showing.
- **sponsorship_compassion**: move `legal_agreement_date` onto `res.partner`
  (it lived in the deleted `website_sponsorship`) and show it on the partner form.
- Small test fixes for Odoo 18.

## Related PRs (please review together)

This is one part of a 3-repo migration. The reviewer of this PR is also concerned
by the other two:

- **compassion-modules (this PR):** https://github.com/CompassionCH/compassion-modules/pull/2108
- compassion-website: https://github.com/CompassionCH/compassion-website/pull/341
- compassion-switzerland: https://github.com/CompassionCH/compassion-switzerland/pull/1763

Merge order: **compassion-modules** first, then compassion-website, then compassion-switzerland.
