### PR TITLE
T3303 recurring digital payments

### DIFF
--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -692,6 +692,12 @@ class CompassionProject(models.Model):
         last hour.
         :return:
         """
+        api_key = tools.config.get("openweathermap_api_key", "")
+        if not api_key:
+            logger.warning(
+                "Missing openweathermap_api_key, skipping weather info update."
+            )
+            return
         for project in self:
             if not project.last_weather_refresh_date or (
                 datetime.now() - project.last_weather_refresh_date > timedelta(hours=1)
@@ -703,11 +709,11 @@ class CompassionProject(models.Model):
                     + "&lon="
                     + str(project.gps_longitude)
                     + "&appid="
-                    + tools.config.get("openweathermap_api_key", ""),
+                    + api_key,
                     timeout=3,
                 ).json()
                 if json["cod"] != 200:
-                    logging.error("Could not retrieve weather info.")
+                    logger.warning("Could not retrieve weather info.")
                     continue
                 project.current_weather = json["weather"][0]["main"]
                 project.current_temperature = json["main"]["temp"]

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -694,7 +694,7 @@ class CompassionProject(models.Model):
         """
         api_key = tools.config.get("openweathermap_api_key", "")
         if not api_key:
-            logger.warning(
+            logger.debug(
                 "Missing openweathermap_api_key, skipping weather info update."
             )
             return

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -62,9 +62,7 @@ class RecurringContract(models.Model):
             # digital contracts are handled by the charge-failure pipeline instead.
             # Unpaid fees count as charge failures, so we don't send
             # sponsors double notifications.
-            search_domain.append(
-                ("payment_mode_id.payment_provider_id", "=", False)
-            )
+            search_domain.append(("payment_mode_id.payment_provider_id", "=", False))
         if not include_suspended:
             search_domain += [
                 "|",

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -58,6 +58,13 @@ class RecurringContract(models.Model):
             ("gmc_commitment_id", "!=", False),
             ("type", "like", "S"),
         ]
+        if "payment_provider_id" in self.env["account.payment.mode"]._fields:
+            # digital contracts are handled by the charge-failure pipeline instead.
+            # Unpaid fees count as charge failures, so we don't send
+            # sponsors double notifications.
+            search_domain.append(
+                ("payment_mode_id.payment_provider_id", "=", False)
+            )
         if not include_suspended:
             search_domain += [
                 "|",

--- a/partner_communication_reminder/models/recurring_contract.py
+++ b/partner_communication_reminder/models/recurring_contract.py
@@ -62,7 +62,14 @@ class RecurringContract(models.Model):
             # digital contracts are handled by the charge-failure pipeline instead.
             # Unpaid fees count as charge failures, so we don't send
             # sponsors double notifications.
-            search_domain.append(("payment_mode_id.payment_provider_id", "=", False))
+            # A NULL payment mode does not match a dotted leaf, so it needs
+            # its own term. Without it a contract with no mode gets no
+            # reminder and no charge failure either.
+            search_domain += [
+                "|",
+                ("payment_mode_id", "=", False),
+                ("payment_mode_id.payment_provider_id", "=", False),
+            ]
         if not include_suspended:
             search_domain += [
                 "|",


### PR DESCRIPTION
# T3303 — reminder exclusion for digital contracts + weather log noise

Two small changes needed by the MyCompassion card checkout.

## Key changes

- **`partner_communication_reminder`** — contracts paid by a digital payment mode are
  excluded from the months-due reminder letters. Those sponsors get the new fix-it emails
  instead, so without this they would receive both. The term is added to the search
  domain only when the field exists, so nothing breaks where the payment module is absent.
- **`child_compassion`** — the weather update no longer logs two errors per child page
  when no OpenWeatherMap key is configured. It just stays quiet.

## Depends on

- `compassion-website` — base `my_compassion` provides the digital payment mode field
  the domain term looks for. https://github.com/CompassionCH/compassion-website/pull/351
