### PR TITLE
T3382 - fix mycompassion donation checkout

### DIFF
--- a/gift_compassion/i18n/de.po
+++ b/gift_compassion/i18n/de.po
@@ -870,3 +870,21 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:gift_compassion.view_gift_collect
 msgid "_Add to gift"
 msgstr ""
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "Unlimited"
+msgstr "Unbegrenzt"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s / year"
+msgstr "%s / Jahr"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s total"
+msgstr "%s insgesamt"

--- a/gift_compassion/i18n/fr_CH.po
+++ b/gift_compassion/i18n/fr_CH.po
@@ -868,3 +868,21 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:gift_compassion.view_gift_collect
 msgid "_Add to gift"
 msgstr ""
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "Unlimited"
+msgstr "Illimité"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s / year"
+msgstr "%s / an"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s total"
+msgstr "%s au total"

--- a/gift_compassion/i18n/it.po
+++ b/gift_compassion/i18n/it.po
@@ -868,3 +868,21 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:gift_compassion.view_gift_collect
 msgid "_Add to gift"
 msgstr ""
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "Unlimited"
+msgstr "Illimitato"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s / year"
+msgstr "%s / anno"
+
+#. module: gift_compassion
+#. odoo-python
+#: code:addons/gift_compassion/models/gift_threshold_settings.py:0
+msgid "%s total"
+msgstr "%s in totale"

--- a/gift_compassion/models/gift_threshold_settings.py
+++ b/gift_compassion/models/gift_threshold_settings.py
@@ -71,8 +71,6 @@ class GiftThresholdSettings(models.Model):
         return _("%s total") % self.gift_frequency
 
     def get_gift_frequency_indicator(self):
-        if self.yearly_threshold and self.gift_frequency == 2:
-            return "*"
         if not self.yearly_threshold and self.gift_frequency == 1:
             return "**"
         return ""

--- a/gift_compassion/models/gift_threshold_settings.py
+++ b/gift_compassion/models/gift_threshold_settings.py
@@ -48,15 +48,20 @@ class GiftThresholdSettings(models.Model):
     def get_gift_type_label(self):
         return self._get_selection_label(self.get_gift_types(), self.gift_type)
 
-    def get_ceiling_converted_amount(self, amount, company, date):
-        raw_amount = self.currency_id._convert(
-            from_amount=amount,
-            to_currency=company.currency_id,
-            company=company,
-            date=date,
-            round=False,
-        )
-        return f"{company.currency_id.name} {int(math.ceil(raw_amount))}"
+    def get_amount_range_label(self, company, date):
+        def ceiling(amount):
+            converted = self.currency_id._convert(
+                from_amount=amount,
+                to_currency=company.currency_id,
+                company=company,
+                date=date,
+                round=False,
+            )
+            return int(math.ceil(converted))
+
+        min_amount = ceiling(self.min_amount)
+        max_amount = ceiling(self.max_amount)
+        return f"{min_amount} - {max_amount} {company.currency_id.name}"
 
     def get_gift_frequency_label(self):
         if not self.gift_frequency:

--- a/gift_compassion/models/gift_threshold_settings.py
+++ b/gift_compassion/models/gift_threshold_settings.py
@@ -72,5 +72,5 @@ class GiftThresholdSettings(models.Model):
 
     def get_gift_frequency_indicator(self):
         if not self.yearly_threshold and self.gift_frequency == 1:
-            return "**"
+            return "*"
         return ""

--- a/gift_compassion/models/gift_threshold_settings.py
+++ b/gift_compassion/models/gift_threshold_settings.py
@@ -9,7 +9,7 @@
 ##############################################################################
 import math
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class GiftThresholdSettings(models.Model):
@@ -57,6 +57,13 @@ class GiftThresholdSettings(models.Model):
             round=False,
         )
         return f"{company.currency_id.name} {int(math.ceil(raw_amount))}"
+
+    def get_gift_frequency_label(self):
+        if not self.gift_frequency:
+            return _("Unlimited")
+        if self.yearly_threshold:
+            return _("%s / year") % self.gift_frequency
+        return _("%s total") % self.gift_frequency
 
     def get_gift_frequency_indicator(self):
         if self.yearly_threshold and self.gift_frequency == 2:

--- a/sbc_compassion/models/ir_actions_report.py
+++ b/sbc_compassion/models/ir_actions_report.py
@@ -11,7 +11,13 @@ class IrActionsReport(models.Model):
         # For correspondence reports, if a letter has a pre-scanned PDF, use that PDF
         # directly instead of rendering the QWeb template.
         # Merge it with other rendered letters.
-        if report_ref != "sbc_compassion.correspondence_report_qweb" or not res_ids:
+        # report_ref can be an id, a record, an xmlid or a report_name (see
+        # _get_report()'s docstring) - normalize before comparing.
+        report = self._get_report(report_ref)
+        if (
+            report.report_name != "sbc_compassion.correspondence_report_qweb"
+            or not res_ids
+        ):
             return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
 
         attachments = self.env["ir.attachment"].search(


### PR DESCRIPTION
# FIX report rendering + gift threshold lookup, ADD giving-limits frequency display

**WARNING**: **SHOULD BE MERGE AFTER HER SISTER PR**( see below compassion-website repository)

## Summary
Two independent fixes/additions found and made while testing the MyCompassion donation and gift-to-a-child flows

## 1. `sbc_compassion` — correspondence report rendering silently broken 
`_render_qweb_pdf(report_ref, ...)` compared `report_ref` directly against the literal string `"sbc_compassion.correspondence_report_qweb"`, but `report_ref` can be an id, a record, an xmlid, or a report_name (per `_get_report()`'s own documented contract). Odoo 18's mail template attachment generation passes the actual `ir.actions.report` record, not a string, so the comparison always mismatched (a `UserWarning`, not a crash) and this override's whole purpose — using a sponsor's pre-scanned letter PDF instead of re-rendering the QWeb template for correspondence reports — never triggered, for any correspondence report, silently falling back to default rendering every time.

**Fix:** normalize via `self._get_report(report_ref)` before comparing `report_name`.

## 2. `gift_compassion` — giving-limits table frequency display
The "Learn more" giving-limits table only showed Type/Min/Max, with frequency folded into an asterisk footnote covering only two specific cases (2/year, or 1/lifetime in the final year). Other frequencies (e.g. Project Gift's 4/year) had no visible info at all.

**Added:** `get_gift_frequency_label()` — a generic "`<n>` / year", "`<n>` total", or "Unlimited" label for every gift type. Also `get_amount_range_label()`, merging Min/Max into one range string after the resulting 4-column table rendered crooked (removed the now-unused `get_ceiling_converted_amount()`). Dropped the twice-a-year asterisk (now redundant); kept the final-year-only indicator, trimmed to a single `*`.
<img width="691" height="540" alt="Screenshot From 2026-08-20 09-54-28" src="https://github.com/user-attachments/assets/a277a407-ff1d-432b-be94-a12bdc15aafa" />

FR/DE/IT translations included, with the required `#. odoo-python` marker on the Python-sourced strings (same pitfall as T3274/`feedback_po_odoo_python_marker`).


## Related PRs
_(part of the T3382 donation-checkout fix set — links to the other 3 repos' PRs added below)_

- https://github.com/CompassionCH/paid-addons/pull/18
- https://github.com/CompassionCH/compassion-website/pull/371
- https://github.com/CompassionCH/compassion-switzerland/pull/1802
