### PR TITLE
T3399-Child_picture_error

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -289,6 +289,8 @@ class CompassionChild(models.Model):
         for child in self:
             if child.pictures_ids:
                 child.fullshot = child.pictures_ids.sorted()[:1].fullshot
+            else:
+                child.fullshot = False
 
     @api.depends_context("qr_utm_medium", "qr_utm_source", "qr_utm_campaign")
     def _compute_qr_code(self):

--- a/child_compassion/report/child_picture.xml
+++ b/child_compassion/report/child_picture.xml
@@ -48,10 +48,22 @@ img {
   border-radius: 2mm;
   text-align: center;
 }
+.no-picture {
+  position: absolute;
+  top: 70mm;
+  left: 10mm;
+  right: 10mm;
+  text-align: center;
+}
           </style>
                             <img
-            t-attf-src="data:image/jpeg;base64,#{ o.fullshot }"
+            t-if="o.fullshot"
+            t-att-src="image_data_uri(o.fullshot)"
+            alt=""
           />
+                            <div t-else="" class="no-picture">
+                                <span>No picture available</span>
+                            </div>
                             <div id="child-ref">
                                 <span t-field="o.preferred_name" />
                                 <span> </span>

--- a/child_compassion/wizards/print_childpicture.py
+++ b/child_compassion/wizards/print_childpicture.py
@@ -67,4 +67,5 @@ class PrintChildPicture(models.TransientModel):
                 "target": "new",
                 "context": self.env.context,
             }
-        return report_ref.report_action(children.ids, data=data, config=False)
+
+        return report_ref.report_action(children.ids, config=False)


### PR DESCRIPTION
## Goal

Printing a child's picture from *Sponsorship > Children* (**Print > Child Picture**) was broken in
both modes: with the **pdf** option checked it crashed with an `RPC_ERROR`, and without it the
downloaded PDF was blank. Both are fixed, and a child with no picture on file now yields a readable
page instead of a crash or a silent white page.

## Technical aspect

Two independent bugs, plus a hardening of the report template:

- **Crash (child without picture, both modes)** — `compassion.child._compute_fullshot` never
  assigned the field when `pictures_ids` was empty, so Odoo raised
  `Compute method failed to assign …fullshot`. It now falls back to `False`, exactly like
  `_compute_portrait` right above it.
- **Blank PDF (child *with* a picture, "no pdf" mode)** — the wizard passed `data` to
  `report_action`. As soon as the action holds data, the web client builds the report URL as
  `?options=…&context=…` and **drops the record ids** (`web/.../reports/utils.js::getReportUrl`), so
  the controller renders with `docids=None`, `docs` is an empty recordset and the template outputs
  nothing. That `data` was unused by this template anyway (copied over from the childpack wizard);
  it is no longer passed, matching the Swiss `child_order_picture` wizard, which prints fine.
- **Report template** — the image is now guarded by `t-if` and built with `image_data_uri()` instead
  of a hardcoded `jpeg` data URI, so the real mimetype is used; a child without a picture renders a
  "No picture available" block.

## Misc

- This report is shared: it also produces the picture attached to *biennial* communications
  (`partner_communication_compassion`) and the printout/ZIP of the Swiss `child_order_picture`
  wizard, whose `_make_zip` relies on **one page per child**. The layout, the page structure and the
  pagination were therefore deliberately left untouched.
- Noticed while investigating, deliberately left out of scope: the template's bare `img` CSS selector
  also stretches the company logo injected by `web.external_layout`; `id="child-ref"` is duplicated
  for every child of a batch; and `compassion.global.child._compute_image_fullshot` has the very same
  unassigned-field bug (it calls `_load_image`, which only ever assigns `portrait`).
- The "No picture available" string is a new msgid and will show in English until translations are
  regenerated.