### PR TITLE
T0492 sponsorship qr code

### DIFF
--- a/child_compassion/__manifest__.py
+++ b/child_compassion/__manifest__.py
@@ -42,7 +42,9 @@
     ],
     "external_dependencies": {
         "python": [
+            "pyqrcode",
             "pyquery",
+            "pypng",
             "pytz",
             "timezonefinder",
             "wbgapi",

--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -10,7 +10,9 @@
 import logging
 import traceback
 from datetime import date
+from urllib.parse import urlencode
 
+import pyqrcode
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
@@ -223,6 +225,10 @@ class CompassionChild(models.Model):
     # Just for migration
     delegated_comment = fields.Text()
 
+    qr_code_data = fields.Binary(
+        compute="_compute_qr_code", help="QR code for sponsoring the child"
+    )
+
     _sql_constraints = [
         ("compass_id", "unique(compass_id)", "The child already exists in database."),
         ("global_id", "unique(global_id)", "The child already exists in database."),
@@ -283,6 +289,27 @@ class CompassionChild(models.Model):
         for child in self:
             if child.pictures_ids:
                 child.fullshot = child.pictures_ids.sorted()[:1].fullshot
+
+    @api.depends_context("qr_utm_medium", "qr_utm_source", "qr_utm_campaign")
+    def _compute_qr_code(self):
+        """QR code linking to the child's online sponsorship page.
+
+        UTMs can be overridden through the context keys ``qr_utm_medium``,
+        ``qr_utm_source`` and ``qr_utm_campaign``.
+        """
+        base_url = self.get_base_url().rstrip("/")
+        utm_params = {
+            "utm_medium": self.env.context.get("qr_utm_medium") or "childpack_qr",
+            "utm_source": self.env.context.get("qr_utm_source") or "hold_campaign",
+        }
+        utm_campaign = self.env.context.get("qr_utm_campaign")
+        if utm_campaign:
+            utm_params["utm_campaign"] = utm_campaign
+        query = urlencode(utm_params)
+        for child in self:
+            url = f"{base_url}/my2/new-sponsorship/{child.id}?{query}"
+            qr = pyqrcode.create(url)
+            child.qr_code_data = qr.png_as_base64_str(15, (0, 84, 166))
 
     @api.model
     def _available_states(self):

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -110,6 +110,12 @@
                         <t t-raw="o.project_id.description_right" />
                     </div>
                 </div>
+                <img
+        t-if="small"
+        class="qrcode"
+        t-attf-src="data:image/png;base64,{{ o.qr_code_data }}"
+        alt="QR code to sponsor this child"
+      />
                 <div class="photo">
                     <img
           t-if="o.fullshot"

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -111,7 +111,7 @@
                     </div>
                 </div>
                 <img
-        t-if="small"
+        t-if="print_qr"
         class="qrcode"
         t-attf-src="data:image/png;base64,{{ o.qr_code_data }}"
         alt="QR code to sponsor this child"

--- a/child_compassion/views/print_childpack_view.xml
+++ b/child_compassion/views/print_childpack_view.xml
@@ -10,6 +10,10 @@
                     <field name="type" />
                     <field name="lang" />
                     <field name="pdf" />
+                    <field
+            name="print_qr"
+            invisible="type not in ('child_compassion.childpack_full', 'child_compassion.childpack_small')"
+          />
                 </group>
                 <group invisible="state != 'pdf'">
                     <field name="pdf_name" invisible="1" />

--- a/child_compassion/wizards/print_childpack.py
+++ b/child_compassion/wizards/print_childpack.py
@@ -30,6 +30,7 @@ class PrintChildpack(models.TransientModel):
     lang = fields.Selection("_lang_selection", default=lambda s: s._default_lang())
     state = fields.Selection([("new", "new"), ("pdf", "pdf")], default="new")
     pdf = fields.Boolean("Print background")
+    print_qr = fields.Boolean("Print QR code", default=True)
     pdf_name = fields.Char(default="childpack.pdf")
     pdf_download = fields.Binary(readonly=True)
     module_name = fields.Char(compute="_compute_module_name")
@@ -87,6 +88,7 @@ class PrintChildpack(models.TransientModel):
             "doc_ids": children.ids,
             "is_pdf": self.pdf,
             "type": self.type,
+            "print_qr": self.print_qr,
         }
         report_name = self.module_name + ".report_" + self.type.split(".")[1]
         report_ref = self.env.ref(report_name).with_context(lang=self.lang)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,8 @@ pdf2image
 phonenumbers
 pyjwt
 pypdf
+pypng
+pyqrcode
 pyquery
 pytesseract
 pytz


### PR DESCRIPTION
- Port the v14 childpack QR concept (child_switzerland) into the shared child_compassion core so the Nordic v18 instance gets it.
- Adds a computed qr_code_data on compassion.child linking to /my2/new-sponsorship/<id> and renders it on the small (A4) childpack.
- Optional qr code on full and small child packs