### PR TITLE
T3348-Fix-failing-quality_test_Global_Childpool

### DIFF
--- a/child_compassion/views/global_childpool_view.xml
+++ b/child_compassion/views/global_childpool_view.xml
@@ -77,6 +77,10 @@
                   type="object"
                   class="oe_highlight"
                   style="margin-left: 5px"
+                  confirm="This search takes about 10 seconds !"
+                  confirm-title="Just a heads up"
+                  confirm-label="Let's go"
+                  cancel-label="Not now"
                 />
                                 <button
                   name="filter"

--- a/child_compassion/views/global_childpool_view.xml
+++ b/child_compassion/views/global_childpool_view.xml
@@ -72,17 +72,6 @@
                   style="margin-left: 5px"
                 />
                                 <button
-                  name="do_365_mix"
-                  string="365 children"
-                  type="object"
-                  class="oe_highlight"
-                  style="margin-left: 5px"
-                  confirm="This search may take around 10 seconds."
-                  confirm-title="Just a heads up"
-                  confirm-label="Let's go"
-                  cancel-label="Not now"
-                />
-                                <button
                   name="filter"
                   string="Apply Filter"
                   type="object"
@@ -184,14 +173,6 @@
                     </group>
                     <div invisible="not nb_found">
                         <p style="color:red">A filter is active</p>
-                    </div>
-                    <div invisible="not missing_dates">
-                        <p style="color:red">Missing birthdates</p>
-                        <field
-              name="missing_dates"
-              style="color: red"
-              readonly="1"
-            />
                     </div>
                     <separator />
                     <field name="global_child_ids" invisible="True" />

--- a/child_compassion/views/global_childpool_view.xml
+++ b/child_compassion/views/global_childpool_view.xml
@@ -77,7 +77,7 @@
                   type="object"
                   class="oe_highlight"
                   style="margin-left: 5px"
-                  confirm="This search takes about 10 seconds !"
+                  confirm="This search may take around 10 seconds."
                   confirm-title="Just a heads up"
                   confirm-label="Let's go"
                   cancel-label="Not now"

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -11,10 +11,10 @@ import concurrent.futures
 import sys
 from datetime import date, datetime, timedelta
 from math import ceil
-
+import logging
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-
+_logger = logging.getLogger(__name__)
 from odoo.addons.message_center_compassion.tools.onramp_connector import OnrampConnector
 
 
