### PR TITLE
T3351-Fix-failing-quality-test-Print-childpack

### DIFF
--- a/child_compassion/models/__init__.py
+++ b/child_compassion/models/__init__.py
@@ -20,5 +20,6 @@ from . import (
     major_revision,
     project_compassion,
     project_lifecycle_event,
+    report_childpack,
     weekly_demand,
 )

--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -297,7 +297,6 @@ class CompassionChild(models.Model):
         UTMs can be overridden through the context keys ``qr_utm_medium``,
         ``qr_utm_source`` and ``qr_utm_campaign``.
         """
-        base_url = self.get_base_url().rstrip("/")
         utm_params = {
             "utm_medium": self.env.context.get("qr_utm_medium") or "childpack_qr",
             "utm_source": self.env.context.get("qr_utm_source") or "hold_campaign",
@@ -307,6 +306,7 @@ class CompassionChild(models.Model):
             utm_params["utm_campaign"] = utm_campaign
         query = urlencode(utm_params)
         for child in self:
+            base_url = child.get_base_url().rstrip("/")
             url = f"{base_url}/my2/new-sponsorship/{child.id}?{query}"
             qr = pyqrcode.create(url)
             child.qr_code_data = qr.png_as_base64_str(15, (0, 84, 166))

--- a/child_compassion/models/report_childpack.py
+++ b/child_compassion/models/report_childpack.py
@@ -1,0 +1,48 @@
+##############################################################################
+#
+#    Copyright (C) 2016-2026 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import api, models
+
+
+class ReportChildpackFull(models.AbstractModel):
+    """
+    Rendering context of the childpack reports.
+
+    The print wizard passes its options (lang, type, print_qr, ...) through the
+    ``data`` dictionary. When that dictionary is set, the web client builds the
+    report URL without the record ids (see ``getReportUrl`` in web), so the
+    report is rendered with no ``docids`` at all and would print a blank page.
+    We therefore fall back on the ids the wizard stored in ``data['doc_ids']``.
+    """
+
+    _name = "report.child_compassion.childpack_full"
+    _description = "Childpack report rendering context"
+
+    @api.model
+    def _get_report_values(self, docids, data=None):
+        data = dict(data or {})
+        docids = docids or data.get("doc_ids") or self.env.context.get("active_ids", [])
+        lang = data.get("lang")
+        docs = self.env["compassion.child"].browse(docids)
+        if lang:
+            docs = docs.with_context(lang=lang)
+        data.update(
+            {
+                "doc_ids": docs.ids,
+                "doc_model": "compassion.child",
+                "docs": docs,
+            }
+        )
+        return data
+
+
+# pylint: disable=R7980
+class ReportChildpackSmall(models.AbstractModel):
+    _inherit = "report.child_compassion.childpack_full"
+    _name = "report.child_compassion.childpack_small"
+    _description = "Small childpack report rendering context"


### PR DESCRIPTION
## Goal

This Ticket, reported by Connor. Here are the problems I've identified, in a more specific way.

- unchecking **Print background** produces a blank PDF, even with "Print QR code" enabled;
- selecting **several children** and printing with **Print QR code** enabled fails with a server error.
- The "Open children" server action doesn't work.


## Technical aspect

-  **Blank page.** Without "Print background", the wizard returns a report action and lets the web client fetch the PDF. `getReportUrl` (`web/.../reports/utils.js`) puts *either* the wizard options *or* the record ids in the URL, never both, so the ids are dropped and the report renders on an empty recordset.

Odoo's way out is the rendering-context model it looks up by name (`report.` + `report_name`). It used to exist and match, but the 14.0 migration moved the report to `child_compassion` while its model stayed in `child_switzerland` as `report.childpack_full`, losing the module prefix. Since then the lookup silently returns `None` → New file `child_compassion/models/report_childpack.py` declaring `report.child_compassion.childpack_full` / `_small`, which recover the ids the wizard already puts in `data['doc_ids']`. It now sits in the same module as the report, so every office benefits, not only installations with `child_switzerland`.

- **Batch print + QR.** `_compute_qr_code` called `self.get_base_url()` on the whole recordset, but that method requires a singleton → `ValueError: Expected singleton` with 2+ children. It had been moved inside the loop.

## Misc

**1. The "Open children" action is NOT fixed by this PR** . It cannot be, it lives only in the database. Under Sponsorship → Global Childpool → Holds, the ⚙️ Action → *Open children* entry is an `ir.actions.server` with no XML id and no source in any addon. Its Python code returns the Odoo 16 view type, which 17+ rejects (`tree` was renamed `list`). To fix it on a real instance:

> Settings → Technical → Actions → Server Actions → **Open children** → tab *Python Code*, then replace `tree,form` with `list,form`:
> ```python
> action = {
>     "type": "ir.actions.act_window",
>     "res_model": "compassion.child",
>     "view_mode": "list,form",          # was "tree,form"
>     "domain": [('id', 'in', records.mapped('child_id').ids)],
>     "name": "Children on hold"
> }
> ```
> Save, then hard-reload the browser .

**2. `child_switzerland/models/report_childpack.py` needs a follow-up PR** on `addons-switzerland`. Its three classes have been dead since 14.0 (wrong names). `report.childpack_full` / `_small` are now redundant with this PR and should be deleted; only the mini childpack is still needed and should be renamed, otherwise it keeps printing blank pages:

