### PR TITLE
T3434-FixChildpack

### DIFF
--- a/child_compassion/i18n/de.po
+++ b/child_compassion/i18n/de.po
@@ -50,6 +50,11 @@ msgid "<span>Born on</span>"
 msgstr "<span>Geb.</span>"
 
 #. module: child_compassion
+#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
+msgid "<span>No photo registered for this child</span>"
+msgstr "<span>Kein Foto für dieses Kind vorhanden</span>"
+
+#. module: child_compassion
 #: model:ir.model.constraint,message:child_compassion.constraint_compassion_household_household_uniq
 msgid "A Household with the same ID already exists."
 msgstr "Es gibt bereits einen Haushalt mit der gleichen ID."

--- a/child_compassion/i18n/fr_CH.po
+++ b/child_compassion/i18n/fr_CH.po
@@ -50,6 +50,11 @@ msgid "<span>Born on</span>"
 msgstr "<span>Né le</span>"
 
 #. module: child_compassion
+#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
+msgid "<span>No photo registered for this child</span>"
+msgstr "<span>Aucune photo enregistrée pour cet enfant</span>"
+
+#. module: child_compassion
 #: model:ir.model.constraint,message:child_compassion.constraint_compassion_household_household_uniq
 msgid "A Household with the same ID already exists."
 msgstr "Un ménage avec le même ID existe déjà."

--- a/child_compassion/i18n/it.po
+++ b/child_compassion/i18n/it.po
@@ -50,6 +50,11 @@ msgid "<span>Born on</span>"
 msgstr "<span>Nato il</span>"
 
 #. module: child_compassion
+#: model_terms:ir.ui.view,arch_db:child_compassion.childpack_document
+msgid "<span>No photo registered for this child</span>"
+msgstr "<span>Nessuna foto registrata per questo bambino</span>"
+
+#. module: child_compassion
 #: model:ir.model.constraint,message:child_compassion.constraint_compassion_household_household_uniq
 msgid "A Household with the same ID already exists."
 msgstr "Esiste già una famiglia con lo stesso ID."