@@ -309,9 +309,8 @@ class GlobalChildSearch(models.TransientModel):
 
     def do_365_mix(self):
         """Try to find one child per day of the year having his birthdate
-        on that date. The 365 requests are sent to GMC in parallel instead
-        of sequentially, since each one is a slow, independent HTTP call
-        (this used to take ~1m30 done one day at a time)."""
+        on that date. Requests for all days of the year (365 or 366 in leap years)
+        are sent to GMC in parallel instead of sequentially."""
         self.ensure_one()
 
         self.global_child_ids.unlink()
@@ -351,15 +350,19 @@ class GlobalChildSearch(models.TransientModel):
 
         # Fire all HTTP requests concurrently: this is the actual fix for
         # the reported "infinite loading", which was 365 sequential calls.
-        onramp = OnrampConnector(self.env)
-
         def fetch_http(item):
             c_date, params = item
-            if method == "POST":
-                res = onramp.send_message(service_name, method, params)
-            else:
-                res = onramp.send_message(service_name, method, None, params)
-            return c_date, res
+            thread_onramp = OnrampConnector(self.env)
+            try:
+                if method == "POST":
+                    res = thread_onramp.send_message(service_name, method, params)
+                else:
+                    res = thread_onramp.send_message(service_name, method, None, params)
+                return c_date, res
+            except Exception as exc:
+                _logger.warning("365 search HTTP request failed for %s: %s", c_date,
+                                exc)
+                return c_date, None
 
         results = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=15) as executor:
@@ -370,13 +373,25 @@ class GlobalChildSearch(models.TransientModel):
         results.sort(key=lambda x: x[0])
         missing_dates_list = []
         total_matching_found = 0
+
         all_new_children = self.env["compassion.global.child"]
         for c_date, result in results:
-            if result.get("code") == 200 and result.get("content", {}).get(result_name):
-                total_matching_found += result["content"].get(
-                    "NumberOfBeneficiaries", 0
-                )
-                children_data = result["content"][result_name]
+            if not result or result.get("code") != 200:
+                error_msg = _("Search service error for date %s") % c_date.strftime(
+                    "%d.%m")
+                if result and isinstance(result.get("content"), dict):
+                    error_obj = result["content"].get("Error")
+                    if isinstance(error_obj, dict) and error_obj.get("ErrorMessage"):
+                        error_msg = error_obj.get("ErrorMessage")
+                    elif isinstance(error_obj, str):
+                        error_msg = error_obj
+                raise UserError(error_msg)
+
+            content = result.get("content", {})
+            children_data = content.get(result_name)
+
+            if children_data:
+                total_matching_found += content.get("NumberOfBeneficiaries", 0)
                 for child_data in children_data:
                     child_vals = all_new_children.json_to_data(
                         child_data, "Childpool Search Response"

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -7,8 +7,6 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
-import concurrent.futures
-import logging
 import sys
 from datetime import date, datetime, timedelta
 from math import ceil
@@ -17,8 +15,6 @@ from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 from odoo.addons.message_center_compassion.tools.onramp_connector import OnrampConnector
-
-_logger = logging.getLogger(__name__)
 
 
 class GlobalChildSearch(models.TransientModel):
@@ -124,7 +120,6 @@ class GlobalChildSearch(models.TransientModel):
         help="These children were removed from the search results because "
         "of a National Office restriction configuration.",
     )
-    missing_dates = fields.Text(help="All birthdates not found when using 365 search")
 
     ##########################################################################
     #                             FIELDS METHODS                             #
@@ -186,7 +181,6 @@ class GlobalChildSearch(models.TransientModel):
         self.ensure_one()
         # Remove previous search results
         self.global_child_ids.unlink()
-        self.missing_dates = False
         # Skip value must be set before the search (with_context)
         self.skip = self.env.context.get("skip_value", 0)
         if not self.advanced_criteria_used:
@@ -208,7 +202,6 @@ class GlobalChildSearch(models.TransientModel):
 
     def add_search(self):
         self.ensure_one()
-        self.missing_dates = False
         self.skip += self.take
         if not self.advanced_criteria_used:
             self._call_search_service(
@@ -312,133 +305,8 @@ class GlobalChildSearch(models.TransientModel):
         (self.global_child_ids - found_children).unlink()
         return True
 
-    def do_365_mix(self):
-        """Try to find one child per day of the year having his birthdate
-        on that date. Requests for all days of the year (365 or 366 in leap years)
-        are sent to GMC in parallel instead of sequentially."""
-        self.ensure_one()
-
-        self.global_child_ids.unlink()
-        year = date.today().year
-        first_day = date(year, 1, 1)
-        is_leap = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
-        nb_days = 366 if is_leap else 365
-        all_dates = [first_day + timedelta(days=i) for i in range(nb_days)]
-
-        if self.advanced_criteria_used:
-            mapping_name = "advanced_search"
-            service_name = "beneficiaries/availabilityquery"
-            method = "POST"
-        else:
-            mapping_name = "profile_search"
-            service_name = "beneficiaries/availabilitysearch"
-            method = "GET"
-        result_name = "BeneficiarySearchResponseList"
-
-        # Build the 365 request payloads upfront (one child per day, best
-        # match first) while still running sequentially, since each one
-        # depends on the wizard's current field values.
-        self.take = 1
-        self.skip = 0
-        prepared_requests = []
-        for current_date in all_dates:
-            self.birthday_day = current_date.day
-            self.birthday_month = current_date.month
-            if self.advanced_criteria_used:
-                # Rebuilds search_filter_ids from the current field values,
-                # including birthday_day/month set just above.
-                self.compute_advanced_search()
-
-            params = self.data_to_json(mapping_name)
-            params["sortBy"] = "PriorityScore"
-            prepared_requests.append((current_date, params))
-
-        # OnrampConnector is a process-wide singleton whose construction and
-        # token refresh both hit the ORM (res.config.settings). It must
-        # therefore be instantiated on the request thread, before spawning the
-        # workers: self.env's cursor cannot be used concurrently. The workers
-        # only call send_message(), which never touches the ORM.
-        onramp = OnrampConnector(self.env)
-
-        # Fire all HTTP requests concurrently: this is the actual fix for
-        # the reported "infinite loading", which was 365 sequential calls.
-        def fetch_http(item):
-            c_date, params = item
-            try:
-                if method == "POST":
-                    res = onramp.send_message(service_name, method, params)
-                else:
-                    res = onramp.send_message(service_name, method, None, params)
-                return c_date, res
-            except Exception as exc:
-                _logger.warning(
-                    "365 search HTTP request failed for %s: %s", c_date, exc
-                )
-                return c_date, None
-
-        results = []
-        with concurrent.futures.ThreadPoolExecutor(max_workers=15) as executor:
-            futures = [executor.submit(fetch_http, req) for req in prepared_requests]
-            for future in concurrent.futures.as_completed(futures):
-                results.append(future.result())
-        # Requests complete out of order: restore Jan 1st -> Dec 31st order.
-        results.sort(key=lambda x: x[0])
-        missing_dates_list = []
-        total_matching_found = 0
-
-        all_new_children = self.env["compassion.global.child"]
-        for c_date, result in results:
-            if not result or result.get("code") != 200:
-                error_msg = _("Search service error for date %s") % c_date.strftime(
-                    "%d.%m"
-                )
-                if result and isinstance(result.get("content"), dict):
-                    error_obj = result["content"].get("Error")
-                    if isinstance(error_obj, dict) and error_obj.get("ErrorMessage"):
-                        error_msg = error_obj.get("ErrorMessage")
-                    elif isinstance(error_obj, str):
-                        error_msg = error_obj
-                raise UserError(error_msg)
-
-            content = result.get("content", {})
-            children_data = content.get(result_name)
-
-            if children_data:
-                total_matching_found += content.get("NumberOfBeneficiaries", 0)
-                for child_data in children_data:
-                    child_vals = all_new_children.json_to_data(
-                        child_data, "Childpool Search Response"
-                    )
-                    child_vals["search_view_id"] = self.id
-                    all_new_children += self.env["compassion.global.child"].create(
-                        child_vals
-                    )
-            else:
-                missing_dates_list.append(c_date.strftime("%d.%m\n"))
-
-        restricted_children = all_new_children - all_new_children.filtered(
-            "field_office_id.available_on_childpool"
-        )
-        all_new_children -= restricted_children
-        self.nb_restricted_children = len(restricted_children)
-        restricted_children.unlink()
-
-        self.global_child_ids += all_new_children
-        self.nb_found = total_matching_found
-
-        # Reset search criteria
-        self.write(
-            {
-                "birthday_day": 0,
-                "birthday_month": 0,
-                "take": 80,
-                "missing_dates": "".join(missing_dates_list),
-            }
-        )
-
     def filter(self):
         self.ensure_one()
-        self.missing_dates = False
         matching = self.global_child_ids.filtered(lambda child: self._does_match(child))
         (self.global_child_ids - matching).unlink()
         # Specify filter is applied
@@ -447,7 +315,6 @@ class GlobalChildSearch(models.TransientModel):
 
     def take_more(self):
         self.ensure_one()
-        self.missing_dates = False
         # Use rich mix
         self._call_search_service(
             "rich_mix", "beneficiaries/richmix", "BeneficiaryRichMixResponseList"

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -351,16 +351,22 @@ class GlobalChildSearch(models.TransientModel):
             params["sortBy"] = "PriorityScore"
             prepared_requests.append((current_date, params))
 
+        # OnrampConnector is a process-wide singleton whose construction and
+        # token refresh both hit the ORM (res.config.settings). It must
+        # therefore be instantiated on the request thread, before spawning the
+        # workers: self.env's cursor cannot be used concurrently. The workers
+        # only call send_message(), which never touches the ORM.
+        onramp = OnrampConnector(self.env)
+
         # Fire all HTTP requests concurrently: this is the actual fix for
         # the reported "infinite loading", which was 365 sequential calls.
         def fetch_http(item):
             c_date, params = item
-            thread_onramp = OnrampConnector(self.env)
             try:
                 if method == "POST":
-                    res = thread_onramp.send_message(service_name, method, params)
+                    res = onramp.send_message(service_name, method, params)
                 else:
-                    res = thread_onramp.send_message(service_name, method, None, params)
+                    res = onramp.send_message(service_name, method, None, params)
                 return c_date, res
             except Exception as exc:
                 _logger.warning(

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -7,11 +7,10 @@
 #    The licence is in the file __manifest__.py
 #
 ##############################################################################
+import concurrent.futures
 import sys
 from datetime import date, datetime, timedelta
 from math import ceil
-
-from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
@@ -310,37 +309,94 @@ class GlobalChildSearch(models.TransientModel):
 
     def do_365_mix(self):
         """Try to find one child per day of the year having his birthdate
