### PR TITLE
T2965 move out the quality check button

### DIFF
--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -48,6 +48,14 @@
         <field name="binding_type">action</field>
     </record>
 
+    <record id="action_quality_check_failed_menu" model="ir.actions.server">
+        <field name="name">Quality Check Failed</field>
+        <field name="model_id" ref="sbc_compassion.model_correspondence" />
+        <field name="state">code</field>
+        <field name="code">records.quality_check_failed()</field>
+        <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />
+        <field name="binding_type">action</field>
+    </record>
 
     <record id="view_correspondence_form" model="ir.ui.view">
         <field name="name">correspondence.form</field>
@@ -86,14 +94,7 @@
                 <sheet>
                     <field name="report_needs_overlay" invisible="True" />
                     <div name="button_box">
-                        <button
-              name="quality_check_failed"
-              type="object"
-              string="Quality Check Failed"
-              invisible="state in ('Printed and sent to ICP', 'Quality check unsuccessful') or direction == 'Beneficiary To Supporter'"
-              class="bg-warning"
-              icon="fa-times"
-            />
+<!--                        <button name="quality_check_failed" type="object" string="Quality Check Failed" invisible="state in ('Printed and sent to ICP', 'Quality check unsuccessful') or direction == 'Beneficiary To Supporter'" class="bg-warning" icon="fa-times"/>-->
                         <button
               name="spread_text_to_pages"
               type="object"

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -48,15 +48,15 @@
         <field name="binding_type">action</field>
     </record>
 
+<!-- Server action to fail quality check -->
     <record id="action_quality_check_failed_menu" model="ir.actions.server">
         <field name="name">Quality Check Failed</field>
         <field name="model_id" ref="sbc_compassion.model_correspondence" />
         <field name="state">code</field>
         <field name="code">
-# records.quality_check_failed()
 for record in records:
     if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
-        raise UserError("You cannot fail the quality check for this letter in its current state or direction.")
+        raise UserError("Failed quality check action cannot be performed for this letter.")
     record.quality_check_failed()
         </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -52,9 +52,16 @@
         <field name="name">Quality Check Failed</field>
         <field name="model_id" ref="sbc_compassion.model_correspondence" />
         <field name="state">code</field>
-        <field name="code">records.quality_check_failed()</field>
+        <field name="code">
+    # records.quality_check_failed()
+    for record in records:
+        if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
+            raise odoo.exceptions.UserError("You cannot fail the quality check for this letter in its current state or direction.")
+        record.quality_check_failed()
+        </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />
         <field name="binding_type">action</field>
+        <field name="binding_view_types">form</field>
     </record>
 
     <record id="view_correspondence_form" model="ir.ui.view">

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -54,10 +54,10 @@
         <field name="model_id" ref="sbc_compassion.model_correspondence" />
         <field name="state">code</field>
         <field name="code">
-for record in records:
-    if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
-        raise UserError("Failed quality check action cannot be performed for this letter.")
-    record.quality_check_failed()
+invalid_records = records.filtered(lambda r: r.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or r.direction == 'Beneficiary To Supporter')
+if invalid_records:
+    raise UserError(_("Failed quality check action cannot be performed for this letter."))
+records.quality_check_failed()
         </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />
         <field name="binding_type">action</field>

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -56,7 +56,7 @@
 # records.quality_check_failed()
 for record in records:
     if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
-        raise odoo.exceptions.UserError("You cannot fail the quality check for this letter in its current state or direction.")
+        raise UserError("You cannot fail the quality check for this letter in its current state or direction.")
     record.quality_check_failed()
         </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -56,7 +56,7 @@
         <field name="code">
 invalid_records = records.filtered(lambda r: r.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or r.direction == 'Beneficiary To Supporter')
 if invalid_records:
-    raise UserError(_("Failed quality check action cannot be performed for this letter."))
+    raise UserError(env._("Failed quality check action cannot be performed for this letter."))
 records.quality_check_failed()
         </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />
@@ -101,7 +101,6 @@ records.quality_check_failed()
                 <sheet>
                     <field name="report_needs_overlay" invisible="True" />
                     <div name="button_box">
-<!--                        <button name="quality_check_failed" type="object" string="Quality Check Failed" invisible="state in ('Printed and sent to ICP', 'Quality check unsuccessful') or direction == 'Beneficiary To Supporter'" class="bg-warning" icon="fa-times"/>-->
                         <button
               name="spread_text_to_pages"
               type="object"

--- a/sbc_compassion/views/correspondence_view.xml
+++ b/sbc_compassion/views/correspondence_view.xml
@@ -53,11 +53,11 @@
         <field name="model_id" ref="sbc_compassion.model_correspondence" />
         <field name="state">code</field>
         <field name="code">
-    # records.quality_check_failed()
-    for record in records:
-        if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
-            raise odoo.exceptions.UserError("You cannot fail the quality check for this letter in its current state or direction.")
-        record.quality_check_failed()
+# records.quality_check_failed()
+for record in records:
+    if record.state in ('Printed and sent to ICP', 'Quality check unsuccessful') or record.direction == 'Beneficiary To Supporter':
+        raise odoo.exceptions.UserError("You cannot fail the quality check for this letter in its current state or direction.")
+    record.quality_check_failed()
         </field>
         <field name="binding_model_id" ref="sbc_compassion.model_correspondence" />
         <field name="binding_type">action</field>


### PR DESCRIPTION
### Goal
The objective of this PR is to improve the user experience  within the letter form view. Previously, the "Quality Check Failed" button was displayed as a prominent button inside the form button_box. This placement was intrusive and caused confusion, as users often mistook it for a status indicator rather than an action triggering a state change. To solve this, the action has been removed and relocated to the an action server.

### Technical Aspect

- **UI Cleanup:** Commented out/removed the old <button> widget from the view_correspondence_form definition.
- **Server Action Creation:** Introduced a new ir.actions.server named action_quality_check_failed_menu.
- **Contextual Binding:** Used binding_model_id and binding_type="action" to inject the option directly into Odoo 18's native Action dropdown menu.
- **View Restrictions:** Limited the action visibility to the form view only (binding_view_types="form").
- **Backend Security:** Moved the original XML visibility constraints into the server action's Python inline code. If a user attempts to run the action on an invalid record (e.g., an incorrect state or direction), a clean UserError is raised, blocking any database changes.

### Misc
This change strictly impacts the presentation layer; the underlying business logic in correspondence.py remains unchanged.

Extensively tested on Odoo 18 local instance: view rendering and error exceptions validate successfully.