### PR TITLE
[T2407] FIX : Correct opportunities count calculation

### DIFF
--- a/crm_compassion/models/res_partner.py
+++ b/crm_compassion/models/res_partner.py
@@ -61,21 +61,6 @@ class Partner(models.Model):
         res = portal.action_apply()
         return res
 
-    def _compute_opportunity_count(self):
-        res = super()._compute_opportunity_count()
-        for partner in self:
-            operator = "child_of" if partner.is_company else "="
-            # Using partner.ids[0] is a trick to avoid error with child_of
-            # when partner has a temporary NewId
-            partner.opportunity_count += self.env["crm.lead"].search_count(
-                [
-                    ("partner_id", operator, partner.ids[0]),
-                    ("type", "=", "opportunity"),
-                    ("active", "=", False),
-                ]
-            )
-        return res
-
     def log_call(self):
         """Prepare crm.phonecall creation."""
         self.ensure_one()


### PR DESCRIPTION
## Goal
The goal of this PR is to fix an inaccurate opportunity counter displayed on `res.partner` records. 

**History & Issue:**

_November 2025:_ A **custom** adjustment was introduced to count all historical opportunities (ongoing or archived) linked to a customer—whether an individual, a company entity, or a rollup of all individuals linked to that company.

_June 2026:_ Following an official update to the Odoo **core** `crm` and `website_crm_partner_assign` add-ons, this legacy custom code began **double-counting archived records**. This caused the UI counter to unexpectedly inflate (e.g., displaying a count of 5 instead of 3 for a partner with 1 active and 2 archived opportunities).

This PR corrects the calculation by removing the redundant logic, ensuring the pipeline overview displays accurate totals for users.

---

## Technical Aspects
The bug stemmed from a redundancy in the Method Resolution Order (MRO) inheritance chain of the `_compute_opportunity_count` function across three modules: Core `crm`, `website_crm_partner_assign`, and the compassion custom module `crm_compassion`.

* **The Core Behavior:** Standard Odoo `crm` already calculates a grand total of historical opportunities (both active and archived) out of the box using `with_context(active_test=False)`. Furthermore, it natively handles the hierarchical roll-up, meaning a member's opportunities automatically bubble up to their parent company via a `child_of` operator search.
* **The Root Cause:** The `crm_compassion` module contained a redundant override that explicitly queried archived opportunities `('active', '=', False)` and forcefully appended them to the existing tally using `+=`. Because Core Odoo had already counted these archived records in step one, this custom logic caused them to be double-counted.
* **The Solution:** The redundant `_compute_opportunity_count` method has been entirely removed from `crm_compassion`. This allows Odoo's native inheritance chain to accurately resolve the count while fully preserving the official intermediate logic `website_crm_partner_assign` and the native member-to-company hierarchical roll-up.

---

## Misc

### Testing & Verification Steps
1. Navigate to a partner/customer record with 3 active opportunities (the UI counter should display `3`).
2. Archive 2 of those opportunities (moving them to "Lost" or archiving them manually).
3. Refresh and verify the partner view: The smart button counter should accurately remain at `3` (representing 1 active + 2 archived) instead of inflating to `5`.