### PR TITLE
T3435 mycompassion child information translations

### DIFF
--- a/advanced_translation/i18n/de.po
+++ b/advanced_translation/i18n/de.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Compassion Odoo 14\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-09 08:25+0000\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.7\n"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "Unknown"
+msgstr "Unbekannt"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "and"
+msgstr "und"

--- a/advanced_translation/i18n/fr_CH.po
+++ b/advanced_translation/i18n/fr_CH.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Compassion Odoo 14\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-09 08:25+0000\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr_CH\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.7\n"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "Unknown"
+msgstr "Inconnu"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "and"
+msgstr "et"

--- a/advanced_translation/i18n/it.po
+++ b/advanced_translation/i18n/it.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Compassion Odoo 14\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-10-09 08:25+0000\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: it\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.7\n"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "Unknown"
+msgstr "Sconosciuto"
+
+#. module: advanced_translation
+#. odoo-python
+#: code:addons/advanced_translation/models/translatable_model.py:0
+#, python-format
+msgid "and"
+msgstr "e"

--- a/advanced_translation/models/ir_advanced_translation.py
+++ b/advanced_translation/models/ir_advanced_translation.py
@@ -42,9 +42,11 @@ class IrAdvancedTranslation(models.Model):
         if not term:
             return _(src)
         if female and plural:
-            return term.female_plural or ""
-        if female:
-            return term.female_singular or ""
-        if plural:
-            return term.male_plural or ""
-        return term.male_singular or ""
+            value = term.female_plural
+        elif female:
+            value = term.female_singular
+        elif plural:
+            value = term.male_plural
+        else:
+            value = term.male_singular
+        return value or _(src)

--- a/child_compassion/i18n/de.po
+++ b/child_compassion/i18n/de.po
@@ -664,6 +664,12 @@ msgid "Baker"
 msgstr "Bäcker"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Bamboo"
+msgstr "Bambus"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_bananas
 msgid "Bananas"
 msgstr "Bananen"
@@ -911,6 +917,12 @@ msgid "Breakfast and devotional time"
 msgstr "Gebet und Morgenandacht"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Brick, block and cement"
+msgstr "Ziegel, Blockstein und Zement"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__bronchitis
 msgid "Bronchitis"
 msgstr "Bronchitis"
@@ -1022,6 +1034,12 @@ msgid "Capital City"
 msgstr ""
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cardboard"
+msgstr "Karton"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__cardiovascular
 msgid "Cardiovascular"
 msgstr "Kardiovaskulär"
@@ -1101,6 +1119,12 @@ msgstr "Cdpr Altersgruppe"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_child__cdsp_type
 msgid "Cdsp Type"
 msgstr "Cdsp Typ"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cement"
+msgstr "Zement"
 
 #. module: child_compassion
 #: model:fcp.program,value:child_compassion.program_csp
@@ -1740,6 +1764,12 @@ msgstr "Nächstgelegene Stadt"
 #: code:addons/child_compassion/wizards/project_description.py:0
 msgid "Closest city"
 msgstr "Nächste Stadt:"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cloth and carpet"
+msgstr "Stoff und Teppich"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_clothing_trades
@@ -2468,6 +2498,12 @@ msgstr "Hast du das gewusst?"
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__diphtheria
 msgid "Diphtheria"
 msgstr "Diphtherie"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Dirt"
+msgstr "Lehmboden"
 
 #. module: child_compassion
 #: model:child.physical.disability,value:child_compassion.disability_leftarm
@@ -5597,6 +5633,18 @@ msgid "Learning Summary"
 msgstr "Lernzusammenfassung"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves and grass"
+msgstr "Blätter und Gras"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves, grass and thatch"
+msgstr "Blätter, Gras und Reet"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_lentils
 msgid "Lentils"
 msgstr "Linsen"
@@ -6123,6 +6171,12 @@ msgstr "Mutter am Leben"
 #: code:addons/child_compassion/wizards/child_description.py:0
 msgid "Mother job"
 msgstr "Arbeit der Mutter:"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Mud, earth, clay and adobe"
+msgstr "Lehm, Erde, Ton und Adobe"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_multimedia
@@ -7269,6 +7323,18 @@ msgstr "Arbeit in Plantagen"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__planting_month_ids
 msgid "Planting months"
 msgstr "Anpflanzungsmonate"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic"
+msgstr "Kunststoff"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic sheets"
+msgstr "Kunststoffplanen"
 
 #. module: child_compassion
 #: model:child.hobby,value:child_compassion.child_hobby_playhouse