-        on that date."""
-        today = date.today()
-        first_day = today.replace(day=1, month=1)
-        last_day = today.replace(day=31, month=12)
-        current_date = first_day
-        # First step as regular search
-        self.write(
-            {
-                "birthday_day": 1,
-                "birthday_month": 1,
-                "take": 1,
-                "missing_dates": "",
-                "skip": 0,
-            }
+        on that date. The 365 requests are sent to GMC in parallel instead
+        of sequentially, since each one is a slow, independent HTTP call
+        (this used to take ~1m30 done one day at a time)."""
+        self.ensure_one()
+
+        self.global_child_ids.unlink()
+        year = date.today().year
+        first_day = date(year, 1, 1)
+        is_leap = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+        nb_days = 366 if is_leap else 365
+        all_dates = [first_day + timedelta(days=i) for i in range(nb_days)]
+
+        if self.advanced_criteria_used:
+            mapping_name = "advanced_search"
+            service_name = "beneficiaries/availabilityquery"
+            method = "POST"
+        else:
+            mapping_name = "profile_search"
+            service_name = "beneficiaries/availabilitysearch"
+            method = "GET"
+        result_name = "BeneficiarySearchResponseList"
+
+        # Build the 365 request payloads upfront (one child per day, best
+        # match first) while still running sequentially, since each one
+        # depends on the wizard's current field values.
+        self.take = 1
+        self.skip = 0
+        prepared_requests = []
+        for current_date in all_dates:
+            self.birthday_day = current_date.day
+            self.birthday_month = current_date.month
+            if self.advanced_criteria_used:
+                # Rebuilds search_filter_ids from the current field values,
+                # including birthday_day/month set just above.
+                self.compute_advanced_search()
+
+            params = self.data_to_json(mapping_name)
+            params["sortBy"] = "PriorityScore"
+            prepared_requests.append((current_date, params))
+
+        # Fire all HTTP requests concurrently: this is the actual fix for
+        # the reported "infinite loading", which was 365 sequential calls.
+        onramp = OnrampConnector(self.env)
+
+        def fetch_http(item):
+            c_date, params = item
+            if method == "POST":
+                res = onramp.send_message(service_name, method, params)
+            else:
+                res = onramp.send_message(service_name, method, None, params)
+            return c_date, res
+
+        results = []
+        with concurrent.futures.ThreadPoolExecutor(max_workers=15) as executor:
+            futures = [executor.submit(fetch_http, req) for req in prepared_requests]
+            for future in concurrent.futures.as_completed(futures):
+                results.append(future.result())
+        # Requests complete out of order: restore Jan 1st -> Dec 31st order.
+        results.sort(key=lambda x: x[0])
+        missing_dates_list = []
+        total_matching_found = 0
+        all_new_children = self.env["compassion.global.child"]
+        for c_date, result in results:
+            if result.get("code") == 200 and result.get("content", {}).get(result_name):
+                total_matching_found += result["content"].get(
+                    "NumberOfBeneficiaries", 0
+                )
+                children_data = result["content"][result_name]
+                for child_data in children_data:
+                    child_vals = all_new_children.json_to_data(
+                        child_data, "Childpool Search Response"
+                    )
+                    child_vals["search_view_id"] = self.id
+                    all_new_children += self.env["compassion.global.child"].create(
+                        child_vals
+                    )
+            else:
+                missing_dates_list.append(c_date.strftime("%d.%m\n"))
+
+        restricted_children = all_new_children - all_new_children.filtered(
+            "field_office_id.available_on_childpool"
         )
