### PR TITLE
T3276 relational mapping ambiguity

### DIFF
--- a/message_center_compassion/models/field_to_json.py
+++ b/message_center_compassion/models/field_to_json.py
@@ -443,13 +443,36 @@ class FieldToJson(models.Model):
         if not target_model or not search_field:
             raise UserError(_("Cannot determine the target model/field to check."))
 
-        duplicate_groups = self.env[target_model]._read_group(
-            domain=[(search_field, "!=", False)],
+        domain = [(search_field, "!=", False)]
+        if self.relational_domain_restrict:
+            domain = expression.AND(
+                [domain, safe_eval(self.relational_domain_restrict)]
+            )
+
+        groups = self.env[target_model]._read_group(
+            domain=domain,
             groupby=[search_field],
             aggregates=["__count"],
-            having=[("__count", ">", 1)],
         )
-        if not duplicate_groups:
+
+        field_type = self.env[target_model]._fields[search_field].type
+        if field_type in ("char", "text", "selection"):
+            buckets = {}
+            for value, count in groups:
+                key = value.lower() if value else value
+                bucket = buckets.setdefault(key, {"count": 0, "values": []})
+                bucket["count"] += count
+                bucket["values"].append(value)
+            ambiguous_values = [
+                value
+                for bucket in buckets.values()
+                if bucket["count"] > 1
+                for value in bucket["values"]
+            ]
+        else:
+            ambiguous_values = [value for value, count in groups if count > 1]
+
+        if not ambiguous_values:
             return {
                 "type": "ir.actions.client",
                 "tag": "display_notification",
@@ -465,11 +488,10 @@ class FieldToJson(models.Model):
                     "sticky": False,
                 },
             }
-        raw_values = [group[0] for group in duplicate_groups]
-        if raw_values and isinstance(raw_values[0], models.BaseModel):
-            domain_values = [value.id for value in raw_values]
+        if isinstance(ambiguous_values[0], models.BaseModel):
+            domain_values = [value.id for value in ambiguous_values]
         else:
-            domain_values = raw_values
+            domain_values = ambiguous_values
         return {
             "type": "ir.actions.act_window",
             "name": _("%(count)s value(s) of %(field)s match several records")

--- a/message_center_compassion/models/field_to_json.py
+++ b/message_center_compassion/models/field_to_json.py
@@ -9,8 +9,9 @@
 ##############################################################################
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.osv import expression
 from odoo.tools.safe_eval import safe_eval, wrap_module
 
 _logger = logging.getLogger(__name__)
@@ -66,6 +67,35 @@ class FieldToJson(models.Model):
         help="Odoo field name that will be used to search for an existing relational "
         "record. If not specified, it will assume a single value is given and "
         "will search according the relational_field set."
+    )
+    relational_domain_restrict = fields.Char(
+        help="Optional domain (Odoo domain syntax) added to the search "
+        "performed for an existing relational record. Use it to disambiguate "
+        "between several records that could otherwise match the same "
+        "search value."
+    )
+    relational_comodel_name = fields.Char(
+        related="relational_field_id.relation",
+        help="Technical field holding the model name of the relational field, "
+        "used to know which model relational_domain_restrict applies to.",
+    )
+    relational_ttype = fields.Selection(
+        related="relational_field_id.ttype",
+        help="Technical field holding the type (many2one, many2many, ...) "
+        "of the relational field, used to show Many2one-specific options "
+        "in the view.",
+    )
+    many2one_multiple_match_policy = fields.Selection(
+        [
+            ("first_match", "Take First Match"),
+            ("raise", "Raise an Error"),
+        ],
+        default="first_match",
+        help="When the search for an existing record on a Many2one field "
+        "returns several matches, decide whether to silently take the "
+        "first one found (legacy behavior) or raise an error so the "
+        "ambiguity can be resolved manually, e.g. with a domain "
+        "restriction.",
     )
     allow_relational_creation = fields.Boolean(
         help="If set to true, new records will be created if no matching "
@@ -236,18 +266,38 @@ class FieldToJson(models.Model):
                 # In that case we receive several values for the relation record
                 # and use one value in particular to find a matching record.
                 search_val = val.get(search_field)
-            records = (
-                relational_model.search(
-                    [
-                        "|",
-                        (search_field, "=", search_val),
-                        (search_field, "=ilike", str(search_val)),
-                    ]
-                )
-                if search_val
-                else relational_model
-            )
+            if search_val:
+                domain = [
+                    "|",
+                    (search_field, "=", search_val),
+                    (search_field, "=ilike", str(search_val)),
+                ]
+                if self.relational_domain_restrict:
+                    domain = expression.AND(
+                        [domain, safe_eval(self.relational_domain_restrict)]
+                    )
+                records = relational_model.search(domain)
+            else:
+                records = relational_model
             if self.relational_field_id.ttype == "many2one":
+                if len(records) > 1 and self.many2one_multiple_match_policy == "raise":
+                    raise UserError(
+                        _(
+                            "Found %(count)s records matching value %(value)r "
+                            "for field %(field)s (mapping %(mapping)s), but "
+                            "expected at most one. Restrict the search with a "
+                            "domain or allow taking the first match on the "
+                            "field mapping configuration. Matching records: "
+                            "%(records)s"
+                        )
+                        % {
+                            "count": len(records),
+                            "value": search_val,
+                            "field": self.odoo_field,
+                            "mapping": self.mapping_id.name,
+                            "records": records,
+                        }
+                    )
                 record = records[:1]  # Only take one relation
                 if not record and self.allow_relational_creation:
                     to_create.append(val)
@@ -364,3 +414,68 @@ class FieldToJson(models.Model):
                         }
                     )
         return [(0, 0, values) for values in record_values]
