### PR TITLE
[T3357] FIX: Child Gift contract invoice generation crash

### DIFF
--- a/sponsorship_compassion/models/contract_group.py
+++ b/sponsorship_compassion/models/contract_group.py
@@ -54,7 +54,7 @@ class ContractGroup(models.Model):
         # Push parent sponsorship for gift contracts
         res = super().build_inv_line_data(invoicing_date, gift_wizard, contract_line)
         if contract_line and contract_line.contract_id.type == "G":
-            res["contract_id"] = contract_line.sponsorship_id
+            res["contract_id"] = contract_line.sponsorship_id.id
         return res
 
     def _get_partner_for_contract(self, contract, gift_wizard=False):


### PR DESCRIPTION
## Original report

Test procedure: create a Child Gift contract for a sponsor with an active
LSV/DD sponsorship, link a sponsorship gift product to the existing
sponsorship, save/validate, then click "Generate invoices". 

Expected: correct invoices generated at the right frequency. 
Actual: clicking "Generate invoices" returned an RPC_ERROR:

## Root cause

`sponsorship_compassion/models/contract_group.py`, `build_inv_line_data()`:

```python
if contract_line and contract_line.contract_id.type == "G":
    res["contract_id"] = contract_line.sponsorship_id
```

`sponsorship_id` (`recurring_contract_line.py`) is a `Many2one` to
`recurring.contract` — so **`contract_line.sponsorship_id` is a recordset, not
an id**. Every other assignment in this method (and the base
`recurring_contract/contract_group.py` version) uses `.id`. When building the
invoice line for a Child Gift contract, `account.move.line.contract_id` was
set to that recordset directly; 

## How to test manually

See [Quality test](https://erp.compassion.ch/web#id=30&model=quality.test.run&view_type=form&cids=1&menu_id=) 