@@ -9383,6 +9449,12 @@ msgid "Thunderstorm"
 msgstr "Gewitter"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tile"
+msgstr "Fliese"
+
+#. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__time
 msgid "Time"
 msgstr "Uhrzeit"
@@ -9406,6 +9478,12 @@ msgstr "Zeit in Minuten"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__timezone
 msgid "Timezone"
 msgstr "Zeitzone"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tin"
+msgstr "Wellblech"
 
 #. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__title
@@ -10077,6 +10155,12 @@ msgstr "Wird arbeiten"
 msgid "Will display the comments when child is selected for sponsorship"
 msgstr ""
 "Zeigt die Kommentare an, wenn das Kind für die Patenschaft ausgewählt wird"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Wood"
+msgstr "Holz"
 
 #. module: child_compassion
 #. odoo-python

--- a/child_compassion/i18n/fr_CH.po
+++ b/child_compassion/i18n/fr_CH.po
@@ -667,6 +667,12 @@ msgid "Baker"
 msgstr "Boulanger"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Bamboo"
+msgstr "Bambou"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_bananas
 msgid "Bananas"
 msgstr "Bananes"
@@ -912,6 +918,12 @@ msgid "Breakfast and devotional time"
 msgstr "Prière et petit-déjeuner"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Brick, block and cement"
+msgstr "Brique, parpaing et ciment"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__bronchitis
 msgid "Bronchitis"
 msgstr "Bronchite"
@@ -1025,6 +1037,12 @@ msgid "Capital City"
 msgstr "L'hospitalité"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cardboard"
+msgstr "Carton"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__cardiovascular
 msgid "Cardiovascular"
 msgstr "Cardiovasculaire"
@@ -1104,6 +1122,12 @@ msgstr "Cdpr Groupe d'âge"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_child__cdsp_type
 msgid "Cdsp Type"
 msgstr "Type de Cdsp"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cement"
+msgstr "Ciment"
 
 #. module: child_compassion
 #: model:fcp.program,value:child_compassion.program_csp
@@ -1746,6 +1770,12 @@ msgstr "Ville la plus proche"
 #: code:addons/child_compassion/wizards/project_description.py:0
 msgid "Closest city"
 msgstr "Ville la plus proche"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cloth and carpet"
+msgstr "Tissu et tapis"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_clothing_trades
@@ -2473,6 +2503,12 @@ msgstr "Le saviez-vous?"
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__diphtheria
 msgid "Diphtheria"
 msgstr "Diphtérie"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Dirt"
+msgstr "Terre battue"
 
 #. module: child_compassion
 #: model:child.physical.disability,value:child_compassion.disability_leftarm
@@ -5613,6 +5649,18 @@ msgid "Learning Summary"
 msgstr "Résumé de l'apprentissage"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves and grass"
+msgstr "Feuilles et herbe"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves, grass and thatch"
+msgstr "Feuilles, herbe et chaume"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_lentils
 msgid "Lentils"
 msgstr "Lentilles"
@@ -6139,6 +6187,12 @@ msgstr "Mère en vie"
 #: code:addons/child_compassion/wizards/child_description.py:0
 msgid "Mother job"
 msgstr "Métier de la maman"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Mud, earth, clay and adobe"
+msgstr "Boue, terre, argile et adobe"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_multimedia
@@ -7285,6 +7339,18 @@ msgstr "Travail dans les plantations"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__planting_month_ids
 msgid "Planting months"
 msgstr "Mois de plantation"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic"
+msgstr "Plastique"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic sheets"
+msgstr "Bâches en plastique"
 
 #. module: child_compassion
 #: model:child.hobby,value:child_compassion.child_hobby_playhouse
@@ -9398,6 +9464,12 @@ msgid "Thunderstorm"
 msgstr "Orages"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tile"
+msgstr "Tuile"
+
+#. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__time
 msgid "Time"
 msgstr "Heure"
@@ -9421,6 +9493,12 @@ msgstr "Temps en minutes"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__timezone
 msgid "Timezone"
 msgstr "Fuseau horaire"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tin"
+msgstr "Tôle"
 
 #. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__title
@@ -10091,6 +10169,12 @@ msgstr "Travaillera"
 msgid "Will display the comments when child is selected for sponsorship"
 msgstr ""
 "Affiche les commentaires lorsque l'enfant est sélectionné pour le parrainage."
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Wood"
+msgstr "Bois"
 
 #. module: child_compassion
 #. odoo-python

