### PR TITLE
T3358-Communication-config-creation

### DIFF
--- a/partner_communication_revision/models/communication_revision.py
+++ b/partner_communication_revision/models/communication_revision.py
@@ -209,7 +209,10 @@ class CommunicationRevision(models.Model):
 
     def _compute_display_name(self):
         for rev in self:
-            rev.display_name = rev.config_id.name + " - " + rev.lang.upper()[:2]
+            name = rev.config_id.name or _("New")
+            if rev.lang:
+                name += " - " + rev.lang.upper()[:2]
+            rev.display_name = name
 
     def _compute_raw_subject(self):
         for revision in self:


### PR DESCRIPTION
## Goal

Creating or editing a communication config (communication rule) threw an `RPC_ERROR` during the onchange, blocking the UI and preventing the record from being saved.

## Technical aspect

- `partner_communication_revision/models/communication_revision.py`: `_compute_display_name` concatenated `config_id.name` and `lang` directly. On a brand new revision, the record the web client snapshots for the onchange , both are still `False`, hence `TypeError: unsupported operand type(s) for +: 'bool' and 'str'`.
- The compute now falls back to "New" while the config is not set, and only appends the language suffix when `lang` has a value. The displayed name is unchanged once both fields are filled.
- The revisions list is `editable="bottom"` in the config form (`views/communication_config_view.xml`), so every line added there went through this path.

## Misc
No misc