### PR TITLE
T3389-FIX-INVOICE_BUTTON

### DIFF
--- a/child_compassion/models/child_compassion.py
+++ b/child_compassion/models/child_compassion.py
@@ -289,6 +289,8 @@ class CompassionChild(models.Model):
         for child in self:
             if child.pictures_ids:
                 child.fullshot = child.pictures_ids.sorted()[:1].fullshot
+            else:
+                child.fullshot = False
 
     @api.depends_context("qr_utm_medium", "qr_utm_source", "qr_utm_campaign")
     def _compute_qr_code(self):

--- a/child_compassion/report/child_picture.xml
+++ b/child_compassion/report/child_picture.xml
@@ -48,10 +48,22 @@ img {
   border-radius: 2mm;
   text-align: center;
 }
+.no-picture {
+  position: absolute;
+  top: 70mm;
+  left: 10mm;
+  right: 10mm;
+  text-align: center;
+}
           </style>
                             <img
-            t-attf-src="data:image/jpeg;base64,#{ o.fullshot }"
+            t-if="o.fullshot"
+            t-att-src="image_data_uri(o.fullshot)"
+            alt=""
           />
+                            <div t-else="" class="no-picture">
+                                <span>No picture available</span>
+                            </div>
                             <div id="child-ref">
                                 <span t-field="o.preferred_name" />
                                 <span> </span>

--- a/child_compassion/wizards/print_childpicture.py
+++ b/child_compassion/wizards/print_childpicture.py
@@ -67,4 +67,5 @@ class PrintChildPicture(models.TransientModel):
                 "target": "new",
                 "context": self.env.context,
             }
-        return report_ref.report_action(children.ids, data=data, config=False)
+
+        return report_ref.report_action(children.ids, config=False)

--- a/sponsorship_compassion/models/contracts.py
+++ b/sponsorship_compassion/models/contracts.py
@@ -291,7 +291,12 @@ class SponsorshipContract(models.Model):
                 or [False]
             )
 
-    @api.depends("invoice_line_ids")
+    @api.depends(
+        "invoice_line_ids",
+        # nb_invoices also counts the gifts of the related sponsorship
+        "contract_line_ids.sponsorship_id.invoice_line_ids.payment_state",
+        "contract_line_ids.sponsorship_id.invoice_line_ids.parent_state",
+    )
     @api.depends_context(
         "open_invoices_sponsorship_only", "open_invoices_exclude_sponsorship"
     )
@@ -311,17 +316,25 @@ class SponsorshipContract(models.Model):
                 contract.open_invoice_ids = contract.open_invoice_ids.filtered(
                     lambda i: i.invoice_category != "sponsorship"
                 )
-        gift_contracts = self.filtered(lambda c: c.type == "G")
-        for contract in gift_contracts:
-            invoices = contract.mapped(
-                "contract_line_ids.sponsorship_id.invoice_line_ids.move_id"
-            )
-            gift_invoices = invoices.filtered(
-                lambda i: i.invoice_category == "gift"
-                and i.state not in ("cancel", "draft")
-            )
-            contract.nb_invoices += len(gift_invoices)
         return res
+
+    def _get_open_invoices(self):
+        """Include the gifts of the related sponsorship for gift contracts.
+
+        Gift invoice lines are attached to the sponsorship contract (see
+        build_inv_line_data), so they never show up in the gift contract own
+        invoice_line_ids.
+        """
+        invoices = super()._get_open_invoices()
+        for contract in self.filtered(lambda c: c.type == "G"):
+            invoices |= (
+                contract.mapped(
+                    "contract_line_ids.sponsorship_id.invoice_line_ids.move_id"
+                )
+                .filtered(lambda i: i.invoice_category == "gift")
+                ._filter_open_invoices()
+            )
+        return invoices
 
     def _compute_gift_partner(self):
         for contract in self:
@@ -743,19 +756,6 @@ class SponsorshipContract(models.Model):
     ##########################################################################
     #                             VIEW CALLBACKS                             #
     ##########################################################################
