### PR TITLE
[T1523] - ADD: Preview PDF button on communication job

### DIFF
--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -818,9 +818,9 @@ class CommunicationJob(models.Model):
 
     def preview_pdf_report(self):
         self.ensure_one()
-        return self.report_id.with_context(lang=self.partner_id.lang).report_action(
-            self.ids, config=False
-        )
+        return self.report_id.with_context(
+            lang=self.partner_id.lang, must_skip_send_to_printer=True
+        ).report_action(self.ids, config=False)
 
     def download_data(self):
         action = {

--- a/partner_communication/models/communication_job.py
+++ b/partner_communication/models/communication_job.py
@@ -816,6 +816,12 @@ class CommunicationJob(models.Model):
             "target": "new",
         }
 
+    def preview_pdf_report(self):
+        self.ensure_one()
+        return self.report_id.with_context(lang=self.partner_id.lang).report_action(
+            self.ids, config=False
+        )
+
     def download_data(self):
         action = {
             "type": "ir.actions.act_window",

--- a/partner_communication/views/communication_job_view.xml
+++ b/partner_communication/views/communication_job_view.xml
@@ -84,6 +84,14 @@
               invisible="state != 'pending'"
             />
                         <button
+              name="preview_pdf_report"
+              string="Preview PDF"
+              type="object"
+              icon="fa-file-pdf-o"
+              class="oe_stat_button"
+              invisible="state != 'pending' or not report_id"
+            />
+                        <button
               name="open_related"
               string="Go to records"
               type="object"


### PR DESCRIPTION
# T1523 — Country map/photo missing on German and Italian onboarding cards

Related PR: https://github.com/CompassionCH/compassion-switzerland/pull/1783

## Original report

The "sponsorship onboarding photo by post" physical communication (Sponsorship > Partner communication > Photo by card) should print a photo alongside the letter, but it only appears on French cards. It's also missing on Italian, so cards are currently being sent without it as a workaround.

## Root cause

The QWeb report template (`onboarding_photo_by_post.xml`, `partner_communication_switzerland`) embeds its layout CSS as literal text inside `<t t-set="custom_css">`. Odoo's translation extraction treats that raw CSS text as translatable, and the German and Italian `.po` translations had the CSS **property names themselves** mistranslated — `width` → `Breite`/`larghezza`, `height` → `Höhe`/`altezza`, `position` → `Position: absolut`/`posizione: assoluta`, `color` → `Farbe`/`colore`. That makes the `#map` positioning rule invalid CSS for German/Italian only, so the photo has no size/position and effectively vanishes. French's translation wasn't corrupted, which is why only French worked.

The same corruption exists identically in both the v14 and v18 `i18n/de.po`/`it.po` files — pre-existing, not introduced by the v14→v18 migration itself. 

Separately (not a bug, confirmed intentional): the image itself is a circular community photo, not a literal country map — the map was replaced by a photo in a 2024 change and stays that way.

## What changed

Two repos:

**compassion-switzerland**, 

`partner_communication_switzerland`
- `report/onboarding_photo_by_post.xml`: added `t-translation="off"` to the  `<t t-set="custom_css">` block so this CSS can never be mistranslated again.
- `i18n/de.po` / `i18n/it.po`: corrected the corrupted translation entries.
- `migrations/18.0.1.1.1/post-migration.py`: guarded DB fix intended to copy the French `arch_db` translation into `de_DE`/`it_IT`. In practice this turned out to be a no-op — `t-translation="off"` alone, combined with the ordinary module-upgrade data reload, was already enough to normalize `arch_db` across all installed languages (it collapses to one shared value, dropping the separate `fr_CH` key entirely). 

**compassion-modules**, 

`partner_communication`:
- New "Preview PDF" button on the Communication Job form, next to the existing "Preview" button. The existing button only ever rendered raw HTML (`_render_qweb_html`) — never the actual PDF — so a broken/invisible image could go unnoticed until physical printing. The new button renders through the real `ir.actions.report` action instead.

## How to test manually

1. Upgrade `partner_communication_switzerland` (`-u partner_communication_switzerland`).
2. Open a "Sponsorship Onboarding - Photo by post" communication job for a German or Italian sponsor, click **Preview PDF** (new button, next to **Preview**), confirm the photo renders, correctly positioned, same as  French.
3. Note: **Preview PDF** renders server-side via wkhtmltopdf, which needs the `report.url` system parameter to point at wherever the Odoo instance is actually being served from (`http://127.0.0.1:<port>` for local testing) — a stale `report.url` will show a blank white square where the image should be.