### PR TITLE
T3348-Fix-failing-quality_test_Global_Childpool_(SOLUTION 2)

### DIFF
--- a/child_compassion/views/global_childpool_view.xml
+++ b/child_compassion/views/global_childpool_view.xml
@@ -77,6 +77,7 @@
                   type="object"
                   class="oe_highlight"
                   style="margin-left: 5px"
+                  confirm="This search can take 20 to 30 seconds. Please be patient."
                 />
                                 <button
                   name="filter"

--- a/child_compassion/views/global_childpool_view.xml
+++ b/child_compassion/views/global_childpool_view.xml
@@ -77,7 +77,10 @@
                   type="object"
                   class="oe_highlight"
                   style="margin-left: 5px"
-                  confirm="This search can take 20 to 30 seconds. Please be patient."
+                  confirm="This search takes about 20 to 30 seconds. Feel free to grab a coffee while you wait!"
+                  confirm-title="Just a heads up"
+                  confirm-label="Let's go"
+                  cancel-label="Not now"
                 />
                                 <button
                   name="filter"

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -358,7 +358,10 @@ class GlobalChildSearch(models.TransientModel):
                 # No more children available in the pool: stop batching.
                 break
             for child in self.global_child_ids - before:
-                key = (child.birthdate.month, child.birthdate.day)
+                birthdate = child.birthdate
+                if not birthdate:
+                    continue
+                key = (birthdate.month, birthdate.day)
                 found_by_date.setdefault(key, child)
             if len(found_by_date) >= len(all_dates):
                 break

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -310,25 +310,71 @@ class GlobalChildSearch(models.TransientModel):
 
     def do_365_mix(self):
         """Try to find one child per day of the year having his birthdate
-        on that date."""
+        on that date.
+
+        Each day used to require its own GMC search (365 sequential HTTP
+        calls), which was very slow. Instead, we first fetch a few broad
+        batches of children (same active filters, but no birthday filter)
+        via the existing do_search/add_search pagination (as if the user
+        clicked "Search" then "Add children" repeatedly), and bucket them
+        locally by birth day/month. Only the days still missing after that
+        fall back to the original one-request-per-day search.
+        """
+        self.ensure_one()
         today = date.today()
         first_day = today.replace(day=1, month=1)
         last_day = today.replace(day=31, month=12)
+        all_dates = []
         current_date = first_day
-        # First step as regular search
+        while current_date <= last_day:
+            all_dates.append(current_date)
+            current_date += relativedelta(days=1)
+
+        batch_size = 80
+        max_batches = 10
+
+        # Phase A: broad batch searches (no birthday filter), reusing the
+        # standard search pagination.
         self.write(
             {
-                "birthday_day": 1,
-                "birthday_month": 1,
-                "take": 1,
+                "birthday_day": 0,
+                "birthday_month": 0,
                 "missing_dates": "",
                 "skip": 0,
+                "take": batch_size,
             }
         )
-        self.do_search()
-        while current_date < last_day:
-            # Next steps: add child to the search result
-            current_date += relativedelta(days=1)
+        self.global_child_ids.unlink()
+
+        found_by_date = {}
+        for batch_index in range(max_batches):
+            before = self.global_child_ids
+            try:
+                if batch_index == 0:
+                    self.do_search()
+                else:
+                    self.add_search()
+            except UserError:
+                # No more children available in the pool: stop batching.
+                break
+            for child in self.global_child_ids - before:
+                key = (child.birthdate.month, child.birthdate.day)
+                found_by_date.setdefault(key, child)
+            if len(found_by_date) >= len(all_dates):
+                break
+
+        # Keep only one child per day found so far, remove the rest.
+        kept = self.env["compassion.global.child"]
+        if found_by_date:
+            kept = kept.union(*found_by_date.values())
+        (self.global_child_ids - kept).unlink()
+
+        # Phase B: fall back to an individual search for the days still
+        # missing, exactly as the original implementation did.
+        self.write({"take": 1})
+        for current_date in all_dates:
+            if (current_date.month, current_date.day) in found_by_date:
+                continue
             self.write(
                 {
                     "birthday_day": current_date.day,


### PR DESCRIPTION
## Goal
The "365 children" button on the Global Childpool search page appeared to hang: clicking it triggered an endless-looking loading state in the UI, which users reported as a functional bug or crash (frozen screen, spinner looping forever).

Investigation showed the backend was not actually broken.It completed correctly, but suffered from a major performance bottleneck: it ran ~1 minute 30 seconds, because it sequentially sent 365 individual HTTP requests to the GMC API (one per day of the year) to find one matching child per day.

## Technical aspect
- `child_compassion/wizards/global_child_search.py` - rewrote `do_365_mix()`:
  - Phase A: instead of 365 separate per-day GMC searches, the method now fetches a handful of broad batches (80 children each, same active search filters, no birthday filter) by reusing the existing `do_search()`/`add_search()` pagination (the same mechanism behind the manual "Search"/"Add children" buttons). Results are bucketed locally by birth day/month, keeping only one child per day.
  - Phase B (fallback): any day not covered by the batches above is searched individually, exactly as the original implementation did, so behavior for edge cases (e.g. rare birthdates, exhausted pool) is preserved.
  - Because pagination is a strict priority-sorted prefix, any day resolved in Phase A yields the same child that the original per-day search would have found; days that fall through to Phase B are handled identically to before.
  - This reduces the number of sequential external API calls from 365 down to roughly a dozen in typical cases, cutting execution time from ~1m30 to ~20-30 seconds.
- `child_compassion/views/global_childpool_view.xml` - added a `confirm` dialog on the "365 children" button, so users are warned upfront that the search still takes 20-30 seconds instead of assuming the UI is frozen. Dialog title/labels were customized (`confirm-title`, `confirm-label`, `cancel-label`) to read as a friendly heads-up rather than a generic "Confirmation"/"Ok" prompt that could be mistaken for an error.
## Misc 
- Previously, since we were searching for all children, The "Number of matching children"  -> nb_found = all matching children. But now, since we iterate in the same way, nb_found is not the same. It is now realigned to the true number of children found once the search completes.