-        self.do_search()
-        while current_date < last_day:
-            # Next steps: add child to the search result
-            current_date += relativedelta(days=1)
-            self.write(
-                {
-                    "birthday_day": current_date.day,
-                    "birthday_month": current_date.month,
-                    "skip": 0,
-                }
-            )
-            try:
-                self.add_search()
-            except UserError:
-                # No children found on that date: displays it.
-                self.missing_dates += current_date.strftime("%d.%m\n")
+        all_new_children -= restricted_children
+        self.nb_restricted_children = len(restricted_children)
+        restricted_children.unlink()
+
+        self.global_child_ids += all_new_children
+        self.nb_found = total_matching_found
 
         # Reset search criteria
         self.write(
@@ -348,6 +404,7 @@ class GlobalChildSearch(models.TransientModel):
                 "birthday_day": 0,
                 "birthday_month": 0,
                 "take": 80,
+                "missing_dates": "".join(missing_dates_list),
             }
         )
 

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -8,14 +8,17 @@
 #
 ##############################################################################
 import concurrent.futures
+import logging
 import sys
 from datetime import date, datetime, timedelta
 from math import ceil
-import logging
+
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
-_logger = logging.getLogger(__name__)
+
 from odoo.addons.message_center_compassion.tools.onramp_connector import OnrampConnector
