### PR TITLE
[T3374] FIX: run demand planning weekly submission as a queue job

### DIFF
--- a/child_compassion/models/demand_planning.py
+++ b/child_compassion/models/demand_planning.py
@@ -114,10 +114,14 @@ class DemandPlanning(models.Model):
 
     @api.model
     def process_weekly_demand(self):
-        """Weekly CRON for Demand Planning.
-        1. Submit previsions
-        2. Create Demand Planning for the next weeks
-        """
+        """Weekly CRON for Demand Planning."""
+        # Push to job queue instead of synchronous
+        # API request. No blocking in cas of an error
+        self.with_delay()._process_weekly_demand()
+        return True
+
+    def _process_weekly_demand(self):
+        """Submit previsions and create Demand Planning for the next weeks."""
         next_week = datetime.today() + timedelta(days=7)
         previsions = self.search([("state", "=", "draft"), ("date", "<=", next_week)])
         previsions.send_planning()


### PR DESCRIPTION
- FIX: run demand planning weekly submission as a queue job
The synchronous GMC send held the single cron thread until the 300s
worker timeout, starving every other scheduled action.