### PR TITLE
[T3274] FIX: double-escaped QWeb entities crashing mail template rendering

### DIFF
--- a/partner_communication/__manifest__.py
+++ b/partner_communication/__manifest__.py
@@ -30,7 +30,7 @@
 # pylint: disable=C8101
 {
     "name": "Partner Communication",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "category": "Other",
     "author": "Compassion Switzerland",
     "license": "AGPL-3",

--- a/partner_communication/migrations/18.0.1.0.2/post-migration.py
+++ b/partner_communication/migrations/18.0.1.0.2/post-migration.py
@@ -1,0 +1,59 @@
+import json
+import logging
+
+from openupgradelib import openupgrade
+
+_logger = logging.getLogger(__name__)
+
+# T3274: found while investigating why sponsorship onboarding communications
+# crashed - the "Donation - Thank You Letter" template had its ">"/"<"/'"'/"'"
+# QWeb comparison/string-literal operators double-escaped
+# (e.g. "&amp;gt;" instead of "&gt;"), so Odoo 18's stricter QWeb compiler
+# tried to evaluate the still-escaped "&amp;gt;" text as a Python operator
+# and crashed. This is a purely mechanical unescape, safe to apply to any
+# mail_template regardless of which module (if any) owns it - many of the
+# affected templates were created directly via the UI and have no owning
+# module at all, so a per-module migration could never reach them.
+ENTITY_FIXES = (
+    ("&amp;gt;", "&gt;"),
+    ("&amp;lt;", "&lt;"),
+    ("&amp;quot;", "&quot;"),
+    ("&amp;apos;", "&apos;"),
+)
+
+
+def _fix_body(body):
+    if not body:
+        return body
+    for broken, fixed in ENTITY_FIXES:
+        body = body.replace(broken, fixed)
+    return body
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    env.cr.execute(
+        """
+        SELECT id, body_html FROM mail_template
+        WHERE body_html::text LIKE '%&amp;gt;%'
+           OR body_html::text LIKE '%&amp;lt;%'
+           OR body_html::text LIKE '%&amp;quot;%'
+           OR body_html::text LIKE '%&amp;apos;%'
+        """
+    )
+    rows = env.cr.fetchall()
+    fixed_count = 0
+    for template_id, body_html in rows:
+        fixed = {lang: _fix_body(body) for lang, body in body_html.items()}
+        if fixed != body_html:
+            env.cr.execute(
+                "UPDATE mail_template SET body_html = %s WHERE id = %s",
+                (json.dumps(fixed), template_id),
+            )
+            fixed_count += 1
+    _logger.info(
+        "T3274: unescaped double-escaped &gt;/&lt;/&quot;/&apos; entities "
+        "in %s/%s mail_template rows",
+        fixed_count,
+        len(rows),
+    )


### PR DESCRIPTION
# T3274 — Fix onboarding welcome generation

There is another pull-request related to it as I work on 2 different module:
https://github.com/CompassionCH/compassion-switzerland/pull/1792

## Original report

Manual test procedure failed at step 11: the "Sponsorship
Onboarding Welcome" and "Sponsorship Onboarding Photo by Post" communications
were both never generated. A previous investigation found a QWeb compilation
error (double-escaped `&amp;gt;`) in the "Donation - Thank You Letter"
template, a stale `noupdate` view crashing on a removed `_is_qr_iban()`
method, and flagged ~80 other `mail_template` rows with the same
double-escape issue.

## Root cause

Two independent bugs, plus one structural gap that turned the first into two
symptoms instead of one:

1. **`report_compassion_qr_slip` view stuck on stale v14 content.** The view
   was reworked for v18 ,
   but its `ir_model_data` had `noupdate=True` — most likely set
   automatically by an in-place edit via the view editor at some point — so
   the ordinary module upgrade never reloaded it. This is what actually crashes:
   `get_sponsorship_payment_slip_attachments()` (used by the Welcome config)
   renders `report_compassion.report_2bvr_sponsorship`/
   `report_single_bvr_sponsorship`, which `t-call`s this view.

2. **`_send_new_dossier()` has no per-config error isolation.**
   (`partner_communication_switzerland/models/contracts.py`) It loops over
   `configs = new_dossier + child_picture` (Welcome, then Photo-by-post) with
   a plain `for` loop. When Welcome's iteration raised (bug #1), the loop
   aborted before ever reaching Photo-by-post's iteration. Confirmed via a
   throwaway migration script: calling `get_photo_by_post_attachment()` and
   rendering its report directly, in isolation, both succeed — Photo-by-post
   has no bug of its own, it's collateral damage from Welcome's crash.

3. **Double-escaped QWeb entities** (`&amp;gt;` instead of `&gt;`, same for
   `&lt;`/`&quot;`/`&apos;`) in several `mail_template` rows, including a raw
   `%  if EXPR:` pragma line (never converted to a real `<t t-if>`, same
   class of bug as T3315) in the Welcome template itself
   (`mail_onboarding_sponsorship_confirmation`, `en_US`/`it_IT`), plus a dead
   `% set könnt = ...` line in `de_DE`. Surveyed the whole DB: 76
   `mail_template` rows affected, 45 of which have **no owning module at all**
   (created directly via the UI) — a per-module migration could never reach
   those.

4. **fr/de/it translations of Python-sourced strings silently ignored.**
   Found manually while testing the fixes above: the Welcome email's
   payment-slip sentence rendered in English on an otherwise-French
   communication. Root cause: Odoo 18 only loads a `.po` entry as a Python
   code translation if its comment block contains a `#. odoo-python` marker
   line (`odoo/tools/translate.py`'s `CodeTranslations`). `partner_
   communication_switzerland`'s `de.po`/`fr_CH.po`/`it.po` still use the
   pre-v17 comment format (`#, python-format`, no `#. odoo-python`), carried
   over from the v14 migration and never regenerated — so every
   `_()`-translated string sourced from Python code in this module silently
   fell back to English for these three languages, regardless of the `.po`
   file actually having a correct translation. Verified this is not unique
   to this one phrase: 43/42/42 entries respectively in these three files
   use the old format; this old-format issue exists in 12 `.po` files across
   compassion-switzerland and 23 across compassion-modules — out of scope
   here (own ticket), only fixed for this module's fr/de/it files in this
   ticket.

## What changed

2 repos:

**compassion-switzerland**
- `report_compassion`: pre-migration clearing the
  stale `noupdate` flag on `report_compassion_qr_slip` so the existing
  (already-correct) tracked view reloads.
- `partner_communication_switzerland/models/contracts.py`: `_send_new_dossier`
  now wraps each config's send in a savepoint + try/except, logs and
  continues on failure instead of aborting the rest.
- `partner_communication_switzerland`: migration
  converting the raw pragma lines in the Welcome template's `body_html`
  (`en_US`, `it_IT`, `de_DE`).

- `partner_communication_switzerland/i18n/{de,fr_CH,it}.po`: added the
  missing `#. odoo-python` marker to every Python-code-sourced entry
  (mechanical, comment-only change, no msgid/msgstr edits).

**compassion-modules**:
- `partner_communication`: migration doing a
  purely mechanical unescape of `&amp;gt;`/`&amp;lt;`/`&amp;quot;`/`&amp;apos;`
  across every `mail_template` row regardless of owning module (placed here
  since it's a shared dependency guaranteed installed wherever any of these
  templates live).

## Out of scope

**SUB sponsorships**: confirmed by design, zero automated communication is
sent when a sponsorship validates in `sds_state == "sub"` — staff sends the
"SUB Accept" letter manually. Unchanged since 2021. If the acceptance
criterion "correct communication for SUB" means this should become
automatic, that's a product decision, not a bug fix — not touched in this
ticket.

Also not touched: `report_compassion_qr_parent` and `communication_style`
(`report_compassion`) are independently `noupdate=True` in the DB despite
their files not being `noupdate` by design — same class of anomaly as bug
#1 above, but not on the crash path for these two onboarding communications.
Worth a follow-up ticket if they turn out to matter elsewhere.

## How to test manually

1. Upgrade all four modules (`-u report_compassion,partner_communication_
   switzerland,partner_communication,recurring_contract`)
2. Follow the original manual test procedure (new sponsorship → validate →
   pay first invoice → check communications).
3. Confirm both "Sponsorship Onboarding - Welcome and payment information"
   and "Sponsorship Onboarding - Photo by post" jobs are created and reach
   "ready"/"done", with the payment slip PDF attached to Welcome and the
   Welcome email body free of visible `%`/code text.