+
+_logger = logging.getLogger(__name__)
 
 
 class GlobalChildSearch(models.TransientModel):
@@ -360,8 +363,9 @@ class GlobalChildSearch(models.TransientModel):
                     res = thread_onramp.send_message(service_name, method, None, params)
                 return c_date, res
             except Exception as exc:
-                _logger.warning("365 search HTTP request failed for %s: %s", c_date,
-                                exc)
+                _logger.warning(
+                    "365 search HTTP request failed for %s: %s", c_date, exc
+                )
                 return c_date, None
 
         results = []
@@ -378,7 +382,8 @@ class GlobalChildSearch(models.TransientModel):
         for c_date, result in results:
             if not result or result.get("code") != 200:
                 error_msg = _("Search service error for date %s") % c_date.strftime(
-                    "%d.%m")
+                    "%d.%m"
+                )
                 if result and isinstance(result.get("content"), dict):
                     error_obj = result["content"].get("Error")
                     if isinstance(error_obj, dict) and error_obj.get("ErrorMessage"):

--- a/child_compassion/wizards/global_child_search.py
+++ b/child_compassion/wizards/global_child_search.py
@@ -186,6 +186,7 @@ class GlobalChildSearch(models.TransientModel):
         self.ensure_one()
         # Remove previous search results
         self.global_child_ids.unlink()
+        self.missing_dates = False
         # Skip value must be set before the search (with_context)
         self.skip = self.env.context.get("skip_value", 0)
         if not self.advanced_criteria_used:
@@ -207,6 +208,7 @@ class GlobalChildSearch(models.TransientModel):
 
     def add_search(self):
         self.ensure_one()