+
+    def action_check_duplicate_matches(self):
+        """
+        Diagnostic action for the "Check for duplicates" button: scans the
+        actual current data of the relational model targeted by this field
+        mapping, and reports which search values currently match more than
+        one record - i.e. the exact ambiguity a Many2one lookup could hit
+        when converting an incoming GMC message (see T3276).
+
+        This lets a non-technical user self-serve the same check a
+        developer would otherwise have to run manually against the
+        database.
+        """
+        self.ensure_one()
+        if (
+            self.relational_field_id.ttype != "many2one"
+            or not self.search_relational_record
+        ):
+            raise UserError(
+                _(
+                    "This check only applies to a Many2one field configured "
+                    "with 'Search Relational Record' enabled."
+                )
+            )
+        target_model = self.relational_comodel_name
+        search_field = self.search_key or self.field_id.name
+        if not target_model or not search_field:
+            raise UserError(_("Cannot determine the target model/field to check."))
+
+        duplicate_groups = self.env[target_model]._read_group(
+            domain=[(search_field, "!=", False)],
+            groupby=[search_field],
+            aggregates=["__count"],
+            having=[("__count", ">", 1)],
+        )
+        if not duplicate_groups:
+            return {
+                "type": "ir.actions.client",
+                "tag": "display_notification",
+                "params": {
+                    "title": _("No ambiguity found"),
+                    "message": _(
+                        "No duplicate values currently exist on %(model)s.%(field)s. "
+                        "This lookup is safe for now, but new data could still "
+                        "introduce a duplicate later."
+                    )
+                    % {"model": target_model, "field": search_field},
+                    "type": "success",
+                    "sticky": False,
+                },
+            }
+        raw_values = [group[0] for group in duplicate_groups]
+        if raw_values and isinstance(raw_values[0], models.BaseModel):
+            domain_values = [value.id for value in raw_values]
+        else:
+            domain_values = raw_values
+        return {
+            "type": "ir.actions.act_window",
+            "name": _("%(count)s value(s) of %(field)s match several records")
+            % {"count": len(domain_values), "field": search_field},
+            "res_model": target_model,
+            "view_mode": "list,form",
+            "domain": [(search_field, "in", domain_values)],
+            "context": {"group_by": [search_field]},
+        }

--- a/message_center_compassion/views/compassion_mapping_view.xml
+++ b/message_center_compassion/views/compassion_mapping_view.xml
@@ -25,6 +25,8 @@
                     <field name="json_name" />
                     <field name="odoo_field" />
                     <field name="relational_field" invisible="1" />
+                    <field name="relational_comodel_name" invisible="1" />
+                    <field name="relational_ttype" invisible="1" />
                     <field
             name="search_relational_record"
             invisible="not relational_field and not sub_mapping_id"
