### PR TITLE
[T3456] Follow the render's language, not the partner's stored one

### DIFF
--- a/thankyou_letters/models/res_partner.py
+++ b/thankyou_letters/models/res_partner.py
@@ -13,7 +13,7 @@ from datetime import datetime
 from babel.dates import format_date
 from markupsafe import Markup, escape
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResPartner(models.Model):
@@ -35,11 +35,13 @@ class ResPartner(models.Model):
     short_address = fields.Char(compute="_compute_address")
     date_communication = fields.Char(compute="_compute_date_communication")
 
+    @api.depends_context("lang")
     def _compute_address(self):
         # Replace line returns
         p = re.compile(r"\n+")
+        lang = self.env.context.get("lang") or self.env.lang
         for partner in self:
-            t_partner = partner.with_context(lang=partner.lang)
+            t_partner = partner.with_context(lang=lang)
             lines = []
             if not partner.is_company and partner.title.shortcut:
                 title = escape(t_partner.title.shortcut)
@@ -53,11 +55,13 @@ class ResPartner(models.Model):
             text = "\n".join(str(line) for line in lines if line)
             partner.short_address = Markup(p.sub("<br/>", text))
 
+    @api.depends_context("lang")
     def _compute_date_communication(self):
         """City and date displayed in the top right of a letter"""
         today = datetime.today()
         city = self.env.user.partner_id.company_id.city
+        lang = self.env.context.get("lang") or self.env.lang
         for partner in self:
-            date = format_date(today, format="long", locale=partner.lang)
-            formatted_date = f"le {date}" if "fr" in partner.lang else date
+            date = format_date(today, format="long", locale=lang)
+            formatted_date = f"le {date}" if "fr" in lang else date
             partner.date_communication = f"{city}, {formatted_date}"


### PR DESCRIPTION
# T3456 — Fix failing quality test: MyCompassion: donations

Follow-up to T3416-tax-receipt-donation-history/T3441-tax-receipt-signature-lang. `compassion-switzerland`, `compassion-website`, `compassion-modules`

## Related PR

- https://github.com/CompassionCH/compassion-switzerland/pull/1819
- https://github.com/CompassionCH/compassion-website/pull/390

## What changed

1. Tax receipt renders in the viewer's interface language, not the partner's stored one (compassion-switzerland)
2. Tax receipt overflowing to a second page (compassion-switzerland)

- The signature `<img>` had no height/width cap (`width: 40%`, ~76mm) — capped to `width: 45mm` (matching `anniversary_card.xml`'s own signature usage). Margin-left adjusted afterward too (was `-15mm`, pushing it into the page margin per user feedback - see below).
- `.body_text` (the letter-body box) is hardcoded to `min-height: 120mm` whenever a signature is shown, forcing a large empty gap below "Best regards" even for the tax receipt's few short paragraphs. Added a `compact_body` flag (set only in `tax_receipt.xml`) that skips this min-height, without touching the other, longer communications that share this template and rely on the fixed height.
- Also trimmed `tax_receipt_content`'s four stacked `<br/>` before the intro heading down to one.

3. Language mismatch on the child gift payment slip (compassion-switzerland)
4. Pager spacing on the donation history list (compassion-website)
5. Stale/corrupted "Date" column header in donation history (compassion-website) — DB-only fix, no commit

## How to test manually
- Donations page (`/my2/donations`): download the tax receipt while browsing in different interface languages — the whole PDF (logo, salutation, date, body text, signature) should consistently follow whichever language you're browsing in.
- Once `report_compassion` can be upgraded again: download a gift payment slip for a sponsored child while browsing in a language different from the partner's stored profile language — labels and the child/gift communication line should match.
- Check the tax receipt PDF is one page, with reasonable spacing between the closing text and the signature.
- Check the "Date" column header in donation history reads correctly in French (already fixed at the DB level locally; will need the same `-u --i18n-overwrite` sync — or `.po` was already correct so a normal deploy pipeline that runs migrations properly should pick it up fine).
- Check spacing between the donation history rows and the Prev/Next pager.