--- a/child_compassion/models/__init__.py
+++ b/child_compassion/models/__init__.py
@@ -17,6 +17,7 @@ from . import (
     global_partner,
     gmc_message,
     household,
+    ir_actions_report,
     major_revision,
     project_compassion,
     project_lifecycle_event,

--- a/child_compassion/models/ir_actions_report.py
+++ b/child_compassion/models/ir_actions_report.py
@@ -1,0 +1,34 @@
+##############################################################################
+#
+#    Copyright (C) 2026 Compassion CH (http://www.compassion.ch)
+#    Releasing children from poverty in Jesus' name
+#
+#    The licence is in the file __manifest__.py
+#
+##############################################################################
+from odoo import models
+
+
+class IrActionsReport(models.Model):
+    _inherit = "ir.actions.report"
+
+    def _render_qweb_html(self, report_ref, docids, data=None):
+        # QWeb overwrites the ``lang`` rendering value with the language of the
+        # rendering environment (``ir.qweb._prepare_environment``), so the
+        # language selected in the print wizard is lost whenever the childpack
+        # is rendered from an environment in another language — typically
+        # base_report_to_printer's ``print_document``, which renders with the
+        # user's own language when the report is sent to the printer. Align the
+        # environment language with the requested one for all childpack reports
+        # (their rendering models inherit ``report.child_compassion.childpack_full``).
+        lang = data and data.get("lang")
+        if lang:
+            report_model = self._get_rendering_context_model(
+                self._get_report(report_ref)
+            )
+            childpack_class = self.env.registry[
+                "report.child_compassion.childpack_full"
+            ]
+            if report_model is not None and isinstance(report_model, childpack_class):
+                self = self.with_context(lang=lang)
+        return super()._render_qweb_html(report_ref, docids, data=data)

--- a/child_compassion/models/ir_actions_report.py
+++ b/child_compassion/models/ir_actions_report.py
@@ -21,14 +21,6 @@ class IrActionsReport(models.Model):
         # user's own language when the report is sent to the printer. Align the
         # environment language with the requested one for all childpack reports
         # (their rendering models inherit ``report.child_compassion.childpack_full``).
-        lang = data and data.get("lang")
-        if lang:
-            report_model = self._get_rendering_context_model(
-                self._get_report(report_ref)
-            )
-            childpack_class = self.env.registry[
-                "report.child_compassion.childpack_full"
-            ]
-            if report_model is not None and isinstance(report_model, childpack_class):
-                self = self.with_context(lang=lang)
-        return super()._render_qweb_html(report_ref, docids, data=data)
+        lang = data and data.get("lang") or self.env.lang
+        return super(IrActionsReport, self.with_context(lang=lang)._render_qweb_html(
+            report_ref, docids, data=data)

--- a/child_compassion/models/ir_actions_report.py
+++ b/child_compassion/models/ir_actions_report.py
@@ -14,13 +14,13 @@ class IrActionsReport(models.Model):
 
     def _render_qweb_html(self, report_ref, docids, data=None):
         # QWeb overwrites the ``lang`` rendering value with the language of the
-        # rendering environment (``ir.qweb._prepare_environment``), so the
-        # language selected in the print wizard is lost whenever the childpack
-        # is rendered from an environment in another language — typically
+        # rendering environment (``ir.qweb._prepare_environment``), so a language
+        # requested through ``data["lang"]`` is lost whenever the report is
+        # rendered from an environment in another language — typically
         # base_report_to_printer's ``print_document``, which renders with the
         # user's own language when the report is sent to the printer. Align the
-        # environment language with the requested one for all childpack reports
-        # (their rendering models inherit ``report.child_compassion.childpack_full``).
+        # environment language with the requested one.
         lang = data and data.get("lang") or self.env.lang
-        return super(IrActionsReport, self.with_context(lang=lang)._render_qweb_html(
-            report_ref, docids, data=data)
+        return super(IrActionsReport, self.with_context(lang=lang))._render_qweb_html(
+            report_ref, docids, data=data
+        )

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -121,7 +121,7 @@
           t-if="o.fullshot"
           t-attf-src="data:image/jpg;base64,{{ o.fullshot }}"
         />
-                    <p t-if="full and not o.fullshot" class="no-photo">
+                    <p t-if="not o.fullshot" class="no-photo">
                         <span>No photo registered for this child</span>
                     </p>
                 </div>

--- a/child_compassion/report/childpack.xml
+++ b/child_compassion/report/childpack.xml
@@ -121,6 +121,9 @@
           t-if="o.fullshot"
           t-attf-src="data:image/jpg;base64,{{ o.fullshot }}"
         />
+                    <p t-if="full and not o.fullshot" class="no-photo">
+                        <span>No photo registered for this child</span>
+                    </p>
                 </div>
                 <div class="summary">
                     <p t-field="o.preferred_name" class="summary_field name" />
@@ -229,6 +232,13 @@
             .photo img {
                 max-width: 100%;
                 max-height: 100%;
+            }
+            .photo .no-photo {
+                margin-top: 55mm;
+                text-align: center;
+                font-style: italic;
+                font-size: 11pt;
+                color: #666666;
             }
             .child-ref {
                 position: absolute;


### PR DESCRIPTION
## Goal
Companion PR in compassion-switzerland (mini childpack note + paper tray selection): CompassionCH/compassion-switzerland#1812.

When a childpack was sent to the printer ("Print background" unchecked), it always came out in the language of the user's interface (typically English) instead of the language selected in the wizard the downloaded PDF was correct, only the printed one was wrong. Additionally, when a child has no photo yet, the childpack should say so in the selected language instead of leaving an empty frame.

## Technical aspect
- **Language fix** (`child_compassion/models/ir_actions_report.py`, new): QWeb unconditionally overwrites the `lang` rendering value with the environment language (`ir.qweb._prepare_environment`). The wizard's language travels correctly in the report `data`, but `base_report_to_printer`'s `print_document` renders from the user's own environment, so the selected language was lost at rendering time. The new `_render_qweb_html` override aligns the environment language with `data["lang"]` for all childpack reports, they are recognised by their rendering model inheriting `report.child_compassion.childpack_full`, so the Swiss Mini childpack is covered too (its template has no `t-lang` at all).
- **Missing photo note** (`report/childpack.xml`): the photo frame of the full and small childpacks now shows a translated note ("No photo registered for this child") when the child has no fullshot. Translations added to the fr_CH/de/it `.po` files.

## Misc