--- a/child_compassion/i18n/it.po
+++ b/child_compassion/i18n/it.po
@@ -666,6 +666,12 @@ msgid "Baker"
 msgstr "Panettiere"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Bamboo"
+msgstr "Bambù"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_bananas
 msgid "Bananas"
 msgstr "Banane"
@@ -914,6 +920,12 @@ msgid "Breakfast and devotional time"
 msgstr "Colazione e momento di devozione"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Brick, block and cement"
+msgstr "Mattoni, blocchi e cemento"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__bronchitis
 msgid "Bronchitis"
 msgstr "Bronchite"
@@ -1026,6 +1038,12 @@ msgid "Capital City"
 msgstr ""
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cardboard"
+msgstr "Cartone"
+
+#. module: child_compassion
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__cardiovascular
 msgid "Cardiovascular"
 msgstr "Cardiovascolare"
@@ -1105,6 +1123,12 @@ msgstr "Gruppo di età del Cdpr"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_child__cdsp_type
 msgid "Cdsp Type"
 msgstr "Tipo di Cdsp"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cement"
+msgstr "Cemento"
 
 #. module: child_compassion
 #: model:fcp.program,value:child_compassion.program_csp
@@ -1744,6 +1768,12 @@ msgstr "Città più vicina"
 #: code:addons/child_compassion/wizards/project_description.py:0
 msgid "Closest city"
 msgstr "Città più vicina"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Cloth and carpet"
+msgstr "Tessuto e tappeto"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_clothing_trades
@@ -2473,6 +2503,12 @@ msgstr "Lo sapevi?"
 #: model:ir.model.fields.selection,name:child_compassion.selection__compassion_child_ble__child_death_subcategory__diphtheria
 msgid "Diphtheria"
 msgstr "Difterite"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Dirt"
+msgstr "Terra battuta"
 
 #. module: child_compassion
 #: model:child.physical.disability,value:child_compassion.disability_leftarm
@@ -5606,6 +5642,18 @@ msgid "Learning Summary"
 msgstr "Riepilogo dell'apprendimento"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves and grass"
+msgstr "Foglie e erba"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Leaves, grass and thatch"
+msgstr "Foglie, erba e paglia"
+
+#. module: child_compassion
 #: model:fcp.diet,value:child_compassion.icp_diet_lentils
 msgid "Lentils"
 msgstr "Lenticchie"
@@ -6132,6 +6180,12 @@ msgstr "Madre viva"
 #: code:addons/child_compassion/wizards/child_description.py:0
 msgid "Mother job"
 msgstr "Lavoro da madre"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Mud, earth, clay and adobe"
+msgstr "Fango, terra, argilla e adobe"
 
 #. module: child_compassion
 #: model:child.vocational.training,value:child_compassion.voc_multimedia
@@ -7283,6 +7337,18 @@ msgstr "Lavori di piantagione"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__planting_month_ids
 msgid "Planting months"
 msgstr "Mesi di semina"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic"
+msgstr "Plastica"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Plastic sheets"
+msgstr "Teli di plastica"
 
 #. module: child_compassion
 #: model:child.hobby,value:child_compassion.child_hobby_playhouse
@@ -9403,6 +9469,12 @@ msgid "Thunderstorm"
 msgstr "Temporale"
 
 #. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tile"
+msgstr "Tegola"
+
+#. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__time
 msgid "Time"
 msgstr "Tempo"
@@ -9426,6 +9498,12 @@ msgstr "Tempo in minuti"
 #: model:ir.model.fields,field_description:child_compassion.field_compassion_project__timezone
 msgid "Timezone"
 msgstr "Fuso orario"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Tin"
+msgstr "Lamiera"
 
 #. module: child_compassion
 #: model:ir.model.fields,field_description:child_compassion.field_field_office_learning__title
@@ -10097,6 +10175,12 @@ msgid "Will display the comments when child is selected for sponsorship"
 msgstr ""
 "Visualizzerà i commenti quando il bambino viene selezionato per la "
 "sponsorizzazione"
+
+#. module: child_compassion
+#. odoo-python
+#: code:addons/child_compassion/models/project_compassion.py:0
+msgid "Wood"
+msgstr "Legno"
 
 #. module: child_compassion
 #. odoo-python

