### PR TITLE
[T3452] FIX: make short_address an Html field to keep its Markup

### DIFF
--- a/thankyou_letters/models/res_partner.py
+++ b/thankyou_letters/models/res_partner.py
@@ -32,7 +32,7 @@ class ResPartner(models.Model):
     thankyou_preference = fields.Selection(
         "_get_delivery_preference", default="auto_digital", required=True
     )
-    short_address = fields.Char(compute="_compute_address")
+    short_address = fields.Html(compute="_compute_address", sanitize=False)
     date_communication = fields.Char(compute="_compute_date_communication")
 
     def _compute_address(self):


### PR DESCRIPTION
fields.Char stripped the Markup built by _compute_address, so every t-out rendered the address as escaped literal <br/> tags.