### PR TITLE
[T3314] Donations linked to events silently lose their event association since the analytic multi-plan migration

### DIFF
--- a/crm_compassion/models/account_move_line.py
+++ b/crm_compassion/models/account_move_line.py
@@ -26,9 +26,17 @@ class MoveLine(models.Model):
 
     @api.depends("analytic_line_ids")
     def _compute_event(self):
+        """Event analytic accounts live in the ``crm_compassion.plan_events``
+        analytic plan, whose column on account.analytic.line is not the
+        generic ``account_id`` (reserved for the root/project plan)."""
+        events_column = self.env.ref("crm_compassion.plan_events")._column_name()
         for line in self:
-            if not line.event_id and line.analytic_line_ids.account_id.event_id:
-                line.event_id = line.analytic_line_ids.account_id.event_id
+            analytic_accounts = line.analytic_line_ids.account_id | (
+                line.analytic_line_ids.mapped(events_column)
+            )
+            event = analytic_accounts.mapped("event_id")[:1]
+            if not line.event_id and event:
+                line.event_id = event
             else:
                 line.event_id = line.event_id
 


### PR DESCRIPTION
# T3314 — Donations linked to events silently lose their event association

Found while working [T0632](https://erp.compassion.ch/web#id=1208&action=521&active_id=907&model=project.task&view_type=form&cids=1&menu_id=2029). 

The whole event-thank-you pipeline couldn't be exercised on real data because `event_id` never resolved on `account.move.line`.

## Root cause

Migration commit `e43ef938 [MIG] T2713 crm_compassion: migration to 18.0` introduced a dedicated analytic plan for events (`crm_compassion.plan_events` — v14 had no concept of analytic plans, a v17+ Odoo accounting feature), and `event_compassion.py`'s `_get_analytic_vals()` assigns every new event's own analytic account to this plan. But `account.move.line._compute_event()` was carried over from the v14 code unchanged — it only ever reads the generic `analytic_line_ids.account_id` field.

Under Odoo 18's multi-plan analytics, each plan stores its account reference in its **own** dedicated column on `account.analytic.line` (`x_plan<N>_id`, N = that plan's id — resolved dynamically via `account.analytic.plan._column_name()`, `addons/analytic/models/ analytic_plan.py:115-121`); the generic `account_id` column is reserved for the root/project plan only. Since every event's own analytic account lives specifically in the "Events" plan, `_compute_event()` could never find it.

This does not fire an error anywhere, just a quietly empty field.

## What changed

- `models/account_move_line.py`: `_compute_event()` now also checks the "Events" plan's dynamic column (resolved via `_column_name()`, not hardcoded — robust to the plan having a different id in another database), in addition to the generic `account_id`.

No backfill migration was added for historical lines affected since the regression window (2026-06-04 onward in this DB) — worth a follow-up if that missing historical data matters.

## How to test manually

1. Upgrade the module (`-u crm_compassion`).
2. Create/find an event, set its analytic distribution on a donation invoice line to that event's own analytic account (`event.analytic_id`).
3. Post the invoice.
4. Check `account.move.line.event_id` — should now resolve to the event (previously always empty for any event created after 2026-06-04 in this DB, or after whichever date production hit the same migration commit).

## Video for testing manually for thank you letters

https://github.com/user-attachments/assets/f0750865-0f86-4b62-8549-e86d1a1dd565