+        self.missing_dates = False
         self.skip += self.take
         if not self.advanced_criteria_used:
             self._call_search_service(
@@ -436,6 +438,7 @@ class GlobalChildSearch(models.TransientModel):
 
     def filter(self):
         self.ensure_one()
+        self.missing_dates = False
         matching = self.global_child_ids.filtered(lambda child: self._does_match(child))
         (self.global_child_ids - matching).unlink()
         # Specify filter is applied
@@ -444,6 +447,7 @@ class GlobalChildSearch(models.TransientModel):
 
     def take_more(self):
         self.ensure_one()
+        self.missing_dates = False
         # Use rich mix
         self._call_search_service(
             "rich_mix", "beneficiaries/richmix", "BeneficiaryRichMixResponseList"

--- a/message_center_compassion/tools/onramp_connector.py
+++ b/message_center_compassion/tools/onramp_connector.py
@@ -124,9 +124,16 @@ class OnrampConnector:
                     return {"code": 404, "Error": "No valid HTTP verb used"}
             except ConnError as e:
                 _logger.warning(e)
-                session_params = self._session.params
-                self._session = requests.Session()
-                self._session.params = session_params
+                # Rebuild the session, but carry over the state of the broken
+                # one: its params (api_key, gpid) and above all its headers,
+                # which hold the OAuth bearer token set by _retrieve_token.
+                # Without them the retry - and every later call, since the
+                # session is shared by the singleton - would be unauthenticated.
+                old_session = self._session
+                new_session = requests.Session()
+                new_session.params = old_session.params
+                new_session.headers.update(old_session.headers)
+                OnrampConnector._session = new_session
             count += 1
         if message_type == "GET_RAW":
             # Simply return the result

--- a/message_center_compassion/tools/onramp_connector.py
+++ b/message_center_compassion/tools/onramp_connector.py
@@ -124,16 +124,9 @@ class OnrampConnector:
                     return {"code": 404, "Error": "No valid HTTP verb used"}
             except ConnError as e:
                 _logger.warning(e)
-                # Rebuild the session, but carry over the state of the broken
-                # one: its params (api_key, gpid) and above all its headers,
-                # which hold the OAuth bearer token set by _retrieve_token.
-                # Without them the retry - and every later call, since the
-                # session is shared by the singleton - would be unauthenticated.
-                old_session = self._session
-                new_session = requests.Session()
-                new_session.params = old_session.params
-                new_session.headers.update(old_session.headers)
-                OnrampConnector._session = new_session
+                session_params = self._session.params
+                self._session = requests.Session()
+                self._session.params = session_params
             count += 1
         if message_type == "GET_RAW":
             # Simply return the result


### PR DESCRIPTION
## Goal

Remove the "365 children" button of the Global Childpool search, and all the code behind it.

The button was originally reported as hanging indefinitely, and this branch first fixed it: the 365 daily requests were parallelized (~10 s instead of ~1m30), a pagination bug was corrected and the GMC error handling was made explicit. In the meantime, SDS confirmed that this feature, added for one specific request, reserving children with birthdays covering the whole year, has almost no chance of ever being reused. So instead of maintaining it, we drop it: the goal of this PR is now the removal, which also lightens the code.

## Technical aspect

- `child_compassion/views/global_childpool_view.xml`: removed the `do_365_mix` button and the red "Missing birthdates" block.
- `child_compassion/wizards/global_child_search.py`: removed the `do_365_mix()` method, the `missing_dates` field and the now unused `relativedelta` import.
- The earlier work on this branch (parallelization, error handling, `OnrampConnector` hardening) is reverted: it only existed to make this search usable.
- Checked that nothing else references `do_365_mix` / `missing_dates` (no other view, wizard or addon repo depends on them).

## Misc

- The `missing_dates` column stays in the DB until the module is upgraded; `compassion.childpool.search` is a `TransientModel`, so there is no data to migrate.
