### PR TITLE
T3359-Childpack_typo

### DIFF
--- a/child_compassion/i18n/da_DK.po
+++ b/child_compassion/i18n/da_DK.po
@@ -41,12 +41,12 @@ msgstr "<span>Tilgængelig indtil: </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>Fødselsdato</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>Fødselsdato</span>"
 
 #. module: child_compassion

--- a/child_compassion/i18n/da_DK.po
+++ b/child_compassion/i18n/da_DK.po
@@ -31,11 +31,6 @@ msgstr "365 børn"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>(</span>"
-msgstr "<span>(</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>Compassion-centret</span>"
 

--- a/child_compassion/i18n/de.po
+++ b/child_compassion/i18n/de.po
@@ -41,12 +41,12 @@ msgstr "<span>Gültig bis: </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>Geb.</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>Geb.</span>"
 
 #. module: child_compassion

--- a/child_compassion/i18n/de.po
+++ b/child_compassion/i18n/de.po
@@ -31,11 +31,6 @@ msgstr "365 Kinder"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>(</span>"
-msgstr "<span>Geb.</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>Über das Kinderzentrum</span>"
 

--- a/child_compassion/i18n/fr_CH.po
+++ b/child_compassion/i18n/fr_CH.po
@@ -31,13 +31,6 @@ msgstr "365 enfants"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-#, fuzzy
-#| msgid "<span>Born</span>"
-msgid "<span>(</span>"
-msgstr "<span>Né</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>À propos du centre de développement de l'enfant</span>"
 
@@ -49,12 +42,12 @@ msgstr "<span>Disponible jusqu'au : </span>"
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>Born (F)</span>"
-msgstr "<span>Née</span>"
+msgstr "<span>Née le</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>Born</span>"
-msgstr "<span>Né</span>"
+msgstr "<span>Né le</span>"
 
 #. module: child_compassion
 #: model:ir.model.constraint,message:child_compassion.constraint_compassion_household_household_uniq

--- a/child_compassion/i18n/fr_CH.po
+++ b/child_compassion/i18n/fr_CH.po
@@ -41,12 +41,12 @@ msgstr "<span>Disponible jusqu'au : </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>Née le</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>Né le</span>"
 
 #. module: child_compassion

--- a/child_compassion/i18n/it.po
+++ b/child_compassion/i18n/it.po
@@ -41,12 +41,12 @@ msgstr "<span>Disponibile fino a: </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>Nata il</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>Nato il</span>"
 
 #. module: child_compassion

--- a/child_compassion/i18n/it.po
+++ b/child_compassion/i18n/it.po
@@ -31,11 +31,6 @@ msgstr "365 bambini"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>(</span>"
-msgstr "<span>Nato</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>Informazioni sul centro Compassion</span>"
 
@@ -47,12 +42,12 @@ msgstr "<span>Disponibile fino a: </span>"
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>Born (F)</span>"
-msgstr "<span>Nata</span>"
+msgstr "<span>Nata il</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>Born</span>"
-msgstr "<span>Nato</span>"
+msgstr "<span>Nato il</span>"
 
 #. module: child_compassion
 #: model:ir.model.constraint,message:child_compassion.constraint_compassion_household_household_uniq

--- a/child_compassion/i18n/nb_NO.po
+++ b/child_compassion/i18n/nb_NO.po
@@ -41,12 +41,12 @@ msgstr "<span>Tilgjengelig til: </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>født</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>født</span>"
 
 #. module: child_compassion

--- a/child_compassion/i18n/nb_NO.po
+++ b/child_compassion/i18n/nb_NO.po
@@ -31,11 +31,6 @@ msgstr "365 barn"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>(</span>"
-msgstr "<span>(</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>Compassion-senteret</span>"
 

--- a/child_compassion/i18n/sv_SE.po
+++ b/child_compassion/i18n/sv_SE.po
@@ -31,11 +31,6 @@ msgstr "365 barn"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>(</span>"
-msgstr "<span>(</span>"
-
-#. module: child_compassion
-#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
 msgid "<span>About the child development center</span>"
 msgstr "<span>Compassion-centret</span>"
 

--- a/child_compassion/i18n/sv_SE.po
+++ b/child_compassion/i18n/sv_SE.po
@@ -41,12 +41,12 @@ msgstr "<span>Tillgänglig till: </span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born (F)</span>"
+msgid "<span>Born on (F)</span>"
 msgstr "<span>född</span>"
 
 #. module: child_compassion
 #: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
-msgid "<span>Born</span>"
+msgid "<span>Born on</span>"
 msgstr "<span>född</span>"
 
 #. module: child_compassion

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -132,10 +132,10 @@
                             <t
               t-if="o.gender=='F' and o.env.lang in ('fr_CH','it_IT')"
             >
-                                <span>Born (F)</span>
+                                <span>Born on (F)</span>
                             </t>
                             <t t-else="">
-                                <span>Born</span>
+                                <span>Born on</span>
                             </t>
                             <span
               t-esc="o.get_date('birthdate', 'dd MMM YYYY')"

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -125,20 +125,22 @@
                 <div class="summary">
                     <p t-field="o.preferred_name" class="summary_field name" />
                     <p class="summary_field birthday">
-                        <t t-if="o.age">
-                            <span t-esc="o.age" />
-                            <span>(</span>
-                        </t>
-                        <t
-            t-if="o.gender=='F' and o.env.lang in ('fr_CH','it_IT')"
+                        <span t-if="o.age" t-esc="o.age" />
+                        <span
+            t-attf-class="birth#{' parenthesis' if o.age else ''}"
           >
-                            <span>Born (F)</span>
-                        </t>
-                        <t t-else="">
-                            <span>Born</span>
-                        </t>
-                        <span t-esc="o.get_date('birthdate', 'dd MMM YYYY')" />
-                        <span t-if="o.age">)</span>
+                            <t
+              t-if="o.gender=='F' and o.env.lang in ('fr_CH','it_IT')"
+            >
+                                <span>Born (F)</span>
+                            </t>
+                            <t t-else="">
+                                <span>Born</span>
+                            </t>
+                            <span
+              t-esc="o.get_date('birthdate', 'dd MMM YYYY')"
+            />
+                        </span>
                     </p>
                     <p
           t-field="o.project_id.country_id.name"
@@ -256,6 +258,14 @@
             }
             .summary_field.country {
                 font-size: 9pt;
+            }
+            /* Drawn in CSS so that the parentheses are neither exposed as
+               translatable terms nor spaced out by the HTML whitespace collapsing */
+            .summary_field.birthday .parenthesis:before {
+                content: "(";
+            }
+            .summary_field.birthday .parenthesis:after {
+                content: ")";
             }
             .activities {
                 display: none;


### PR DESCRIPTION
## Goal

The childpack PDF printed a garbled line under the child photo. In French it read
`8 NÉ NÉ 01 JANV. 2018 )` instead of `8 (NÉ LE 01 JANV. 2018)`, and German and
Italian had the same problem.

## Technical aspect

Two distinct bugs in `child_compassion/report/childpack.xml`, both in the
`.summary` block:

- The parentheses around the birth date were wrapped in their own `<span>`, which
  exposed `(` as a translatable term. `fr_CH`, `de` and `it` had it translated as
  `Né` / `Geb.` / `Nato`, so the opening parenthesis was replaced by a second birth
  label. They are now drawn with `:before` / `:after` CSS rules, which no
  translation can reach. The `msgid "<span>(</span>"` entries are removed from the
  six `.po` files.
- The spans sat on separate source lines, so HTML whitespace collapsing added a
  space on both sides of each parenthesis. Nesting the label and the date inside a
  single wrapper span removes those.

French and Italian labels lacked prepositions (`Né` instead of `Né le`). Updating `msgstr` alone doesn't apply on standard Odoo upgrades due to `overwrite=False`. To force the update across environments without needing `--i18n-overwrite`, the source term was renamed from `Born` to `Born on`, creating a new `msgid`.

## Misc

No misc