--- a/child_compassion/models/project_compassion.py
+++ b/child_compassion/models/project_compassion.py
@@ -529,21 +529,21 @@ class CompassionProject(models.Model):
     @api.model
     def _get_materials(self):
         return [
-            ("Bamboo", "Bamboo"),
-            ("Brick/Block/Cement", "Brick, block and cement"),
-            ("Cardboard", "Cardboard"),
-            ("Cement", "Cement"),
-            ("Cloth/Carpet", "Cloth and carpet"),
-            ("Dirt", "Dirt"),
-            ("Leaves/Grass/Thatch", "Leaves, grass and thatch"),
-            ("Leaves/Grass", "Leaves and grass"),
-            ("Mud/Earth/Clay/Adobe", "Mud, earth, clay and adobe"),
-            ("Plastic Sheets", "Plastic sheets"),
-            ("Tile", "Tile"),
-            ("Tin/Corrugated Iron", "Tin"),
-            ("Wood", "Wood"),
-            ("Tin", "Tin"),
-            ("Plastic", "Plastic"),
+            ("Bamboo", _("Bamboo")),
+            ("Brick/Block/Cement", _("Brick, block and cement")),
+            ("Cardboard", _("Cardboard")),
+            ("Cement", _("Cement")),
+            ("Cloth/Carpet", _("Cloth and carpet")),
+            ("Dirt", _("Dirt")),
+            ("Leaves/Grass/Thatch", _("Leaves, grass and thatch")),
+            ("Leaves/Grass", _("Leaves and grass")),
+            ("Mud/Earth/Clay/Adobe", _("Mud, earth, clay and adobe")),
+            ("Plastic Sheets", _("Plastic sheets")),
+            ("Tile", _("Tile")),
+            ("Tin/Corrugated Iron", _("Tin")),
+            ("Wood", _("Wood")),
+            ("Tin", _("Tin")),
+            ("Plastic", _("Plastic")),
         ]
 
     @api.depends("gps_latitude", "gps_longitude", "closest_city")

--- a/sbc_compassion/models/ir_actions_report.py
+++ b/sbc_compassion/models/ir_actions_report.py
@@ -1,7 +1,10 @@
+import logging
 from io import BytesIO
 
 from odoo import models
 from odoo.tools.pdf import to_pdf_stream
+
+_logger = logging.getLogger(__name__)
 
 
 class IrActionsReport(models.Model):
@@ -30,7 +33,28 @@ class IrActionsReport(models.Model):
         if not attachments:
             return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
 
-        streams = [to_pdf_stream(attachment) for attachment in attachments]
+        streams = []
+        for attachment in attachments:
+            try:
+                stream = to_pdf_stream(attachment)
+            except Exception:
+                _logger.warning(
+                    "Skipping unreadable correspondence letter scan "
+                    "(attachment %s) while generating the PDF",
+                    attachment.id,
+                    exc_info=True,
+                )
+                continue
+            if stream is None:
+                _logger.warning(
+                    "Skipping correspondence letter scan (attachment %s) "
+                    "with unrecognized mimetype %s",
+                    attachment.id,
+                    attachment.mimetype,
+                )
+                continue
+            streams.append(stream)
+
         without_scan_ids = set(res_ids) - {att.res_id for att in attachments}
         if without_scan_ids:
             pdf_bytes, _ = super()._render_qweb_pdf(
@@ -38,5 +62,14 @@ class IrActionsReport(models.Model):
             )
             streams.append(BytesIO(pdf_bytes))
 
-        with self._merge_pdfs(streams) as pdf_merged_stream:
+        def _skip_corrupted_letter(error, error_stream):
+            _logger.warning(
+                "Skipping a corrupted correspondence letter scan while "
+                "merging PDFs: %s",
+                error,
+            )
+
+        with self._merge_pdfs(
+            streams, handle_error=_skip_corrupted_letter
+        ) as pdf_merged_stream:
             return pdf_merged_stream.getvalue(), "pdf"

--- a/sbc_compassion/models/ir_actions_report.py
+++ b/sbc_compassion/models/ir_actions_report.py
@@ -34,6 +34,7 @@ class IrActionsReport(models.Model):
             return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
 
         streams = []
+        stream_res_ids = {}
         failed_scan_res_ids = set()
         for attachment in attachments:
             try:
@@ -57,6 +58,7 @@ class IrActionsReport(models.Model):
                 failed_scan_res_ids.add(attachment.res_id)
                 continue
             streams.append(stream)
+            stream_res_ids[id(stream)] = attachment.res_id
 
         # A letter whose scan attachment exists but failed to convert is
         # treated the same as one with no scan at all: render it from the
@@ -71,14 +73,34 @@ class IrActionsReport(models.Model):
             )
             streams.append(BytesIO(pdf_bytes))
 