@@ -32,6 +34,23 @@
                     <field
             name="search_key"
             invisible="not search_relational_record and not sub_mapping_id"
+          />
+                    <field
+            name="relational_domain_restrict"
+            widget="domain"
+            options="{'model': 'relational_comodel_name'}"
+            invisible="not search_relational_record and not sub_mapping_id"
+          />
+                    <field
+            name="many2one_multiple_match_policy"
+            invisible="relational_ttype != 'many2one' or (not search_relational_record and not sub_mapping_id)"
+          />
+                    <button
+            name="action_check_duplicate_matches"
+            type="object"
+            string="Check for duplicates"
+            class="btn-secondary"
+            invisible="relational_ttype != 'many2one' or not search_relational_record"
           />
                     <field
             name="allow_null"
@@ -72,9 +91,51 @@
                 <field name="json_name" />
                 <field name="odoo_field" />
                 <field name="sub_mapping_id" />
+                <field name="relational_domain_restrict" optional="hide" />
+                <field name="many2one_multiple_match_policy" optional="hide" />
             </list>
         </field>
     </record>
+    <record id="view_field_to_json_many2one_review_list" model="ir.ui.view">
+        <field name="name">field.to.json.many2one.review.list</field>
+        <field name="model">compassion.field.to.json</field>
+        <field name="arch" type="xml">
+            <list>
+                <field name="mapping_id" />
+                <field name="model" string="Source Model" />
+                <field name="json_name" />
+                <field name="odoo_field" />
+                <field name="relational_comodel_name" string="Target Model" />
+                <field name="relational_domain_restrict" />
+                <field name="many2one_multiple_match_policy" />
+                <button
+            name="action_check_duplicate_matches"
+            type="object"
+            string="Check for duplicates"
+            class="btn-secondary"
+          />
+            </list>
+        </field>
+    </record>
+
+    <record id="action_field_to_json_many2one_review" model="ir.actions.act_window">
+        <field name="name">Many2one Fields to Review</field>
+        <field name="res_model">compassion.field.to.json</field>
+        <field name="view_mode">list,form</field>
+        <field name="view_id" ref="view_field_to_json_many2one_review_list" />
+        <field
+      name="domain"
+    >[('search_relational_record', '=', True), ('relational_ttype', '=', 'many2one')]</field>
+    </record>
+
+    <menuitem
+    id="menu_field_to_json_many2one_review"
+    parent="menu_message_config"
+    name="Many2one Fields to Review"
+    action="action_field_to_json_many2one_review"
+    sequence="40"
+  />
+
     <record id="view_compassion_mapping_tree" model="ir.ui.view">
         <field name="name">compassion.mapping.list</field>
         <field name="model">compassion.mapping</field>

--- a/sponsorship_compassion/security/ir.model.access.csv
+++ b/sponsorship_compassion/security/ir.model.access.csv
@@ -3,7 +3,6 @@ access_recurring_contract,Full access on recurring.contract,recurring_contract.m
 access_recurring_contract_line,Full access on recurring.contract.line,recurring_contract.model_recurring_contract_line,child_compassion.group_sponsorship,1,1,1,1
 access_recurring_contract_group,Full access on recurring.contract.group,recurring_contract.model_recurring_contract_group,child_compassion.group_sponsorship,1,1,1,1
 access_recurring_contract_origin,Full access on recurring.contract.origin,model_recurring_contract_origin,child_compassion.group_sponsorship,1,1,1,1
-access_recurring_invoicer,Full access on recurring.invoicer,recurring_contract.model_recurring_invoicer,child_compassion.group_sponsorship,1,1,1,1
 access_account_move,Full access on account.move,account.model_account_move,child_compassion.group_sponsorship,1,1,1,1
 access_account_move_line,Full access on account.move.line,account.model_account_move_line,child_compassion.group_sponsorship,1,1,1,1
 access_account_journal,Read access on account.journal,account.model_account_journal,child_compassion.group_sponsorship,1,0,0,0

--- a/sponsorship_compassion/views/sponsorship_contract_view.xml
+++ b/sponsorship_compassion/views/sponsorship_contract_view.xml
@@ -358,13 +358,6 @@
     sequence="12"
     action="recurring_contract.action_invoice_automatic_generation"
   />
