### PR TITLE
T3315 thankyou letter pragma lines

### DIFF
--- a/thankyou_letters/__manifest__.py
+++ b/thankyou_letters/__manifest__.py
@@ -28,7 +28,7 @@
 # pylint: disable=C8101
 {
     "name": "Thank You Letters",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "category": "Other",
     "author": "Compassion CH",
     "development_status": "Production/Stable",

--- a/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
+++ b/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
@@ -2,6 +2,7 @@ import html
 import json
 import logging
 import re
+import unicodedata
 
 from openupgradelib import openupgrade
 
@@ -19,11 +20,47 @@ PRAGMA_SET_RE = re.compile(
 # Single stray leftover with no matching "% if" anywhere in the template.
 STRAY_PRAGMA_RE = re.compile(r"^\s*%\s*endif\s*$")
 
+# Matches a variable name already converted to a real <t t-set> tag - needed
+# so this migration stays idempotent/safe to re-run on a database where an
+# earlier version of it already converted the pragma line but kept an
+# invalid (non-ASCII) varname.
+TSET_TAG_NAME_RE = re.compile(r'<t\s+t-set="(?P<name>[^"]+)"')
+
+# QWeb's <t t-set> only accepts ASCII alphanumerics/underscore in varnames;
+# some variable names use ligatures (e.g. "cœur") that aren't covered by
+# plain accent-stripping.
+_LIGATURES = {"œ": "oe", "Œ": "Oe", "æ": "ae", "Æ": "Ae"}
+
+
+def _sanitize_varname(name):
+    for src, dst in _LIGATURES.items():
+        name = name.replace(src, dst)
+    name = unicodedata.normalize("NFKD", name)
+    name = "".join(c for c in name if not unicodedata.combining(c))
+    return re.sub(r"[^0-9A-Za-z_]", "_", name)
+
 
 def _fix_body(body):
     if not body:
         return body
     body = body.replace("&amp;gt;", "&gt;").replace("&amp;lt;", "&lt;")
+
+    # Rename any variable whose name QWeb would reject, everywhere it's used
+    # (not just where it's declared) - existing t-out/t-if/t-value
+    # expressions already reference the original name. Checks both raw
+    # "% set" pragma lines and already-converted <t t-set> tags, so this
+    # stays safe to re-run regardless of which state the database is in.
+    invalid_names = set()
+    for line in body.split("\n"):
+        match = PRAGMA_SET_RE.match(line)
+        if match:
+            invalid_names.add(match["name"])
+    invalid_names.update(m["name"] for m in TSET_TAG_NAME_RE.finditer(body))
+    for name in invalid_names:
+        safe_name = _sanitize_varname(name)
+        if safe_name != name:
+            body = re.sub(rf"\b{re.escape(name)}\b", safe_name, body)
+
     lines = []
     for line in body.split("\n"):
         if STRAY_PRAGMA_RE.match(line):

--- a/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
+++ b/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
@@ -18,7 +18,10 @@ PRAGMA_SET_RE = re.compile(
 )
 
 # Single stray leftover with no matching "% if" anywhere in the template.
-STRAY_PRAGMA_RE = re.compile(r"^\s*%\s*endif\s*$")
+# Not always alone on its own line (e.g. "% endif</body>") - matched and
+# stripped as a substring, not a whole-line match, so whatever follows on
+# the same line is preserved.
+STRAY_PRAGMA_RE = re.compile(r"(?m)^[ \t]*%\s*endif[ \t]*")
 
 # Matches a variable name already converted to a real <t t-set> tag - needed
 # so this migration stays idempotent/safe to re-run on a database where an
@@ -87,8 +90,6 @@ def _fix_body(body):
     if not body:
         return body
     body = body.replace("&amp;gt;", "&gt;").replace("&amp;lt;", "&lt;")
-    body = _fix_unguarded_thanks_name(body)
-    body = body.replace(_UNSAFE_DEFAULT_CODE_STARTSWITH, _SAFE_DEFAULT_CODE_STARTSWITH)
 
     # Rename any variable whose name QWeb would reject, everywhere it's used
     # (not just where it's declared) - existing t-out/t-if/t-value
@@ -106,16 +107,25 @@ def _fix_body(body):
         if safe_name != name:
             body = re.sub(rf"\b{re.escape(name)}\b", safe_name, body)
 
+    body = STRAY_PRAGMA_RE.sub("", body)
+
     lines = []
     for line in body.split("\n"):
-        if STRAY_PRAGMA_RE.match(line):
-            continue
         match = PRAGMA_SET_RE.match(line)
         if match:
             expr = html.escape(match["expr"].strip(), quote=True)
             line = f'{match["indent"]}<t t-set="{match["name"]}" t-value="{expr}"/>'
         lines.append(line)
-    return "\n".join(lines)
+    body = "\n".join(lines)
+
+    # Must run after the pragma-to-<t t-set> conversion above: on a
+    # genuinely raw (never-migrated) template, the thanks_name ternary is
+    # still plain, unescaped "% set" text at this point (literal quotes,
+    # not yet &#x27;) - matching here first would silently no-op, leaving
+    # the crash-prone code completely unfixed on a fresh run.
+    body = _fix_unguarded_thanks_name(body)
+    body = body.replace(_UNSAFE_DEFAULT_CODE_STARTSWITH, _SAFE_DEFAULT_CODE_STARTSWITH)
+    return body
 
 
 @openupgrade.migrate()

--- a/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
+++ b/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
@@ -40,10 +40,47 @@ def _sanitize_varname(name):
     return re.sub(r"[^0-9A-Za-z_]", "_", name)
 
 
+# fr_CH accesses products[0].thanks_name (a Char field, False when unset)
+# directly and unguarded, unlike de_DE/it_IT which already define a safe
+# "thanks_name" variable ("products[0].thanks_name if ... else ''"). This
+# crashes with "'bool' object is not subscriptable"/AttributeError for any
+# product without a thanks_name (e.g. "undesignated donation") - previously
+# masked because the surrounding "% set" line never actually executed.
+_FR_UNSAFE_THANKS_NAME_TERNARY = (
+    "(products[0].thanks_name if products[0].thanks_name[:1] in "
+    "(&#x27;.&#x27;,&#x27;!&#x27;,&#x27;?&#x27;) else &#x27; &#x27;"
+    "+products[0].thanks_name)"
+)
+_FR_SAFE_THANKS_NAME_TERNARY = (
+    "(thanks_name if thanks_name[:1] in "
+    "(&#x27;.&#x27;,&#x27;!&#x27;,&#x27;?&#x27;) else &#x27; &#x27;+thanks_name)"
+)
+_FR_UNSAFE_LINE_THANKS_NAME = "line.product_id.thanks_name.replace("
+_FR_SAFE_LINE_THANKS_NAME = "(line.product_id.thanks_name or &#x27;&#x27;).replace("
+_FR_PRODUCTS_TSET = (
+    '<t t-set="products" t-value="invoice_lines.mapped(&#x27;product_id&#x27;)"/>'
+)
+
+
+def _fix_unguarded_thanks_name(body):
+    if _FR_UNSAFE_THANKS_NAME_TERNARY not in body:
+        return body
+    body = body.replace(_FR_UNSAFE_THANKS_NAME_TERNARY, _FR_SAFE_THANKS_NAME_TERNARY)
+    body = body.replace(_FR_UNSAFE_LINE_THANKS_NAME, _FR_SAFE_LINE_THANKS_NAME)
+    body = body.replace(
+        _FR_PRODUCTS_TSET,
+        _FR_PRODUCTS_TSET
+        + '\n    <t t-set="thanks_name" t-value="products[0].thanks_name if '
+        'products[0].thanks_name else &#x27;&#x27;"/>',
+    )
+    return body
+
+
 def _fix_body(body):
     if not body:
         return body
     body = body.replace("&amp;gt;", "&gt;").replace("&amp;lt;", "&lt;")
+    body = _fix_unguarded_thanks_name(body)
 
     # Rename any variable whose name QWeb would reject, everywhere it's used
     # (not just where it's declared) - existing t-out/t-if/t-value

--- a/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
+++ b/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
@@ -1,0 +1,60 @@
+import html
+import json
+import logging
+import re
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+# "% set NAME=EXPR" is a non-standard shorthand that was never converted to a
+# real QWeb <t t-set> directive. QWeb only interprets t-* attributes on
+# elements, so these lines were rendered verbatim as literal text in every
+# sent thank you letter, and the variables they were meant to define stayed
+# unset (leaving dependent sentences blank).
+PRAGMA_SET_RE = re.compile(
+    r"^(?P<indent>\s*)%\s*set\s+(?P<name>[^\s=]+)\s*=\s*(?P<expr>.*)$"
+)
+
+# Single stray leftover with no matching "% if" anywhere in the template.
+STRAY_PRAGMA_RE = re.compile(r"^\s*%\s*endif\s*$")
+
+
+def _fix_body(body):
+    if not body:
+        return body
+    body = body.replace("&amp;gt;", "&gt;").replace("&amp;lt;", "&lt;")
+    lines = []
+    for line in body.split("\n"):
+        if STRAY_PRAGMA_RE.match(line):
+            continue
+        match = PRAGMA_SET_RE.match(line)
+        if match:
+            expr = html.escape(match["expr"].strip(), quote=True)
+            line = f'{match["indent"]}<t t-set="{match["name"]}" t-value="{expr}"/>'
+        lines.append(line)
+    return "\n".join(lines)
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    template = env.ref("thankyou_letters.thankyou_letter_template")
+    env.cr.execute("SELECT body_html FROM mail_template WHERE id = %s", (template.id,))
+    (body_html,) = env.cr.fetchone()
+    if not body_html:
+        return
+
+    fixed = {lang: _fix_body(body) for lang, body in body_html.items()}
+    if fixed == body_html:
+        _logger.info("thankyou_letter_template: nothing to fix")
+        return
+
+    env.cr.execute(
+        "UPDATE mail_template SET body_html = %s WHERE id = %s",
+        (json.dumps(fixed), template.id),
+    )
+    _logger.info(
+        "thankyou_letter_template: fixed raw pragma lines / double-escaped "
+        "entities for languages: %s",
+        ", ".join(lang for lang in fixed if fixed[lang] != body_html.get(lang)),
+    )

--- a/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
+++ b/thankyou_letters/migrations/18.0.1.0.1/post-migration.py
@@ -62,6 +62,13 @@ _FR_PRODUCTS_TSET = (
 )
 
 
+# Shared by fr_CH and de_DE, both inside a previously-dead "% set" line:
+# default_code is a Char field, False for any product without one, and
+# .startswith() raises AttributeError on a bool.
+_UNSAFE_DEFAULT_CODE_STARTSWITH = "products[0].default_code.startswith("
+_SAFE_DEFAULT_CODE_STARTSWITH = "(products[0].default_code or &#x27;&#x27;).startswith("
+
+
 def _fix_unguarded_thanks_name(body):
     if _FR_UNSAFE_THANKS_NAME_TERNARY not in body:
         return body
@@ -81,6 +88,7 @@ def _fix_body(body):
         return body
     body = body.replace("&amp;gt;", "&gt;").replace("&amp;lt;", "&lt;")
     body = _fix_unguarded_thanks_name(body)
+    body = body.replace(_UNSAFE_DEFAULT_CODE_STARTSWITH, _SAFE_DEFAULT_CODE_STARTSWITH)
 
     # Rename any variable whose name QWeb would reject, everywhere it's used
     # (not just where it's declared) - existing t-out/t-if/t-value


### PR DESCRIPTION
# T3315 — Thank you letter message has raw pragma lines

Found while working [T0632](https://erp.compassion.ch/web#id=1208&action=521&active_id=907&model=project.task&view_type=form&cids=1&menu_id=2029)/[T3314](https://erp.compassion.ch/web#id=3907&action=521&active_id=895&model=project.task&view_type=form&cids=1&menu_id=2029)

Once T3314 let a real communication job actually get created and rendered, the resulting email showed raw code text instead of the intended letter.

## Root cause

The "Donation - Thank You Letter" template (`mail.template` id 94, xmlid `thankyou_letters.thankyou_letter_template`) — the primary email/letter sent to donors — has a `body_html` containing raw `% set VAR = expr` shorthand lines as literal text, not real QWeb `<t t-set>` tags. QWeb only interprets `t-*` attributes on elements, not arbitrary "%"-prefixed text, so these lines were never executed: they rendered verbatim as garbage code in every sent thank-you letter, and any content depending on those variables (e.g. the core "thank you for your donation of X" sentence) came out blank.

The template's content is entirely DB-only — the tracked source (`thankyou_letters/data/email_template.xml`) is `noupdate="1"` with just a trivial 4-line placeholder, completely unrelated to what's actually running. No tracked "correct" version exists to diff against or restore from; the fix had to be written as a migration that corrects the live content mechanically.

Fixing the `% set` syntax alone uncovered two further latent bugs, both inside what used to be dead code (i.e. never actually executed before, since the surrounding `% set` line never ran):

- **`fr_CH`**: `products[0].thanks_name` (a `Char` field, `False` when unset) was accessed unguarded in two spots. Crashes with `'bool' object is not subscriptable` for any product without a `thanks_name` set (e.g. "undesignated donation" — confirmed ~real product used in testing). de_DE`/`it_IT` already used a safe `thanks_name if thanks_name else ''` pattern; `fr_CH` didn't.
- **`fr_CH` and `de_DE`**: both called `.startswith()` on `default_code` (also `False` when unset) unguarded. In the dev DB, 71 of 349 thankable products (~20%) have no `default_code` at all — a real, substantial risk, not theoretical.

Both would have made things **worse**, not better, if left unfixed: instead of a garbled-but-sent letter (the pre-existing bug), the letter would crash and never send at all for a large class of real donations.

## What changed

1. Convert `% set NAME=EXPR` lines to `<t t-set="NAME" t-value="EXPR"/>`, unescape double-escaped `&amp;gt;`/`&amp;lt;` entities (a separate, smaller corruption in the same template, found and fixed live via direct SQL before this migration existed, then folded into it for reproducibility), and drop one stray orphaned `% endif` in `it_IT`.
2. Sanitize non-ASCII pragma variable names (QWeb's `<t t-set>` only accepts ASCII alphanumerics/underscore — `fr_CH`'s  `Merci_de_tout_cœur_pour_votre_don` failed to compile otherwise), renamed everywhere it's referenced, not just where declared.
3. Guard the unguarded `thanks_name` access in `fr_CH`.
4. Guard the unguarded `default_code.startswith()` in `fr_CH`/`de_DE`.

The migration is idempotent/safe to re-run regardless of which of these states a given database is currently in (handles both raw `% set` text and already-converted-but-invalid `<t t-set>` tags).

## How to test manually

1. Reset `ir_module_module.latest_version` for `thankyou_letters` back to its previous version if it's already been applied once, so `-u` re-triggers the migration (`# UPDATE ir_module_module SET latest_version = '18.0.1.0.0' WHERE name = 'thankyou_letters';`). **The migration is currently idempotent**
2. Upgrade the module (`-u thankyou_letters`).
3. Trigger a real thank-you letter (see T3314's testing steps or **see the video below** — needs an event-linked, `requires_thankyou` donation, posted and paid).
4. Open the resulting `partner.communication.job`, click **Send**, and check the actual email via MailHog (`http://localhost:8025`) — should read as a normal, clean letter with no visible `%`/code text, and the correct donation amount / ambassador name / event name.
5. Test with a product that has **no** `thanks_name` and **no** `default_code` set, in `fr_CH`, to specifically exercise the two previously-crashing guards.

## Video for manually test the communication with thank you letters

https://github.com/user-attachments/assets/f0750865-0f86-4b62-8549-e86d1a1dd565
