### PR TITLE
[T1984] FIX : Prevent automatic letter publishing on translation removal

### DIFF
--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -459,6 +459,7 @@ class Correspondence(models.Model):
             {
                 "state": "Received in the system",
                 "translator": False,
+                "new_translator_id": False,
                 "translation_status": False,
             }
         )

--- a/sbc_translation/models/correspondence.py
+++ b/sbc_translation/models/correspondence.py
@@ -449,16 +449,24 @@ class Correspondence(models.Model):
     def action_remove_local_translate(self):
         """
         Remove a letter from local translation platform and change state of
-        letter in Odoo
-        :return: None
+        letter in Odoo without triggering automated publishing or emails.
+        :return: bool
         """
         self.ensure_one()
+
+        # Reset both B2S and S2B to a clean neutral state and clear translation metadata
+        self.write(
+            {
+                "state": "Received in the system",
+                "translator": False,
+                "translation_status": False,
+            }
+        )
+
+        # Only S2B requires internal kit bundling
         if self.direction == "Supporter To Beneficiary":
-            self.state = "Received in the system"
             self.create_commkit()
-        else:
-            self.state = "Published to Global Partner"
-            self.with_context(force_publish=True).process_letter()
+
         return True
 
     def save_translation(self, letter_elements, translator_id=None, submit=False):


### PR DESCRIPTION
## Goal
Update `action_remove_local_translate` to safely remove B2S letters from the translation platform upon activation of the existing "Remove from translation" button, revert its state to `"Received in the system"`, and clean up translation metadata without triggering automated publishing or email workflows.

## Technical Aspects
* **Record Enforcement & State Reset:**
  * Enforced single-record execution using `self.ensure_one()`.
  * Updated record fields via `write()`:
    * Reverted `state` to `"Received in the system"`.
    * Cleared `translator` and `translation_status` (reset to `False`).

* **Retained The Existing Directional Handling for S2B**

## MISC
- In theory, this action intentionally avoids triggering standard automated publishing or email notifications by resetting the state to "Received in the system" (previously to "Published" which activates downstream workflows). 
- MailHog tests have been conducted in local instances but did not yield concrete validating results. Further investigation in Stage environment is advised.