### PR TITLE
T3337-FIX-UI-crash-on-Partner-Communication-list-view

### DIFF
--- a/partner_communication/views/communication_job_view.xml
+++ b/partner_communication/views/communication_job_view.xml
@@ -206,7 +206,7 @@
             <list
         decoration-primary="state == 'pending'"
         decoration-muted="state in ('done', 'cancel')"
-        decoration-danger="need_call!=False and len(activity_ids) or state == 'failure'"
+        decoration-danger="need_call and activity_ids or state == 'failure'"
       >
                 <field name="date" />
                 <field name="config_id" />


### PR DESCRIPTION
  ## Goal                                                                                                                                                                     
                                                                                                                                                                              
  Opening the Partner Communication list view (Sponsorship → Communication → Partner Communication) could crash the UI with an `UncaughtPromiseError > OwlError`, depending on
  which search filters were removed and in what order. 
          
  ## Technical aspect                                                                                                                                                         
                                                                                                                                                                              
  - `partner_communication/views/communication_job_view.xml`: rewrote the `decoration-danger` expression on the `partner.communication.job` list view from                    
    `need_call!=False and len(activity_ids) or state == 'failure'`                                                                                                            
    to                                                                                                                                                                        
    `need_call and activity_ids or state == 'failure'`.                                                                                                                       
  - The fix relies on `activity_ids` (a list/recordset) being falsy when empty.                       
                                                                                                                                                                              