+        # A scan whose mimetype is application/pdf can still hold malformed
+        # content - to_pdf_stream() doesn't validate that, so such a stream
+        # reaches here and only fails once _merge_pdfs() actually tries to
+        # parse it. Map it back to its correspondence so it can still be
+        # rendered from QWeb instead of just vanishing from the batch.
+        merge_rejected_res_ids = set()
+
         def _skip_corrupted_letter(error, error_stream):
+            res_id = stream_res_ids.get(id(error_stream))
             _logger.warning(
-                "Skipping a corrupted correspondence letter scan while "
-                "merging PDFs: %s",
+                "Skipping a corrupted correspondence letter scan "
+                "(correspondence %s) while merging PDFs: %s",
+                res_id,
                 error,
             )
+            if res_id is not None:
+                merge_rejected_res_ids.add(res_id)
 
         with self._merge_pdfs(
             streams, handle_error=_skip_corrupted_letter
         ) as pdf_merged_stream:
-            return pdf_merged_stream.getvalue(), "pdf"
+            if not merge_rejected_res_ids:
+                return pdf_merged_stream.getvalue(), "pdf"
+            pdf_merged_stream.seek(0)
+            fallback_bytes, _ = super()._render_qweb_pdf(
+                report_ref, res_ids=list(merge_rejected_res_ids), data=data
+            )
+            with self._merge_pdfs(
+                [pdf_merged_stream, BytesIO(fallback_bytes)]
+            ) as final_stream:
+                return final_stream.getvalue(), "pdf"

--- a/sbc_compassion/models/ir_actions_report.py
+++ b/sbc_compassion/models/ir_actions_report.py
@@ -34,6 +34,7 @@ class IrActionsReport(models.Model):
             return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
 
         streams = []
+        failed_scan_res_ids = set()
         for attachment in attachments:
             try:
                 stream = to_pdf_stream(attachment)
@@ -44,6 +45,7 @@ class IrActionsReport(models.Model):
                     attachment.id,
                     exc_info=True,
                 )
+                failed_scan_res_ids.add(attachment.res_id)
                 continue
             if stream is None:
                 _logger.warning(
@@ -52,10 +54,17 @@ class IrActionsReport(models.Model):
                     attachment.id,
                     attachment.mimetype,
                 )
+                failed_scan_res_ids.add(attachment.res_id)
                 continue
             streams.append(stream)
 
-        without_scan_ids = set(res_ids) - {att.res_id for att in attachments}
+        # A letter whose scan attachment exists but failed to convert is
+        # treated the same as one with no scan at all: render it from the
+        # QWeb template instead of just dropping it, so a batch where every
+        # scan fails still produces the letters, not a silent empty PDF.
+        without_scan_ids = (
+            set(res_ids) - {att.res_id for att in attachments}
+        ) | failed_scan_res_ids
         if without_scan_ids:
             pdf_bytes, _ = super()._render_qweb_pdf(
                 report_ref, res_ids=list(without_scan_ids), data=data


### PR DESCRIPTION
# T3435 — MyCompassion: child information page translation issues + letters download error

## Related PR

- https://github.com/CompassionCH/compassion-website/pull/376

## Original report

Quality test failure on the MyCompassion portal's "Child information" page: several pieces of information have errors in some languages, especially french.

## Known separate/open issue — not fixed

`ir.advanced.translation.get()` fell back to `_(src)` (English) when no translation row existed for a term, but returned a hard `""` when a row *did* exist for the language but the specific requested gender/plural field (e.g. `female_singular`) was left empty — exactly the "Ma mère travaille comme ." case, where a French row existed with `male_singular` filled in but `female_singular` blank. Fixed to fall back to `_(src)` in that case too, so an incomplete translation degrades to English instead of disappearing. **Note:** the actual missing French text for this specific occupation is a data gap in that table, not something this code fix can supply — someone needs to fill in the actual `female_singular` value for whichever source string this is which bring the known separate issue. This fix only prevents the *blank* symptom for its own scenario (translation row exists, specific field blank) going forward; the actual French text for whatever specific occupation values are missing is still absent from the `ir.advanced.translation` table and needs a data fix, not a code fix.

## How to test manually

1. Upgrade `advanced_translation`, `child_compassion`, `sbc_compassion` with `-u ... --i18n-overwrite`.
2. On the MyCompassion portal in French, open a child's page: favorite subjects/hobbies lists should join with "et", not "and".
3. "Mon centre" tab: house construction material fields should show in French (e.g. "Brique, parpaing et ciment").
4. Download a correspondence letters PDF for a partner with at least one corrupted/unreadable scanned letter attachment — should succeed and include every other letter, instead of a 400 Bad Request.