-    <menuitem
-    id="menu_recurring_invoicer_form"
-    name="Generated invoices"
-    parent="account.menu_finance_receivables"
-    sequence="13"
-    action="recurring_contract.action_recurring_invoicer_form"
-  />
 
     <!-- Move the Sponsorships Menu to the Sponsorship Section -->
     <menuitem


### PR DESCRIPTION
# T3276 — Improve odoo message center json to odoo conversion

## Problem

When GMC Connect sends a JSON message, textual values that map to a
Many2one field are resolved by a generic search on the target model. If more than one record
matches, the code silently takes the first one found — there was no way to
narrow the search or to be warned when the match is ambiguous.

## What changed

- `models/field_to_json.py`: two new fields on `compassion.field.to.json`:
  - `relational_domain_restrict` (Char, domain expression) — AND-ed into
    the search whenever a relational lookup is performed, regardless of
    field type.
  - `many2one_multiple_match_policy` (Selection `first_match`/`raise`,
    default `first_match`) — only meaningful for Many2one fields; when set
    to `raise`, `_search_for_relational_values` now raises a `UserError`
    if the search returns more than one record instead of silently taking
    `records[:1]`.
  - New `action_check_duplicate_matches()`: a self-service diagnostic that
    scans the *real current data* of the target model/field for existing
    duplicate values (`_read_group` + `having __count > 1`), so anyone can
    check whether a given lookup is actually ambiguous today without DB
    access.
  - `relational_comodel_name`/`relational_ttype`: technical `related`
    fields (not `compute`+`store`) exposing the target model/type for the
    view and the diagnostic — deliberately not stored `compute` fields,
    see "Bugs found" below.
- `views/compassion_mapping_view.xml`: exposes the two new fields (Many2one
  policy only shown for Many2one fields) and a "Check for duplicates"
  button on the field-to-json form; adds a dedicated flattened list +
  menu, **Message Center → Configuration → Many2one Fields to Review**,
  showing all Many2one relational lookups across every mapping in one
  screen (previously only reachable by opening each mapping individually).

Default policy is `first_match` for all existing rows — **no behavior
change** for any existing mapping until someone explicitly reviews and
changes a specific field.

### Unrelated fix bundled in (separate commit)

`[T3284] Remove stale recurring.invoicer references blocking module
upgrades` — `sponsorship_compassion/security/ir.model.access.csv` and
`views/sponsorship_contract_view.xml`. Discovered that `origin/18.0`
itself currently crashes on any full module load: `recurring.invoicer` was
removed from `compassion-accounting`, but its cleanup companion (ticket
**T3284**) never got merged — it's sitting on its own unmerged branch,
`T3284-Remove-recurring-invoicer-object`. This commit mirrors that
already-authored fix exactly, scoped to unblock this branch.
**T3284's own PR still needs to be merged** so this isn't needed again on
the next fresh branch off `18.0`.

## Impact verification — deferred, not done in this PR

The ticket's own acceptance criteria calls for reviewing all existing
Many2one relational mappings and deciding, field by field, whether they
need a domain restriction and/or the `raise` policy, decisions are being made separately.

Once decisions are made, the actual mapping change needs to go into the
relevant module's `static/mappings/*.json` file (the real source of
truth — `compassion.mapping.load_from_json()` deletes and recreates all
of a mapping's `compassion.field.to.json` rows from that file on every
reload), then reloaded via `-u <module>` or the "Import GMC Mapping
Wizard" (Message Center → Configuration). Editing the field directly in
the UI is useful for testing but does not persist across a reload.

## How to test manually

1. Message Center → Configuration → **Many2one Fields to Review**.
2. Pick a row (e.g. `PrimaryOwner` on "Hold Creation") → **Check for
   duplicates**. With no duplicates, get a green "No ambiguity found"
   notification. With duplicates (tested live against `CompassNeedKey` and
   `PrimaryHoldOwner), get a list of the actual
   matching records.
3. Open a Many2one field row's form: `Domain Restrict` and `Match Policy`
   only show for Many2one fields with `search_relational_record` enabled;
   non-relational rows (e.g. `HoldID`) show neither.