-    def open_invoices(self):
-        res = super().open_invoices()
-        if self.type == "G":
-            # Include gifts of related sponsorship for gift contracts
-            sponsorship_invoices = self.mapped(
-                "contract_line_ids.sponsorship_id.invoice_line_ids.move_id"
-            )
-            gift_invoices = sponsorship_invoices.filtered(
-                lambda i: i.invoice_category == "gift"
-            )
-            res["domain"] = [("id", "in", gift_invoices.ids)]
-        return res
-
     @api.onchange("parent_id")
     def on_change_parent_id(self):
         """If a previous sponsorship is selected, the origin should be


### PR DESCRIPTION
> ⚠️ **PR liée** : CompassionCH/compassion-accounting#283 — même ticket, même nom de branche. **À merger ensemble.** Celle-ci dépend de la méthode `_get_open_invoices()` introduite là-bas ; seule, elle ne fonctionne pas.

## Goal

Complément du correctif T3389 pour les contrats **Child Gift** (`type == "G"`).

Ces contrats ne portent pas leurs factures : quand un cadeau est facturé, `build_inv_line_data` rattache la ligne de facture au **parrainage lié**, pas au contrat cadeau. Sans traitement particulier, leur bouton afficherait donc toujours 0.

Ce module compensait, mais **à deux endroits différents et avec deux critères différents** — d'où un compteur et une liste qui ne pouvaient pas coïncider.

## Technical aspect

Deux rustines supprimées, remplacées par une seule surcharge du point d'extension créé dans `compassion-accounting`.

- **Supprimé dans `_compute_invoices`** : `contract.nb_invoices += len(gift_invoices)`. Ce code incrémentait un entier **sans** que les factures correspondantes existent dans un recordset — le bouton annonçait donc un nombre que rien ne pouvait afficher. Structurellement incompatible avec l'objectif « compteur = liste ».
- **Supprimé : la surcharge de `open_invoices()`**. Elle faisait `res["domain"] = [...]`, ce qui **remplaçait** le domaine du parent : les factures propres au contrat cadeau disparaissaient de la liste. Et son filtre était `invoice_category == "gift"` seul, sans aucun filtre d'état ni de paiement — la liste contenait donc aussi les cadeaux payés, annulés et brouillons.
- **Ajouté : `_get_open_invoices()`**, qui pour les contrats `G` ajoute (union, pas remplacement) les factures de cadeau du parrainage lié, filtrées par le critère commun `_filter_open_invoices()`. Compteur et liste consommant tous deux cette méthode, ils ne peuvent plus diverger.
- **`@api.depends` complété** : le compteur d'un contrat cadeau dépend des lignes de facture d'un **autre** contrat (le parrainage). Ce chemin n'était déclaré nulle part, donc l'encaissement d'un cadeau ne rafraîchissait pas le compteur.

## Ce qui change pour l'utilisateur

Sur un contrat Child Gift :

| | Avant : compteur | Avant : liste | Après : les deux |
| --- | :-: | :-: | :-: |
| cadeaux du parrainage, ouverts | ✅ | ✅ | ✅ |
| cadeaux du parrainage, **payés / annulés** | ✅ / ❌ | ✅ | ❌ |
| ses factures propres, postées impayées | ❌ | ❌ **jamais visibles** | ✅ |

Le seul changement visible côté métier : **les cadeaux payés ne sont plus dans « Open invoices »**. Ils restent accessibles par le bouton **« Gifts »** juste à côté, qui n'est pas modifié.

## Misc

- ⚠️ **Cette branche contient aussi le commit `991953ef` du ticket T3399** (« Child picture printing crash »), pas encore mergé dans `18.0`. Il n'a aucun rapport avec T3389 — à merger dans le bon ordre, ou à rebaser une fois T3399 parti.
- **Un cadeau impayé n'apparaît pas dans « Gifts »** : l'enregistrement `sponsorship.gift` n'est créé qu'au paiement de la facture (`invoice_paid` → `_trigger_gifts`). Les deux boutons sont donc complémentaires — facture ouverte avant paiement, cadeau après. Exception : avec l'option `no_birthday_invoice`, le cadeau est créé sans facture et n'apparaît que dans « Gifts ».
- **Le bouton du groupe n'affiche pas les cadeaux d'un contrat cadeau** si le parrainage est dans un autre moyen de paiement. Volontaire : le groupe répond à « qu'est-ce qui sera encaissé par ce moyen de paiement ? », et cette facture sera encaissée par celui du parrainage. L'afficher des deux côtés rendrait le recouvrement ambigu.
- **Les filtres contextuels `open_invoices_sponsorship_only` / `open_invoices_exclude_sponsorship` sont inchangés** : ils portent sur `open_invoice_ids`, qui reste réservé au métier (génération de cadeaux, cascade d'écriture).
- Aucun test automatique n'existe sur ce module ; validation manuelle sur base V18.